### PR TITLE
Fix octave bug on score loops 2-5

### DIFF
--- a/scores/mm-1-4.svg
+++ b/scores/mm-1-4.svg
@@ -175,8 +175,8 @@ tspan { white-space: pre; }
 <g transform="translate(24.7519, 4.0450)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9782" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(27.7348, 4.0450)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8067" ry="0.0400" fill="currentColor"/>
+<g transform="translate(27.6698, 3.0450)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(30.6527, 2.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -202,8 +202,8 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <path transform="scale(0.0040, -0.0040)" d="M0 205c91 51 211 131 211 233c0 24 -5 48 -14 70c-79 -89 -197 -160 -197 -282v-21zM267 663c0 -44 -16 -82 -39 -116c16 -35 25 -71 25 -109c0 -181 -253 -257 -253 -438h-16v500h16v-70c97 49 224 128 224 233c0 21 -5 42 -13 62c-3 16 10 27 23 27c32 0 33 -83 33 -89
 z" fill="currentColor"/>
 </g>
-<g transform="translate(27.6698, 3.0450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(27.7348, 4.0450)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8067" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(12.3810, 1.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -217,7 +217,13 @@ z" fill="currentColor"/>
 <g transform="translate(12.4460, 4.0450)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="6.9806" ry="0.0400" fill="currentColor"/>
 </g>
+<g transform="translate(48.3650, 4.0450)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.2707" ry="0.0400" fill="currentColor"/>
+</g>
 <g transform="translate(39.3513, 3.0450)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(48.3000, 1.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(39.4163, 4.0450)">
@@ -235,23 +241,17 @@ z" fill="currentColor"/>
 <g transform="translate(45.3821, 4.0450)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.9144" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(48.3000, 1.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(48.3650, 4.0450)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.2707" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(51.2829, 1.0450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(51.3479, 4.0450)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.6270" ry="0.0400" fill="currentColor"/>
-</g>
 <g transform="translate(33.3856, 4.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(33.4506, 4.0450)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.4891" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(51.3479, 4.0450)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.6270" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(51.2829, 1.0450)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(36.3685, 3.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>

--- a/scores/mm-10-12.svg
+++ b/scores/mm-10-12.svg
@@ -1,521 +1,429 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="39.77mm" viewBox="-2.2535 0.0600 104.6834 22.6329">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="33.34mm" viewBox="-2.2535 -0.0000 104.6834 18.9732">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
-<g transform="translate(0.0000, 7.6429)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="63.7331" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 6.6429)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(0.0000, 0.5450)">
+<rect x="50.9313" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 5.6429)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="50.9313" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 4.6429)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="44.9659" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 3.6429)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="39.2506" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 8.6429)">
-<rect x="99.8220" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="33.2853" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 9.6429)">
-<rect x="99.8220" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="30.3026" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 8.6429)">
-<rect x="96.1454" y="-0.1000" width="1.9491" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="21.3546" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 8.6429)">
-<rect x="92.2544" y="-0.1000" width="1.9491" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="9.5750" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 8.6429)">
-<rect x="86.3287" y="-0.1000" width="1.9063" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.6429)">
-<rect x="84.3296" y="-0.1000" width="1.8991" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.6429)">
-<rect x="18.5341" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.6429)">
-<rect x="14.6974" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 9.6429)">
-<rect x="14.6974" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 10.6429)">
-<rect x="14.6974" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.6429)">
-<rect x="11.3607" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(39.0774, 5.6429)">
+<g transform="translate(102.2399, 4.5450)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(72.4987, 5.6429)">
+<g transform="translate(56.7359, 4.5450)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(55.8416, 5.6429)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+<g transform="translate(0.0000, 6.5450)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(102.2399, 5.6429)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+<g transform="translate(0.0000, 5.5450)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(22.6255, 5.6429)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+<g transform="translate(0.0000, 4.5450)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(80.0620, 5.6429)">
-<rect x="-0.0650" y="-2.9114" width="0.1300" height="4.2253" ry="0.0400" fill="currentColor"/>
+<g transform="translate(0.0000, 3.5450)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(78.8228, 7.1429)">
+<g transform="translate(0.0000, 2.5450)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+</g>
+<g transform="translate(72.7571, 3.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(78.1501, 5.6429)">
-<rect x="-0.0650" y="-2.9443" width="0.1300" height="2.7582" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(76.9109, 5.6429)">
+<g transform="translate(66.7918, 2.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(80.7647, 7.6429)">
+<g transform="translate(66.8568, 4.5450)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.3082" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(69.7744, 3.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(82.0039, 5.6429)">
-<rect x="-0.0650" y="-2.8780" width="0.1300" height="4.6919" ry="0.0400" fill="currentColor"/>
+<g transform="translate(69.8394, 4.5450)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.9127" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(82.7066, 8.1429)">
+<g transform="translate(78.7874, 4.5450)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.6245" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(72.8221, 4.5450)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.5172" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(75.7398, 4.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(83.9458, 5.6429)">
-<rect x="-0.0650" y="-2.8446" width="0.1300" height="5.1584" ry="0.0400" fill="currentColor"/>
+<g transform="translate(75.8048, 4.5450)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1216" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(69.9145, 5.6429)">
-<rect x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(87.7790, 4.8329)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="13.6333 -0.2000 13.6333 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(87.7790, 5.6429)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="13.6333 -0.2000 13.6333 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(61.5733, 7.1429)">
+<g transform="translate(78.7224, 4.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(62.8125, 5.6429)">
-<rect x="-0.0650" y="-2.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(78.7224, 6.5450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.7187 -0.0100 20.7187 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(65.3925, 5.1429)">
+<g transform="translate(78.7224, 7.3550)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.7187 -0.0100 20.7187 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(53.9900, 3.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(65.4575, 5.6429)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(54.0550, 4.5450)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.3133" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(68.6753, 7.6429)">
+<g transform="translate(58.1662, 3.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(73.7436, 8.1429)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(74.3957, 2.1600)">
+<g transform="translate(58.8183, 2.2450)">
 <path transform="scale(0.0040, -0.0040)" d="M-297 227c0 -15 8 -30 39 -30c10 0 46 2 103 28l5 24c-23 17 -50 29 -81 29c-51 0 -66 -31 -66 -51zM-26 104c0 -61 -47 -115 -98 -115c-39 0 -56 44 -56 91c0 14 1 28 4 41l15 76c-20 -8 -63 -25 -101 -25c-19 0 -60 6 -60 51c0 38 32 80 96 80c31 0 58 -10 82 -25
 l46 232c6 -3 13 -5 20 -5c22 0 48 16 68 35l-53 -266l64 36c26 14 51 20 74 20c29 0 53 -10 64 -28c18 20 44 30 69 30c36 0 69 -22 69 -69c0 -49 -31 -90 -65 -90c-25 0 -38 22 -38 48c0 50 37 64 60 64h3c-8 14 -23 20 -38 20c-24 0 -50 -16 -55 -43l-54 -270
 c-11 7 -24 11 -38 11s-29 -4 -43 -11l54 270v7c0 16 -12 26 -29 26c-7 0 -16 -3 -24 -7l-79 -44l-7 -31c27 -31 50 -67 50 -109zM-86 39c23 0 35 34 35 61c0 30 -14 55 -32 78l-5 -27c-4 -18 -13 -56 -13 -83c0 -17 4 -29 15 -29z" fill="currentColor"/>
 </g>
-<g transform="translate(75.4978, 8.1429)">
+<g transform="translate(59.9204, 3.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(74.9828, 5.6429)">
-<rect x="-0.0650" y="-2.9989" width="0.1300" height="5.3128" ry="0.0400" fill="currentColor"/>
+<g transform="translate(58.2312, 4.5450)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.0062" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(100.1480, 9.6429)">
+<g transform="translate(64.0591, 1.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(99.7953, 5.6429)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(64.1241, 4.5450)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="5.7125" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(98.5561, 7.1429)">
+<g transform="translate(96.6184, 2.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(101.3872, 5.6429)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(96.6834, 4.5450)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.7883" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(97.7035, 5.6429)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(96.4642, 9.1429)">
+<g transform="translate(99.3511, 5.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(74.9178, 2.6429)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="10.9948 -0.0100 10.9948 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(99.4161, 4.5450)">
+<rect x="-0.0650" y="0.6861" width="0.1300" height="2.3133" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(78.0851, 3.5074)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.8276 -0.0645 7.8276 0.3355 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(9.7500, 8.2350)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.9687 -0.2000 20.9687 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(85.8877, 5.6429)">
-<rect x="-0.0650" y="-2.8111" width="0.1300" height="5.6250" ry="0.0400" fill="currentColor"/>
+<g transform="translate(9.7500, 9.0450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.9687 -0.2000 20.9687 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(86.6048, 9.1429)">
+<g transform="translate(33.6113, 4.5450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.4687 -0.0100 20.4687 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(33.6113, 5.3550)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.4687 -0.0100 20.4687 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(64.0591, 6.1314)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="11.7707 0.2136 11.7707 0.6136 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(58.1662, 6.7350)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.6636 0.4200 17.6636 0.8200 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(81.9551, 2.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(87.8440, 5.6429)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(82.0201, 4.5450)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.6541" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(88.6967, 7.1429)">
+<g transform="translate(84.9378, 3.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(89.9359, 5.6429)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(85.0028, 4.5450)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1814" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(84.6485, 8.6429)">
+<g transform="translate(87.6704, 4.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(90.6386, 7.6429)">
+<g transform="translate(87.7354, 4.5450)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.2064" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(90.6531, 3.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(91.8778, 5.6429)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(90.7181, 4.5450)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.7337" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(92.5805, 8.6429)">
+<g transform="translate(93.3858, 4.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(93.8197, 5.6429)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(93.4508, 4.5450)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.7587" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(94.5223, 8.1429)">
+<g transform="translate(18.4480, 4.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(95.7616, 5.6429)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(18.5130, 4.5450)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(23.5704, 6.1429)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(26.2596, 5.6429)">
-<rect x="-0.0650" y="-3.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(25.0204, 6.1429)">
+<g transform="translate(21.6807, 1.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(20.0994, 5.6429)">
-<rect x="-0.0650" y="-0.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(21.7457, 4.5450)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="7.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(18.8602, 8.6429)">
+<g transform="translate(15.2803, 4.5450)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(24.4133, 2.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.3571, 7.1429)">
+<g transform="translate(24.4783, 4.5450)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="6.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(27.4610, 4.5450)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(30.6287, 1.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(29.5963, 5.6429)">
-<rect x="-0.0650" y="-2.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(31.9438, 6.6429)">
+<g transform="translate(9.7500, 1.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(33.1831, 5.6429)">
-<rect x="-0.0650" y="-2.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g color="rgb(100.0000%, 100.0000%, 100.0000%)">
+<g transform="translate(0.0000, 4.5450)">
+<rect x="0.0000" y="-2.0812" width="3.7500" height="4.1625" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(8.3500, 6.1429)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 4.6429)">
+<g transform="translate(0.6000, 4.5450)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(1.6500, 4.5450)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(2.7000, 4.5450)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(4.7500, 3.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 4.6429)">
+<g transform="translate(9.8150, 4.5450)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="7.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(8.3000, 1.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(-2.2535, 2.5682)">
+<g transform="translate(27.3960, 2.0450)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(-2.2535, 1.4703)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>10</tspan>
 </text>
 </g>
-<g transform="translate(9.5892, 5.6429)">
-<rect x="-0.0650" y="-3.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(6.9000, 6.1429)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(11.6867, 8.6429)">
+<g transform="translate(12.4827, 4.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.9260, 5.6429)">
-<rect x="-0.0650" y="-0.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(12.5477, 4.5450)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.0235, 11.1429)">
+<g transform="translate(15.2153, 6.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(16.2627, 5.6429)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="5.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(48.0896, 4.5450)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.7580" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(44.8090, 7.1429)">
+<g transform="translate(39.5767, 1.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(46.0483, 5.6429)">
-<rect x="-0.0650" y="-2.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(39.6417, 4.5450)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1798" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(48.5569, 5.6429)">
+<g transform="translate(48.0246, 2.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(48.6219, 5.6429)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="3.1472" ry="0.0400" fill="currentColor"/>
+<g transform="translate(30.6937, 4.5450)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="7.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(52.0539, 6.6429)">
+<g transform="translate(42.3093, 2.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(53.2931, 5.6429)">
-<rect x="-0.0650" y="-2.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(42.3743, 4.5450)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.2051" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(58.2365, 6.1429)">
+<g transform="translate(45.2920, 1.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(59.4758, 5.6429)">
-<rect x="-0.0650" y="-3.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(45.3570, 4.5450)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.7327" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(56.7865, 6.1429)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(42.7115, 5.6429)">
-<rect x="-0.0650" y="-3.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(41.4723, 6.1429)">
+<g transform="translate(51.2573, 0.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(40.0223, 6.1429)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(35.6853, 5.6429)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="3.1472" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(35.6203, 5.6429)">
+<g transform="translate(33.6113, 1.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 18.1479)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="35.9350" y2="0"/>
+<g transform="translate(51.3223, 4.5450)">
+<rect x="-0.0650" y="-3.8139" width="0.1300" height="4.7880" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 17.1479)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="35.9350" y2="0"/>
+<g transform="translate(33.6763, 4.5450)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6245" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 16.1479)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="35.9350" y2="0"/>
+<g transform="translate(36.4090, 4.5450)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6498" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 15.1479)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="35.9350" y2="0"/>
+<g transform="translate(36.3440, 2.5450)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 14.1479)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="35.9350" y2="0"/>
+<g transform="translate(0.0000, 17.9282)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
 </g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="33.6719" y="-0.1000" width="1.9063" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 16.9282)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
 </g>
