### PR TITLE
Show allemande score by default on page load

### DIFF
--- a/song.html
+++ b/song.html
@@ -238,7 +238,6 @@
         }
         loopActive = false;
         currentLoopIndex = null;
-        hideScore();
       }
 
       function startLoop(i) {
@@ -380,6 +379,10 @@
             const scoreSrc = Array.isArray(loop) ? null : loop.score;
             createLoopElement(start, end, label, scoreSrc);
           });
+
+          // Show the first loop's score by default
+          const firstScore = loops.find(l => l.scoreSrc);
+          if (firstScore) showScore(firstScore.scoreSrc);
 
           // Initialize YouTube player if video mode
           if (isVideoMode) {


### PR DESCRIPTION
## Summary
The score block from #21 only appeared while a loop was playing — easy to miss on a phone where the loop buttons sit below the YouTube embed. Now the first loop's score renders as soon as the page initialises, and it stays visible after a loop stops (it only swaps when you start a different loop).

## Test plan
- [ ] Load `song.html?s=allemande` on phone. The mm 1-3 score should be visible without any clicks.
- [ ] Tap "loop section" on m. 3-6 — the score should swap.
- [ ] Tap "stop" — the m. 3-6 score should remain visible (not hide).

https://claude.ai/code/session_01Fyj6ZZXhaNmrnongBRUghb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fyj6ZZXhaNmrnongBRUghb)_