### PR TITLE
Add fine-tune nudge buttons for allemande loops

### DIFF
--- a/song.css
+++ b/song.css
@@ -49,6 +49,19 @@ body {
   text-align: center;
 }
 
+.nudge {
+  display: inline-flex;
+  gap: 0.2em;
+  margin-left: 0.3em;
+  vertical-align: middle;
+}
+
+.nudge-btn {
+  font-size: 0.9rem;
+  padding: 0.1em 0.45em;
+  line-height: 1;
+}
+
 .loop .loop-btn {
   font-size: 1rem;
   padding: 0.4em 0.8em;

--- a/song.html
+++ b/song.html
@@ -98,6 +98,7 @@
       let loops = [];
       let isVideoMode = false;
       let isAudioMode = false;
+      let fineTune = false;
 
       const loopsContainer = document.getElementById('loops');
       const addLoopBtn = document.getElementById('add-loop');
@@ -121,6 +122,43 @@
         return `${m}:${s}`;
       }
 
+      function formatTimeFine(sec) {
+        const safe = Math.max(0, sec);
+        const m = Math.floor(safe / 60);
+        const rem = safe - m * 60;
+        const whole = Math.floor(rem).toString().padStart(2, '0');
+        const tenths = Math.round((rem - Math.floor(rem)) * 10);
+        if (tenths === 10) {
+          return formatTimeFine((m * 60) + Math.floor(rem) + 1);
+        }
+        return `${m}:${whole}.${tenths}`;
+      }
+
+      function nudge(input, delta) {
+        const next = Math.max(0, parseTime(input.value) + delta);
+        input.value = formatTimeFine(next);
+      }
+
+      function makeNudgeButtons(input) {
+        const wrap = document.createElement('span');
+        wrap.className = 'nudge';
+        const minus = document.createElement('button');
+        minus.type = 'button';
+        minus.className = 'nudge-btn';
+        minus.textContent = '−';
+        minus.title = '−0.1s';
+        minus.addEventListener('click', () => nudge(input, -0.1));
+        const plus = document.createElement('button');
+        plus.type = 'button';
+        plus.className = 'nudge-btn';
+        plus.textContent = '+';
+        plus.title = '+0.1s';
+        plus.addEventListener('click', () => nudge(input, 0.1));
+        wrap.appendChild(minus);
+        wrap.appendChild(plus);
+        return wrap;
+      }
+
       function createLoopElement(startVal, endVal, label) {
         if (label) {
           const labelDiv = document.createElement('div');
@@ -139,6 +177,7 @@
         startInput.className = 'start';
         startInput.value = startVal;
         startLabel.appendChild(startInput);
+        if (fineTune) startLabel.appendChild(makeNudgeButtons(startInput));
 
         const endLabel = document.createElement('label');
         endLabel.textContent = 'end ';
@@ -147,6 +186,7 @@
         endInput.className = 'end';
         endInput.value = endVal;
         endLabel.appendChild(endInput);
+        if (fineTune) endLabel.appendChild(makeNudgeButtons(endInput));
 
         const btn = document.createElement('button');
         btn.textContent = 'loop section';
@@ -301,6 +341,8 @@
           if (song.speedMin) {
             speedInput.min = song.speedMin;
           }
+
+          fineTune = !!song.fineTune;
 
           // Build loop elements from JSON
           (song.loops || []).forEach((loop) => {

--- a/song.html
+++ b/song.html
@@ -123,39 +123,34 @@
       }
 
       function formatTimeFine(sec) {
-        const safe = Math.max(0, sec);
-        const m = Math.floor(safe / 60);
-        const rem = safe - m * 60;
-        const whole = Math.floor(rem).toString().padStart(2, '0');
-        const tenths = Math.round((rem - Math.floor(rem)) * 10);
-        if (tenths === 10) {
-          return formatTimeFine((m * 60) + Math.floor(rem) + 1);
-        }
-        return `${m}:${whole}.${tenths}`;
+        const tenths = Math.max(0, Math.round(sec * 10));
+        const m = Math.floor(tenths / 600);
+        const s = String(Math.floor(tenths / 10) % 60).padStart(2, '0');
+        return `${m}:${s}.${tenths % 10}`;
       }
 
       function nudge(input, delta) {
-        const next = Math.max(0, parseTime(input.value) + delta);
-        input.value = formatTimeFine(next);
+        const cur = parseTime(input.value);
+        const base = Number.isFinite(cur) ? cur : 0;
+        input.value = formatTimeFine(base + delta);
       }
 
       function makeNudgeButtons(input) {
         const wrap = document.createElement('span');
         wrap.className = 'nudge';
-        const minus = document.createElement('button');
-        minus.type = 'button';
-        minus.className = 'nudge-btn';
-        minus.textContent = '−';
-        minus.title = '−0.1s';
-        minus.addEventListener('click', () => nudge(input, -0.1));
-        const plus = document.createElement('button');
-        plus.type = 'button';
-        plus.className = 'nudge-btn';
-        plus.textContent = '+';
-        plus.title = '+0.1s';
-        plus.addEventListener('click', () => nudge(input, 0.1));
-        wrap.appendChild(minus);
-        wrap.appendChild(plus);
+        const target = input.className;
+        const mk = (label, delta, action) => {
+          const b = document.createElement('button');
+          b.type = 'button';
+          b.className = 'nudge-btn';
+          b.textContent = label;
+          b.title = `${label}0.1s`;
+          b.setAttribute('aria-label', `${action} ${target} by 0.1 seconds`);
+          b.addEventListener('click', () => nudge(input, delta));
+          return b;
+        };
+        wrap.appendChild(mk('−', -0.1, 'decrease'));
+        wrap.appendChild(mk('+', 0.1, 'increase'));
         return wrap;
       }
 
@@ -268,7 +263,8 @@
         const last = loops[loops.length - 1];
         const startVal = last.end.value;
         const startSec = parseTime(startVal);
-        createLoopElement(startVal, formatTime(startSec + 10));
+        const fmt = fineTune ? formatTimeFine : formatTime;
+        createLoopElement(startVal, fmt(startSec + 10));
       });
 
       playBtn.addEventListener('click', () => {

--- a/songs.json
+++ b/songs.json
@@ -4,6 +4,7 @@
     "allemande": {
       "title": "allemande",
       "videoId": "7qpvIepLWPI",
+      "fineTune": true,
       "loops": [
         { "start": "0:00", "end": "0:30", "label": "Section 1" }
       ]


### PR DESCRIPTION
## Summary
- Adds a `fineTune` flag to song JSON entries; when true, each loop's start/end input gets a pair of −0.1s / +0.1s buttons that rewrite the value as `M:SS.X` (e.g. `0:30.4`).
- Enabled on the allemande entry so clean break points can be dialed in before being hardcoded.

## Test plan
- [ ] Visit `song.html?s=allemande` and confirm − / + buttons appear next to start and end inputs.
- [ ] Click + and − a few times and confirm the value updates by 0.1s and the loop respects the fractional time.
- [ ] Visit a non-allemande song (e.g. `?s=amazing-grace`) and confirm the buttons do NOT appear.

https://claude.ai/code/session_01Fyj6ZZXhaNmrnongBRUghb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fyj6ZZXhaNmrnongBRUghb)_