-<g transform="translate(0.0000, 20.1479)">
-<rect x="33.6719" y="-0.1000" width="1.9063" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 15.9282)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
 </g>
-<g transform="translate(0.0000, 21.1479)">
-<rect x="33.6719" y="-0.1000" width="1.9063" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 14.9282)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
 </g>
-<g transform="translate(0.0000, 22.1479)">
-<rect x="33.6719" y="-0.1000" width="1.9063" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 13.9282)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
 </g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="31.7156" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="29.7593" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 20.1479)">
-<rect x="29.7593" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 21.1479)">
-<rect x="29.7593" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="27.8029" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 20.1479)">
-<rect x="27.8029" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="25.8466" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 20.1479)">
-<rect x="25.8466" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 21.1479)">
-<rect x="25.8466" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="23.8903" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 20.1479)">
-<rect x="23.8903" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="21.9340" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="19.9777" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 20.1479)">
-<rect x="19.9777" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 21.1479)">
-<rect x="19.9777" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="18.0213" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 20.1479)">
-<rect x="18.0213" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 21.1479)">
-<rect x="18.0213" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="16.0650" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 20.1479)">
-<rect x="16.0650" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="14.1087" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 20.1479)">
-<rect x="14.1087" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="12.1024" y="-0.1000" width="1.9063" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.1479)">
-<rect x="7.5740" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 20.1479)">
-<rect x="7.5740" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(35.7950, 16.1479)">
+<g transform="translate(44.8609, 15.9282)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(26.1227, 21.1479)">
+<g transform="translate(32.3399, 17.4282)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(27.3619, 16.1479)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(33.5791, 15.9282)">
+<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(28.0790, 20.6479)">
+<g transform="translate(34.8441, 16.9282)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(29.3182, 16.1479)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="4.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(36.0833, 15.9282)">
+<rect x="-0.0650" y="-2.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(20.2537, 21.6479)">
+<g transform="translate(24.8272, 17.9282)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(25.4056, 16.1479)">
-<rect x="-0.0650" y="0.0000" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(31.3249, 15.9282)">
+<rect x="-0.0650" y="-2.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(24.1663, 20.1479)">
+<g transform="translate(30.0857, 16.4282)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(23.4492, 16.1479)">
-<rect x="-0.0650" y="0.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(28.8207, 15.9282)">
+<rect x="-0.0650" y="-2.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(22.2100, 19.6479)">
+<g transform="translate(27.5814, 15.9282)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(21.4929, 16.1479)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="5.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(26.0664, 15.9282)">
+<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(21.4279, 16.1479)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="13.7842 -0.2000 13.7842 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(26.0014, 13.1182)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.3695 -0.2000 17.3695 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(21.4279, 16.9579)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="13.7842 -0.2000 13.7842 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(26.0014, 13.9282)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.3695 -0.2000 17.3695 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(9.0742, 15.3379)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="10.4874 -0.2000 10.4874 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(9.0742, 11.9282)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="14.5130 -0.0100 14.5130 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(11.8284, 16.1479)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.7332 -0.2000 7.7332 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(13.7304, 12.7989)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.8568 -0.0708 9.8568 0.3292 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(35.1872, 16.1479)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="5.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(33.9479, 22.1479)">
+<g transform="translate(37.0983, 17.9282)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(33.2308, 16.1479)">
-<rect x="-0.0650" y="0.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(43.3459, 15.9282)">
+<rect x="-0.0650" y="-2.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(31.9916, 19.6479)">
+<g transform="translate(42.1067, 18.4282)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(31.2745, 16.1479)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="5.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(41.0917, 15.9282)">
+<rect x="-0.0650" y="-2.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(30.0353, 21.6479)">
+<g transform="translate(39.8525, 15.9282)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(11.8934, 16.1479)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(38.3375, 15.9282)">
+<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(10.6542, 18.1479)">
+<g transform="translate(7.9000, 16.9282)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(9.1392, 16.1479)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(14.8104, 15.9282)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(9.6542, 20.6479)">
+<g transform="translate(13.7954, 15.9282)">
+<rect x="-0.0650" y="-3.9384" width="0.1300" height="2.2523" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(12.5562, 14.4282)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(9.1392, 15.9282)">
+<rect x="-0.0650" y="-3.9992" width="0.1300" height="4.8130" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(9.6542, 16.4282)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(8.5521, 13.8479)">
+<g transform="translate(8.5521, 11.4450)">
 <path transform="scale(0.0040, -0.0040)" d="M-297 227c0 -15 8 -30 39 -30c10 0 46 2 103 28l5 24c-23 17 -50 29 -81 29c-51 0 -66 -31 -66 -51zM-26 104c0 -61 -47 -115 -98 -115c-39 0 -56 44 -56 91c0 14 1 28 4 41l15 76c-20 -8 -63 -25 -101 -25c-19 0 -60 6 -60 51c0 38 32 80 96 80c31 0 58 -10 82 -25
 l46 232c6 -3 13 -5 20 -5c22 0 48 16 68 35l-53 -266l64 36c26 14 51 20 74 20c29 0 53 -10 64 -28c18 20 44 30 69 30c36 0 69 -22 69 -69c0 -49 -31 -90 -65 -90c-25 0 -38 22 -38 48c0 50 37 64 60 64h3c-8 14 -23 20 -38 20c-24 0 -50 -16 -55 -43l-54 -270
 c-11 7 -24 11 -38 11s-29 -4 -43 -11l54 270v7c0 16 -12 26 -29 26c-7 0 -16 -3 -24 -7l-79 -44l-7 -31c27 -31 50 -67 50 -109zM-86 39c23 0 35 34 35 61c0 30 -14 55 -32 78l-5 -27c-4 -18 -13 -56 -13 -83c0 -17 4 -29 15 -29z" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 20.6479)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(-2.2535, 13.0732)">
