### PR TITLE
Lower minimum playback speed for golden slider

### DIFF
--- a/golden.html
+++ b/golden.html
@@ -36,7 +36,7 @@
     </div>
     <div>
       <label style="margin-right:0.5rem;">speed <span id="speed-display">1x</span></label>
-      <input id="speed" type="range" min="0.5" max="1.5" step="0.05" value="1">
+      <input id="speed" type="range" min="0.25" max="1.5" step="0.05" value="1">
     </div>
     <div>
       <button id="play-btn">play piece</button>


### PR DESCRIPTION
## Summary
- allow the golden page playback speed slider to go down to 0.25x

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_690a62c25850832f8203a743096dfd9e