+<g transform="translate(-2.2535, 12.8782)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
-<tspan>15</tspan>
+<tspan>12</tspan>
 </text>
 </g>
-<g transform="translate(4.3000, 15.1479)">
+<g transform="translate(4.3000, 14.9282)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 15.1479)">
+<g transform="translate(0.8000, 14.9282)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(15.6240, 16.1479)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(21.0580, 15.9282)">
+<rect x="-0.0650" y="-3.8435" width="0.1300" height="4.6574" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(17.5803, 16.1479)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(16.3411, 20.6479)">
+<g transform="translate(19.8188, 16.9282)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.2974, 21.1479)">
+<g transform="translate(16.0496, 15.9282)">
+<rect x="-0.0650" y="-3.9089" width="0.1300" height="3.7228" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(22.3230, 17.4282)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(14.3848, 20.1479)">
+<g transform="translate(18.5538, 15.9282)">
+<rect x="-0.0650" y="-3.8762" width="0.1300" height="4.1901" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(17.3146, 16.4282)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(19.5366, 16.1479)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="5.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(13.6677, 16.1479)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(12.4284, 19.6479)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(23.5622, 15.9282)">
+<rect x="-0.0650" y="-3.8108" width="0.1300" height="5.1247" ry="0.0400" fill="currentColor"/>
 </g>
 </svg>

--- a/scores/mm-4-6.svg
+++ b/scores/mm-4-6.svg
@@ -1,9 +1,24 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="38.24mm" viewBox="-1.1267 -0.0000 103.5567 21.7588">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="31.07mm" viewBox="-1.1267 -0.0000 103.5567 17.6809">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
+<g transform="translate(0.0000, 1.3459)">
+<rect x="86.8045" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.3459)">
+<rect x="61.7338" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.3459)">
+<rect x="42.0809" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(102.2399, 4.3459)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(54.4185, 4.3459)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
 <g transform="translate(0.0000, 6.3459)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
@@ -19,460 +34,365 @@ tspan { white-space: pre; }
 <g transform="translate(0.0000, 2.3459)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(57.4461, 4.3459)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+<g transform="translate(64.9369, 4.3459)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(102.2399, 4.3459)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(32.0516, 4.3459)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3459)">
-<rect x="58.3629" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.3459)">
-<rect x="58.3629" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 9.3459)">
-<rect x="58.3629" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3459)">
-<rect x="50.8500" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.3459)">
-<rect x="50.8500" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 9.3459)">
-<rect x="50.8500" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3459)">
-<rect x="44.9728" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.3459)">
-<rect x="44.9728" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3459)">
-<rect x="38.8456" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.3459)">
-<rect x="38.8456" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3459)">
-<rect x="32.9684" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3459)">
-<rect x="25.4555" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(80.1975, 4.3459)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(76.0464, 6.3459)">
+<g transform="translate(67.9340, 2.8459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(77.2856, 4.3459)">
-<rect x="-0.0650" y="-2.0000" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(67.9990, 4.3459)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(84.7820, 4.8459)">
+<g transform="translate(70.9961, 3.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(78.9583, 5.8459)">
+<g transform="translate(64.8719, 2.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(81.8701, 5.3459)">
+<g transform="translate(71.0611, 4.3459)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(74.0581, 2.8459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(83.1093, 4.3459)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(74.1231, 4.3459)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(80.1325, 2.5359)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.2231 -0.2000 20.2231 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(80.1325, 3.3459)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.2231 -0.2000 20.2231 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(64.3989, 5.3459)">
+<g transform="translate(77.1202, 2.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(65.6381, 4.3459)">
-<rect x="-0.0650" y="-2.0000" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(77.1852, 4.3459)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(67.3108, 4.8459)">
+<g transform="translate(55.9357, 2.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(68.5500, 4.3459)">
-<rect x="-0.0650" y="-2.0000" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(87.1305, 6.4732)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.3383 -0.3273 12.3383 0.0727 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(70.2226, 5.3459)">
+<g transform="translate(81.0323, 7.3459)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="18.4365 -0.3900 18.4365 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(56.0007, 4.3459)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(58.9977, 1.8459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(71.4619, 4.3459)">
-<rect x="-0.0650" y="-2.0000" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(59.0627, 4.3459)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(73.1345, 5.8459)">
+<g transform="translate(62.0598, 1.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(74.3737, 4.3459)">
-<rect x="-0.0650" y="-2.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(62.1248, 4.3459)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(97.4187, 4.3459)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(99.0913, 5.8459)">
+<g transform="translate(96.3168, 2.8459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(100.3306, 4.3459)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(96.3818, 4.3459)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1561" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(96.1795, 6.3459)">
+<g transform="translate(99.3788, 3.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(59.8632, 2.3459)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.4474 -0.2000 17.4474 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(99.4438, 4.3459)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6246" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(65.5731, 3.1559)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="11.7375 -0.2000 11.7375 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(9.7500, 5.5359)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.5245 2.3000 20.5245 2.7000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(91.5949, 4.3459)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(9.7500, 6.3459)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.5245 2.3000 20.5245 2.7000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(87.4439, 5.8459)">
+<g transform="translate(39.3448, 7.4781)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.3383 -1.3322 12.3383 -0.9322 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(33.2466, 8.8459)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="18.4365 -1.8900 18.4365 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(55.9357, 5.3459)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="21.2745 -0.2000 21.2745 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(55.9357, 6.1559)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="21.2745 -0.2000 21.2745 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(87.1955, 4.3459)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="5.7505" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(81.0323, 4.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(88.6831, 4.3459)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(82.7865, 3.8459)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(90.3557, 6.3459)">
+<g transform="translate(81.0973, 4.3459)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8132" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(79.5823, 4.3459)">
+<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
+v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+</g>
+<g transform="translate(87.1305, 1.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(86.0212, 4.3459)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(93.2676, 6.8459)">
+<g transform="translate(90.1926, 1.8459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(94.5068, 4.3459)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(90.2576, 4.3459)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="5.2190" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(19.9044, 6.3459)">
+<g transform="translate(93.2547, 2.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(21.1436, 4.3459)">
-<rect x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(93.3197, 4.3459)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.6875" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(25.7816, 7.8459)">
+<g transform="translate(18.4362, 4.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(27.0208, 4.3459)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(18.5012, 4.3459)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8778" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(33.2945, 7.8459)">
+<g transform="translate(21.4983, 4.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(34.5337, 4.3459)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(21.5633, 4.3459)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="3.2500" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 5.3459)">
+<g transform="translate(15.6891, 4.3459)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.0359" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(24.3104, 5.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 3.3459)">
+<g transform="translate(24.3754, 4.3459)">
+<rect x="-0.0650" y="1.1861" width="0.1300" height="2.5919" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(27.4375, 4.3459)">
+<rect x="-0.0650" y="1.1861" width="0.1300" height="2.9641" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(9.7500, 1.8459)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g color="rgb(100.0000%, 100.0000%, 100.0000%)">
+<g transform="translate(0.0000, 4.3459)">
+<rect x="0.0000" y="-2.0812" width="3.7500" height="4.1625" ry="0.0000" fill="currentColor"/>
+</g>
+</g>
+<g transform="translate(0.6000, 4.3459)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(1.6500, 4.3459)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(2.7000, 4.3459)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(4.7500, 3.3459)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 3.3459)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+<g transform="translate(9.8150, 4.3459)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.3218" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(27.3725, 5.3459)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(-1.1267, 1.2959)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>4</tspan>
 </text>
 </g>
-<g transform="translate(9.1392, 4.3459)">
-<rect x="-0.0650" y="-2.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(13.7772, 6.3459)">
+<g transform="translate(12.5621, 2.8459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(15.0164, 4.3459)">
-<rect x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(12.6271, 4.3459)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.6637" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(60.4432, 9.8459)">
+<g transform="translate(15.6241, 2.8459)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(42.4719, 4.3459)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="6.4701" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(39.3448, 1.8459)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(39.4098, 4.3459)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.2502" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(48.5961, 4.3459)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.9099" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(42.4069, 1.3459)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(30.1845, 6.3459)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(48.5311, 2.3459)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(45.4690, 1.8459)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(45.5340, 4.3459)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="5.6900" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(33.3116, 4.3459)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3079" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(33.2466, 6.3459)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(35.0008, 5.8459)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(51.1760, 9.8459)">
+<g transform="translate(51.6582, 4.3459)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1298" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(51.5932, 2.8459)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(52.4153, 4.3459)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="5.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(30.2495, 4.3459)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3060" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(58.6890, 9.8459)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(0.0000, 17.1359)">
+<rect x="26.6077" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(59.9282, 4.3459)">
-<rect x="-0.0650" y="-2.0000" width="0.1300" height="7.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(0.0000, 17.1359)">
+<rect x="24.1034" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(45.2989, 8.8459)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(0.0000, 16.1359)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
 </g>
-<g transform="translate(40.4109, 4.3459)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="4.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(0.0000, 15.1359)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
 </g>
-<g transform="translate(39.1717, 8.8459)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(0.0000, 14.1359)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
 </g>
-<g transform="translate(46.5381, 4.3459)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="4.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(0.0000, 13.1359)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
 </g>
-<g transform="translate(0.0000, 16.7138)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="63.7782" y2="0"/>
+<g transform="translate(0.0000, 12.1359)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
 </g>
-<g transform="translate(0.0000, 15.7138)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="63.7782" y2="0"/>
-</g>
-<g transform="translate(0.0000, 14.7138)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="63.7782" y2="0"/>
-</g>
-<g transform="translate(0.0000, 13.7138)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="63.7782" y2="0"/>
-</g>
-<g transform="translate(0.0000, 12.7138)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="63.7782" y2="0"/>
-</g>
-<g transform="translate(44.8109, 14.7138)">
+<g transform="translate(44.8609, 14.1359)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 17.7138)">
-<rect x="52.9853" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.7138)">
-<rect x="50.2310" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 18.7138)">
-<rect x="50.2310" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.7138)">
-<rect x="45.5749" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 18.7138)">
-<rect x="45.5749" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.7138)">
-<rect x="45.5749" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 20.7138)">
-<rect x="45.5749" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.7138)">
-<rect x="41.7307" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 18.7138)">
-<rect x="41.7307" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.7138)">
-<rect x="41.7307" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 20.7138)">
-<rect x="41.7307" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.7138)">
-<rect x="39.4765" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 18.7138)">
-<rect x="39.4765" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.7138)">
-<rect x="39.4765" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.7138)">
-<rect x="36.9722" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 18.7138)">
-<rect x="36.9722" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.7138)">
-<rect x="36.9722" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.7138)">
-<rect x="34.7180" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 18.7138)">
-<rect x="34.7180" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.7138)">
-<rect x="32.2138" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 18.7138)">
-<rect x="32.2138" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.7138)">
-<rect x="29.9596" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.7138)">
-<rect x="27.4554" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.7138)">
-<rect x="8.1750" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(45.9009, 21.2138)">
+<g transform="translate(31.5899, 15.1359)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(42.0567, 21.2138)">
+<g transform="translate(32.8291, 14.1359)">
+<rect x="-0.0650" y="-2.9853" width="0.1300" height="3.7992" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(34.3441, 13.6359)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(43.2959, 14.7138)">
-<rect x="-0.0650" y="-0.0020" width="0.1300" height="6.3158" ry="0.0400" fill="currentColor"/>
+<g transform="translate(35.5833, 14.1359)">
+<rect x="-0.0650" y="-3.4493" width="0.1300" height="2.7632" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(47.6551, 21.2138)">
+<g transform="translate(28.1729, 14.1359)">
+<rect x="-0.0650" y="-2.2009" width="0.1300" height="5.0148" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(28.6879, 16.6359)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(47.1401, 14.7138)">
-<rect x="-0.0650" y="-0.0042" width="0.1300" height="6.3181" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(32.5399, 19.2138)">
+<g transform="translate(26.9337, 17.1359)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(47.0751, 14.7138)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="15.5130 -1.2000 15.5130 -0.8000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(25.6687, 14.1359)">
+<rect x="-0.0650" y="-1.8193" width="0.1300" height="4.6332" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(51.7313, 15.2244)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="10.8568 -0.9006 10.8568 -0.5006 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(33.7791, 14.7138)">
-<rect x="-0.0650" y="-0.2876" width="0.1300" height="4.6015" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(35.0441, 19.2138)">
+<g transform="translate(24.4295, 17.1359)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(36.2833, 14.7138)">
-<rect x="-0.0650" y="-0.2124" width="0.1300" height="4.5263" ry="0.0400" fill="currentColor"/>
+<g transform="translate(28.1079, 11.9459)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="15.5130 -2.8200 15.5130 -2.4200 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(41.0417, 14.7138)">
-<rect x="-0.0650" y="-0.0696" width="0.1300" height="5.3835" ry="0.0400" fill="currentColor"/>
+<g transform="translate(32.7641, 11.9716)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="10.8568 -2.0356 10.8568 -1.6356 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(37.2983, 20.2138)">
+<g transform="translate(9.0742, 9.9459)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="16.6195 2.1800 16.6195 2.5800 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(9.0742, 10.7559)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="16.6195 2.1800 16.6195 2.5800 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(37.0983, 12.6359)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(38.5375, 14.7138)">
-<rect x="-0.0650" y="-0.1448" width="0.1300" height="5.4587" ry="0.0400" fill="currentColor"/>
+<g transform="translate(43.5959, 14.1359)">
+<rect x="-0.0650" y="-4.7991" width="0.1300" height="2.6129" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(39.8025, 20.2138)">
+<g transform="translate(42.3567, 12.1359)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(56.0655, 16.7138)">
+<g transform="translate(40.8417, 14.1359)">
+<rect x="-0.0650" y="-4.3351" width="0.1300" height="3.1490" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(39.6025, 13.1359)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(57.3047, 14.7138)">
-<rect x="-0.0650" y="-0.6577" width="0.1300" height="2.4716" ry="0.0400" fill="currentColor"/>
+<g transform="translate(38.3375, 14.1359)">
+<rect x="-0.0650" y="-3.9132" width="0.1300" height="2.2271" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(58.5697, 17.2138)">
+<g transform="translate(7.9000, 12.6359)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(59.8089, 14.7138)">
-<rect x="-0.0650" y="-0.8187" width="0.1300" height="3.1326" ry="0.0400" fill="currentColor"/>
+<g transform="translate(13.8976, 14.1359)">
+<rect x="-0.0650" y="-3.5009" width="0.1300" height="2.8148" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(61.3239, 16.2138)">
+<g transform="translate(12.6584, 13.6359)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(62.5632, 14.7138)">
-<rect x="-0.0650" y="-0.9958" width="0.1300" height="2.3097" ry="0.0400" fill="currentColor"/>
+<g transform="translate(11.3934, 14.1359)">
+<rect x="-0.0650" y="-3.8587" width="0.1300" height="3.1726" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(9.5242, 12.9038)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="14.7630 -0.2000 14.7630 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(14.1804, 13.7138)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="10.1068 -0.2000 10.1068 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(26.7014, 14.2138)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="16.6195 0.3000 16.6195 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(26.7014, 15.0238)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="16.6195 0.3000 16.6195 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(51.7963, 14.7138)">
-<rect x="-0.0650" y="-0.3036" width="0.1300" height="4.6174" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(50.5571, 19.2138)">
+<g transform="translate(10.1542, 13.6359)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(53.3113, 17.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(9.1392, 14.1359)">
+<rect x="-0.0650" y="-4.1807" width="0.1300" height="2.4946" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(54.5505, 14.7138)">
-<rect x="-0.0650" y="-0.4806" width="0.1300" height="3.2945" ry="0.0400" fill="currentColor"/>
+<g transform="translate(23.4145, 14.1359)">
+<rect x="-0.0650" y="-2.1413" width="0.1300" height="3.9552" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.5104, 15.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(16.7496, 14.7138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(18.0146, 16.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(19.2538, 14.7138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(20.5188, 16.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(8.3500, 18.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(10.1042, 18.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(9.5892, 14.7138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(21.7580, 14.7138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(6.9000, 18.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(13.0062, 15.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(14.2454, 14.7138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(27.7814, 17.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(29.0207, 14.7138)">
-<rect x="-0.0650" y="-0.4304" width="0.1300" height="3.2443" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(30.2857, 17.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(31.5249, 14.7138)">
-<rect x="-0.0650" y="-0.3552" width="0.1300" height="3.1691" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(26.7664, 14.7138)">
-<rect x="-0.0650" y="-0.4980" width="0.1300" height="2.3119" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(-1.1267, 11.6638)">
+<g transform="translate(-1.1267, 11.0612)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
-<tspan>7</tspan>
+<tspan>6</tspan>
 </text>
 </g>
-<g transform="translate(4.3000, 13.7138)">
+<g transform="translate(4.3000, 13.1359)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(23.0230, 17.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(24.2622, 14.7138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(0.8000, 13.7138)">
+<g transform="translate(0.8000, 13.1359)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(25.5272, 16.7138)">
+<g transform="translate(22.1753, 16.1359)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(20.9103, 14.1359)">
+<rect x="-0.0650" y="-2.4991" width="0.1300" height="4.3130" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(19.6711, 16.1359)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(18.6561, 14.1359)">
+<rect x="-0.0650" y="-2.8211" width="0.1300" height="3.6350" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(17.4169, 15.1359)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(16.1519, 14.1359)">
+<rect x="-0.0650" y="-3.1789" width="0.1300" height="3.9928" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(14.9126, 15.1359)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 </svg>

--- a/scores/mm-6-7.svg
+++ b/scores/mm-6-7.svg
@@ -1,368 +1,274 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="37.49mm" viewBox="-1.1267 -0.0000 103.5567 21.3312">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="157.26mm" height="15.99mm" viewBox="-1.1267 0.0000 89.4877 9.1000">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
-<g transform="translate(0.0000, 6.3706)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(0.0000, 2.0500)">
+<rect x="71.0521" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 5.3706)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(0.0000, 2.0500)">
+<rect x="61.1863" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 4.3706)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(0.0000, 8.0500)">
+<rect x="28.4576" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 3.3706)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(0.0000, 8.0500)">
+<rect x="25.9534" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 2.3706)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
-</g>
-<g transform="translate(56.4711, 4.3706)">
+<g transform="translate(88.1710, 5.0500)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(102.2399, 4.3706)">
+<g transform="translate(46.7109, 5.0500)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(31.5716, 4.3706)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+<g transform="translate(0.0000, 7.0500)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="88.3110" y2="0"/>
 </g>
-<g transform="translate(0.0000, 7.3706)">
-<rect x="83.8326" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 6.0500)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="88.3110" y2="0"/>
 </g>
-<g transform="translate(0.0000, 7.3706)">
-<rect x="66.1014" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 5.0500)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="88.3110" y2="0"/>
 </g>
-<g transform="translate(0.0000, 7.3706)">
-<rect x="62.9795" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 4.0500)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="88.3110" y2="0"/>
 </g>
-<g transform="translate(0.0000, 8.3706)">
-<rect x="62.9795" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 3.0500)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="88.3110" y2="0"/>
 </g>
-<g transform="translate(0.0000, 7.3706)">
-<rect x="57.3730" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.3706)">
-<rect x="57.3730" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 9.3706)">
-<rect x="57.3730" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 10.3706)">
-<rect x="57.3730" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3706)">
-<rect x="49.9950" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.3706)">
-<rect x="49.9950" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 9.3706)">
-<rect x="49.9950" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 10.3706)">
-<rect x="49.9950" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3706)">
-<rect x="44.2379" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.3706)">
-<rect x="44.2379" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 9.3706)">
-<rect x="44.2379" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3706)">
-<rect x="38.2307" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.3706)">
-<rect x="38.2307" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 9.3706)">
-<rect x="38.2307" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3706)">
-<rect x="32.4735" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.3706)">
-<rect x="32.4735" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3706)">
-<rect x="25.0955" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.3706)">
-<rect x="25.0955" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3706)">
-<rect x="19.3383" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3706)">
-<rect x="13.3312" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(75.5431, 5.8706)">
+<g transform="translate(63.6155, 3.5500)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(76.7823, 4.3706)">
-<rect x="-0.0650" y="-0.9964" width="0.1300" height="2.3103" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(85.3979, 4.3706)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="5.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(78.4149, 6.3706)">
+<g transform="translate(58.0071, 3.5500)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(79.6542, 4.3706)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(58.0721, 5.0500)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(84.1587, 7.3706)">
+<g transform="translate(61.3613, 2.0500)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(81.2868, 6.8706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(61.4263, 5.0500)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(82.5260, 4.3706)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(79.5892, 1.5606)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.7931 -0.2000 20.7931 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(79.5892, 2.3706)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.7931 -0.2000 20.7931 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(63.3056, 8.8706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(64.5448, 4.3706)">
-<rect x="-0.0650" y="-0.3155" width="0.1300" height="4.6294" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(66.4274, 7.3706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(67.6667, 4.3706)">
-<rect x="-0.0650" y="-0.4892" width="0.1300" height="3.3031" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(69.5493, 6.3706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(70.7885, 4.3706)">
-<rect x="-0.0650" y="-0.6629" width="0.1300" height="2.4768" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(72.4212, 6.8706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(73.6604, 4.3706)">
-<rect x="-0.0650" y="-0.8227" width="0.1300" height="3.1366" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(96.2462, 6.3706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(97.4854, 4.3706)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(99.1180, 6.8706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(100.3573, 4.3706)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(58.8732, 4.3706)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.9340 -1.2000 17.9340 -0.8000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(64.4798, 4.8687)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.3275 -0.8881 12.3275 -0.4881 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(87.0306, 6.8706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(88.2698, 4.3706)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(89.9024, 6.3706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(91.1416, 4.3706)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(93.6243, 4.8706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(94.8635, 4.3706)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(92.1743, 4.8706)">
+<g transform="translate(59.9113, 2.0500)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(19.6644, 7.3706)">
+<g transform="translate(68.6890, 5.0500)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(63.6805, 5.0500)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(66.1198, 4.0500)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(20.9036, 4.3706)">
-<rect x="-0.0650" y="-0.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(66.1848, 5.0500)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(25.4216, 8.8706)">
+<g transform="translate(68.6240, 3.5500)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(26.6608, 4.3706)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="4.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(50.5595, 5.0500)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(32.7995, 8.8706)">
+<g transform="translate(68.6240, 8.0500)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.3695 -0.2000 17.3695 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(68.6240, 8.8600)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.3695 -0.2000 17.3695 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(48.0553, 5.0500)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(50.4945, 4.0500)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(34.0387, 4.3706)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="4.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 6.3706)">
+<g transform="translate(52.9987, 4.5500)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 3.3706)">
+<g transform="translate(53.0637, 5.0500)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(55.5029, 4.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(55.5679, 5.0500)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(83.1492, 6.5500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(83.2142, 5.0500)">
+<rect x="-0.0650" y="1.6861" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(85.9035, 3.5500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(85.9685, 5.0500)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(10.9242, 0.8600)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="16.6195 2.1800 16.6195 2.5800 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(10.9242, 1.6700)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="16.6195 2.1800 16.6195 2.5800 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(29.9579, 2.8600)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="15.5130 -2.8200 15.5130 -2.4200 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(34.6141, 2.8856)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="10.8568 -2.0356 10.8568 -1.6356 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(47.9903, 6.2400)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="18.2195 -0.2000 18.2195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(47.9903, 7.0500)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="18.2195 -0.2000 18.2195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(71.3782, 2.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(71.4432, 5.0500)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="6.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(73.6324, 4.5500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(73.6974, 5.0500)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(76.1366, 4.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(76.2016, 5.0500)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(78.6408, 3.5500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(78.7058, 5.0500)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(80.8950, 4.5500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(80.9600, 5.0500)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(16.7626, 6.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(18.0018, 5.0500)">
+<rect x="-0.0650" y="-3.1789" width="0.1300" height="3.9928" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(19.2668, 6.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(20.5060, 5.0500)">
+<rect x="-0.0650" y="-2.8211" width="0.1300" height="3.6350" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(21.5210, 7.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(22.7603, 5.0500)">
+<rect x="-0.0650" y="-2.4991" width="0.1300" height="4.3130" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(24.0253, 7.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(26.2795, 8.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(27.5187, 5.0500)">
+<rect x="-0.0650" y="-1.8193" width="0.1300" height="4.6332" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(9.7500, 3.5500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g color="rgb(100.0000%, 100.0000%, 100.0000%)">
+<g transform="translate(0.0000, 5.0500)">
+<rect x="0.0000" y="-2.0812" width="3.7500" height="4.1625" ry="0.0000" fill="currentColor"/>
+</g>
+</g>
+<g transform="translate(0.6000, 5.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(1.6500, 5.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(2.7000, 5.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(4.7500, 4.0500)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 3.3706)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+<g transform="translate(10.9892, 5.0500)">
+<rect x="-0.0650" y="-4.1807" width="0.1300" height="2.4946" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 1.2959)">
+<g transform="translate(25.2645, 5.0500)">
+<rect x="-0.0650" y="-2.1413" width="0.1300" height="3.9552" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(-1.1267, 1.9753)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>6</tspan>
 </text>
 </g>
-<g transform="translate(9.1392, 4.3706)">
-<rect x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(13.6572, 7.3706)">
+<g transform="translate(12.0042, 4.5500)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(14.8964, 4.3706)">
-<rect x="-0.0650" y="-0.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(13.2434, 5.0500)">
+<rect x="-0.0650" y="-3.8587" width="0.1300" height="3.1726" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(58.9382, 4.3706)">
-<rect x="-0.0650" y="-0.0036" width="0.1300" height="6.3175" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(50.3211, 10.8706)">
+<g transform="translate(14.5084, 4.5500)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(51.5603, 4.3706)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="6.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(15.7476, 5.0500)">
+<rect x="-0.0650" y="-3.5009" width="0.1300" height="2.8148" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(57.6990, 10.8706)">
+<g transform="translate(41.4525, 4.0500)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(59.4532, 10.8706)">
+<g transform="translate(36.1941, 4.5500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(37.4333, 5.0500)">
+<rect x="-0.0650" y="-3.4493" width="0.1300" height="2.7632" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(38.9483, 3.5500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(40.1875, 5.0500)">
+<rect x="-0.0650" y="-3.9132" width="0.1300" height="2.2271" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(42.6917, 5.0500)">
+<rect x="-0.0650" y="-4.3351" width="0.1300" height="3.1490" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(44.2067, 3.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(45.4459, 5.0500)">
+<rect x="-0.0650" y="-4.7991" width="0.1300" height="2.6129" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(47.9903, 3.5500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(28.7837, 8.0500)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(30.5379, 7.5500)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(39.7959, 4.3706)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="5.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(30.0229, 5.0500)">
+<rect x="-0.0650" y="-2.2009" width="0.1300" height="5.0148" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(38.5567, 9.8706)">
+<g transform="translate(33.4399, 6.0500)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(44.5639, 9.8706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(45.8031, 4.3706)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="5.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.7862)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="28.2337" y2="0"/>
-</g>
-<g transform="translate(0.0000, 16.7862)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="28.2337" y2="0"/>
-</g>
-<g transform="translate(0.0000, 15.7862)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="28.2337" y2="0"/>
-</g>
-<g transform="translate(0.0000, 14.7862)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="28.2337" y2="0"/>
-</g>
-<g transform="translate(0.0000, 13.7862)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="28.2337" y2="0"/>
-</g>
-<g transform="translate(0.0000, 18.7862)">
-<rect x="22.6992" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.7862)">
-<rect x="22.6992" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 20.7862)">
-<rect x="22.6992" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 18.7862)">
-<rect x="20.4450" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 18.7862)">
-<rect x="13.1824" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(20.7711, 18.7862)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(19.7561, 15.7862)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(18.5169, 17.7862)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(17.2519, 15.7862)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(16.0126, 18.2862)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(9.0742, 12.9762)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.9695 -0.2000 17.9695 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(9.0742, 13.7862)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.9695 -0.2000 17.9695 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(27.0187, 15.7862)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(25.7795, 17.7862)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(22.0103, 15.7862)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="5.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(24.2645, 15.7862)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="7.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(23.0253, 20.7862)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(9.1392, 15.7862)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(14.7476, 15.7862)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="5.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 17.7862)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(-1.1267, 12.7115)">
-<text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
-<tspan>9</tspan>
-</text>
-</g>
-<g transform="translate(4.3000, 14.7862)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(0.8000, 14.7862)">
-<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
-c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
-</g>
-<g transform="translate(13.5084, 18.7862)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(9.8042, 16.2862)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(12.4934, 15.7862)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(11.2542, 16.2862)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(34.6791, 5.0500)">
+<rect x="-0.0650" y="-2.9853" width="0.1300" height="3.7992" ry="0.0400" fill="currentColor"/>
 </g>
 </svg>

--- a/scores/mm-7-10.svg
+++ b/scores/mm-7-10.svg
@@ -1,580 +1,562 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="35.60mm" viewBox="-2.2535 -0.0000 104.6834 20.2588">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="31.34mm" viewBox="-1.1267 -0.0000 103.5567 17.8350">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
-<g transform="translate(0.0000, 6.3229)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(0.0000, 1.5000)">
+<rect x="96.5841" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 5.3229)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(0.0000, 1.5000)">
+<rect x="36.5078" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 4.3229)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(0.0000, 1.5000)">
+<rect x="24.9994" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 3.3229)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
-</g>
-<g transform="translate(0.0000, 2.3229)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
-</g>
-<g transform="translate(70.9737, 4.3229)">
+<g transform="translate(102.2399, 4.5000)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(38.9194, 4.3229)">
+<g transform="translate(56.5013, 4.5000)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(55.1113, 4.3229)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+<g transform="translate(0.0000, 6.5000)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(102.2399, 4.3229)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+<g transform="translate(0.0000, 5.5000)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(22.7275, 4.3229)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+<g transform="translate(0.0000, 4.5000)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 7.3229)">
-<rect x="87.9242" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 3.5000)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 7.3229)">
-<rect x="84.0090" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 2.5000)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 7.3229)">
-<rect x="79.9439" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3229)">
-<rect x="76.0781" y="-0.1000" width="1.9069" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3229)">
-<rect x="74.0711" y="-0.1000" width="1.9069" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3229)">
-<rect x="62.8544" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 8.3229)">
-<rect x="62.8544" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 9.3229)">
-<rect x="62.8544" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3229)">
-<rect x="59.4511" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3229)">
-<rect x="47.2644" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 7.3229)">
-<rect x="14.8805" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(76.3548, 7.3229)">
+<g transform="translate(68.0114, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(77.5940, 4.3229)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(68.0764, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(75.6364, 4.3229)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(78.3123, 6.8229)">
+<g transform="translate(70.6763, 4.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(79.5516, 4.3229)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(70.7413, 4.5000)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(74.3972, 7.8229)">
+<g transform="translate(53.8231, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(80.2699, 7.8229)">
+<g transform="translate(79.4209, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(81.5091, 4.3229)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(82.3775, 6.3229)">
+<g transform="translate(73.8412, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(83.6167, 4.3229)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(73.9062, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(87.4668, 2.5129)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="13.9430 -0.2000 13.9430 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(87.4668, 3.3229)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="13.9430 -0.2000 13.9430 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(59.7772, 7.3229)">
+<g transform="translate(76.5060, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(61.0164, 4.3229)">
-<rect x="-0.0650" y="-0.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(76.5710, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(63.1804, 9.3229)">
+<g transform="translate(79.4209, 6.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.2441 -0.2000 20.2441 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(79.4209, 7.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.2441 -0.2000 20.2441 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(53.8881, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(57.9061, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(64.4197, 4.3229)">
-<rect x="-0.0650" y="-0.0000" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(57.9711, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(67.0837, 6.3229)">
+<g transform="translate(65.1615, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(62.1816, 4.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(68.3229, 4.3229)">
-<rect x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(62.2466, 4.5000)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(72.2363, 6.8229)">
+<g transform="translate(65.0965, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(73.4755, 4.3229)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(100.1456, 5.8229)">
+<g transform="translate(96.9102, 1.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(99.4273, 4.3229)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(96.9752, 4.5000)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="5.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(98.1881, 4.8229)">
+<g transform="translate(99.5750, 2.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(101.3849, 4.3229)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(99.6400, 4.5000)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(97.4697, 4.3229)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(94.0603, 4.5000)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(96.2305, 5.3229)">
+<g transform="translate(9.7500, 5.6900)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="21.0941 -0.2000 21.0941 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(9.7500, 6.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="21.0941 -0.2000 21.0941 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(33.6690, 7.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.2441 -0.2000 20.2441 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(33.6690, 8.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.2441 -0.2000 20.2441 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(62.1816, 6.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="14.4144 -0.2000 14.4144 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(57.9061, 7.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="18.6899 -0.2000 18.6899 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(82.0858, 4.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(73.4105, 3.5129)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.1888 -0.2000 12.1888 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(82.1508, 4.5000)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(75.5714, 4.3229)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="10.0279 -0.2000 10.0279 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(85.5743, 4.3229)">
-<rect x="-0.0650" y="-0.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(86.2926, 6.8229)">
+<g transform="translate(85.2507, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(87.5318, 4.3229)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(85.3157, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(88.2502, 7.8229)">
+<g transform="translate(79.4859, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(88.1655, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(89.4894, 4.3229)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(88.2305, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(84.3351, 7.3229)">
+<g transform="translate(91.0804, 2.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(90.3578, 6.8229)">
+<g transform="translate(91.1454, 4.5000)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(93.9953, 2.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(91.5970, 4.3229)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(92.3154, 6.3229)">
+<g transform="translate(25.1744, 1.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(93.5546, 4.3229)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(94.2729, 5.8229)">
+<g transform="translate(18.4946, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(95.5121, 4.3229)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(18.5596, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(27.9952, 4.8229)">
+<g transform="translate(21.4095, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(29.2344, 4.3229)">
-<rect x="-0.0650" y="-3.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(21.4745, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(26.5452, 4.8229)">
+<g transform="translate(25.2394, 4.5000)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(23.7244, 1.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(31.3985, 6.3229)">
+<g transform="translate(27.8392, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(32.6377, 4.3229)">
-<rect x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(35.0518, 6.8229)">
+<g transform="translate(30.7541, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(36.2910, 4.3229)">
-<rect x="-0.0650" y="-1.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(30.8191, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(40.1819, 6.3229)">
+<g transform="translate(9.7500, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(11.5533, 6.8229)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g color="rgb(100.0000%, 100.0000%, 100.0000%)">
+<g transform="translate(0.0000, 4.5000)">
+<rect x="0.0000" y="-2.0812" width="3.7500" height="4.1625" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(15.2066, 7.3229)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(16.4458, 4.3229)">
-<rect x="-0.0650" y="-0.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(0.6000, 4.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(18.8599, 6.8229)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(1.6500, 4.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(20.0991, 4.3229)">
-<rect x="-0.0650" y="-1.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(2.7000, 4.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(12.7925, 4.3229)">
-<rect x="-0.0650" y="-1.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(4.7500, 3.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
+c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(23.9900, 6.3229)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(9.8150, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(25.2292, 4.3229)">
-<rect x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(27.9042, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(48.8297, 4.3229)">
-<rect x="-0.0650" y="-0.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(51.2438, 6.8229)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(52.4830, 4.3229)">
-<rect x="-0.0650" y="-1.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 6.3229)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(56.3739, 6.3229)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(57.6131, 4.3229)">
-<rect x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(41.4211, 4.3229)">
-<rect x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(9.1392, 4.3229)">
-<rect x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(-1.1267, 1.2729)">
+<g transform="translate(-1.1267, 1.4500)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>7</tspan>
 </text>
 </g>
-<g transform="translate(44.1872, 4.8229)">
+<g transform="translate(12.6649, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(45.4264, 4.3229)">
-<rect x="-0.0650" y="-3.0000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(12.7299, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 3.3229)">
+<g transform="translate(15.5797, 4.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(15.6447, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(39.4988, 4.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(39.5638, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(42.4136, 3.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(42.4786, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(45.3285, 3.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(45.3935, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(47.9934, 4.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(48.0584, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(50.6583, 6.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(50.7233, 4.5000)">
+<rect x="-0.0650" y="1.6861" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(36.8989, 4.5000)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="6.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(33.7340, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(36.8339, 1.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(33.6690, 3.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 9.0950)">
+<rect x="84.5403" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 10.0950)">
+<rect x="84.5403" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 10.0950)">
+<rect x="79.5319" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 10.0950)">
+<rect x="74.7735" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 10.0950)">
+<rect x="69.7650" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 10.0950)">
+<rect x="67.2608" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 10.0950)">
+<rect x="59.7482" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 10.0950)">
+<rect x="49.8824" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 10.0950)">
+<rect x="42.9829" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 10.0950)">
+<rect x="40.6298" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(89.3881, 13.0950)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(47.8174, 13.0950)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 15.0950)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="89.5281" y2="0"/>
+</g>
+<g transform="translate(0.0000, 14.0950)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="89.5281" y2="0"/>
+</g>
+<g transform="translate(0.0000, 13.0950)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="89.5281" y2="0"/>
+</g>
+<g transform="translate(0.0000, 12.0950)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="89.5281" y2="0"/>
+</g>
+<g transform="translate(0.0000, 11.0950)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="89.5281" y2="0"/>
+</g>
+<g transform="translate(62.3935, 13.0950)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="6.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(62.3285, 11.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(60.1393, 13.0950)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="7.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(60.0743, 10.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(57.3850, 13.0950)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(57.3200, 12.5950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(64.8327, 10.5950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(64.8977, 13.0950)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(67.5869, 9.5950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(67.6519, 13.0950)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="7.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(70.0911, 13.0950)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.1195 -0.0100 17.1195 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(70.0911, 13.9050)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.1195 -0.0100 17.1195 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(50.0574, 10.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(50.1224, 13.0950)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="7.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(48.6074, 10.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(42.7372, 4.8229)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(47.5905, 7.3229)">
+<g transform="translate(52.3116, 12.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 3.3229)">
+<g transform="translate(52.3766, 13.0950)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(54.5658, 15.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(54.6308, 13.0950)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(82.1772, 13.0950)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.7577" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(84.8664, 9.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(84.9314, 13.0950)">
+<rect x="-0.0650" y="-3.8139" width="0.1300" height="4.7882" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(87.1206, 11.5950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(87.1856, 13.0950)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.3132" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(82.1122, 11.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 16.7850)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.1195 -0.2000 17.1195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(7.9000, 17.5950)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.1195 -0.2000 17.1195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(27.4337, 14.0950)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="18.2195 -0.2000 18.2195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(27.4337, 14.9050)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="18.2195 -0.2000 18.2195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(50.0574, 16.7850)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.6195 -0.2000 17.6195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(50.0574, 17.5950)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.6195 -0.2000 17.6195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(70.0911, 10.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(70.1561, 13.0950)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6246" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(72.3453, 11.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(72.4103, 13.0950)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6496" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(75.0995, 9.5950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(75.1645, 13.0950)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1801" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(77.3537, 10.5950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(77.4187, 13.0950)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.2050" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(79.8579, 10.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(79.9229, 13.0950)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.7328" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(15.1626, 13.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(15.2276, 13.0950)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="4.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(17.9169, 10.5950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(17.9819, 13.0950)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(20.1711, 11.5950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(20.2361, 13.0950)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="5.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(22.6753, 11.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(22.7403, 13.0950)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="6.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(24.9295, 12.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(24.9945, 13.0950)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="5.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(7.9650, 13.0950)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(0.8000, 12.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 16.2138)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="70.2742" y2="0"/>
-</g>
-<g transform="translate(0.0000, 15.2138)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="70.2742" y2="0"/>
-</g>
-<g transform="translate(0.0000, 14.2138)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="70.2742" y2="0"/>
-</g>
-<g transform="translate(0.0000, 13.2138)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="70.2742" y2="0"/>
-</g>
-<g transform="translate(0.0000, 12.2138)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="70.2742" y2="0"/>
-</g>
-<g transform="translate(0.0000, 17.2138)">
-<rect x="46.0034" y="-0.1000" width="1.9063" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.2138)">
-<rect x="44.0471" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 18.2138)">
-<rect x="44.0471" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.2138)">
-<rect x="44.0471" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.2138)">
-<rect x="42.0408" y="-0.1000" width="1.9063" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.2138)">
-<rect x="23.9161" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.2138)">
-<rect x="12.9908" y="-0.1000" width="1.9063" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.2138)">
-<rect x="11.0345" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 18.2138)">
-<rect x="11.0345" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.2138)">
-<rect x="11.0345" y="-0.1000" width="1.8563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 17.2138)">
-<rect x="9.0282" y="-0.1000" width="1.9063" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(70.1342, 14.2138)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(38.6726, 14.2138)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(50.0379, 15.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(49.4729, 14.2138)">
-<rect x="-0.0650" y="-2.3776" width="0.1300" height="2.6915" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(48.2337, 14.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(47.5187, 14.2138)">
-<rect x="-0.0650" y="-2.2274" width="0.1300" height="5.0413" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(46.2795, 17.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(51.2771, 14.2138)">
-<rect x="-0.0650" y="-2.5162" width="0.1300" height="3.8301" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(51.8421, 15.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(53.0813, 14.2138)">
-<rect x="-0.0650" y="-2.6548" width="0.1300" height="3.4687" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(53.7963, 14.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(55.0355, 14.2138)">
-<rect x="-0.0650" y="-2.8050" width="0.1300" height="2.6189" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(56.7747, 11.4038)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.6695 -0.2000 12.6695 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(56.7747, 12.2138)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.6695 -0.2000 12.6695 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(40.9126, 14.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(42.1518, 14.2138)">
-<rect x="-0.0650" y="-1.8150" width="0.1300" height="2.1289" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(39.4626, 14.7138)">
+<g transform="translate(4.3000, 12.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(42.3668, 17.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(43.6060, 14.2138)">
-<rect x="-0.0650" y="-1.9267" width="0.1300" height="4.7406" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(44.3231, 19.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(45.5623, 14.2138)">
-<rect x="-0.0650" y="-2.0771" width="0.1300" height="7.3910" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(64.7716, 15.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(66.0108, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(66.7258, 13.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(67.9650, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(68.1800, 16.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(69.4192, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(9.0742, 12.4038)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.8237 -0.2000 12.8237 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(9.0742, 13.2138)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.8237 -0.2000 12.8237 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(23.6121, 11.4038)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="14.4195 -0.2000 14.4195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(23.6121, 12.2138)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="14.4195 -0.2000 14.4195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(42.0868, 12.4038)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.9737 -1.2000 12.9737 -0.8000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(42.0868, 13.2138)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.9737 -1.2000 12.9737 -0.8000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(55.6005, 14.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(56.8397, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(57.4047, 15.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(58.6439, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(59.3589, 14.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(60.5982, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(61.1632, 15.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(62.4024, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(62.9674, 14.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(64.2066, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(18.2645, 14.2138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(13.2669, 17.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(14.5061, 14.2138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(15.2211, 15.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(16.4603, 14.2138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(17.0253, 16.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(18.8295, 15.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(20.0687, 14.2138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(20.6337, 16.7138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(21.8729, 14.2138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 15.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(0.8000, 13.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
-c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
-</g>
-<g transform="translate(4.3000, 13.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(-2.2535, 11.1638)">
+<g transform="translate(-1.1267, 10.0203)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
-<tspan>12</tspan>
+<tspan>9</tspan>
 </text>
 </g>
-<g transform="translate(9.1392, 14.2138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(9.3542, 17.7138)">
+<g transform="translate(7.9000, 10.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(10.5934, 14.2138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(11.3105, 19.7138)">
+<g transform="translate(10.1542, 13.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.5498, 14.2138)">
-<rect x="-0.0650" y="-1.8100" width="0.1300" height="7.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(10.2192, 13.0950)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="4.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(34.3982, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(28.0006, 15.7138)">
+<g transform="translate(12.4084, 15.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(29.2398, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(12.4734, 13.0950)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(29.8048, 15.2138)">
+<g transform="translate(34.9463, 11.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(31.0440, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(35.0113, 13.0950)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(33.1590, 14.7138)">
+<g transform="translate(37.4506, 10.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(31.7090, 14.7138)">
+<g transform="translate(37.5156, 13.0950)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(40.8048, 10.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(40.8698, 13.0950)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(27.4337, 11.5950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(39.3548, 10.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(34.9632, 14.2138)">
+<g transform="translate(43.3090, 9.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(36.2024, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(43.3740, 13.0950)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(36.7674, 15.2138)">
+<g transform="translate(45.5632, 10.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(38.0066, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(45.6282, 13.0950)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(23.6771, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(29.7529, 13.0950)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(26.1963, 16.2138)">
+<g transform="translate(29.6879, 12.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(27.4356, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(25.4813, 14.2138)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="5.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(22.4379, 16.2138)">
+<g transform="translate(32.4421, 11.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(24.2421, 17.2138)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(27.4987, 13.0950)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(32.5071, 13.0950)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
 </svg>


### PR DESCRIPTION
## Summary
Bug: loops 2 through 5 rendered notes at wrong octaves (sometimes off by an octave or more). Cause: the LilyPond source uses `\relative` notation — each pitch is read relative to the previous one. Slicing measures out of context made the first note of each snippet resolve relative to the implicit `\relative c` reference instead of relative to the last note of the prior measure.

Fix: for any range starting after m. 1, emit the prior measures inside `\set Score.skipTypesetting = ##t`. LilyPond parses them (advancing the relative-pitch state) without drawing them, then we re-enable typesetting and use `currentBarNumber` to renumber.

## Test plan
- [ ] Loop 2's first measure (m. 4) matches loop 1's last measure (m. 4).
- [ ] Loops 3, 4, 5 sit in normal cello range with no wild ledger-line stacks.

https://claude.ai/code/session_01Fyj6ZZXhaNmrnongBRUghb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fyj6ZZXhaNmrnongBRUghb)_