### PR TITLE
Commit LilyPond source as the source of truth for scores

### DIFF
--- a/tools/scores/README.md
+++ b/tools/scores/README.md
@@ -1,0 +1,29 @@
+# Score builder
+
+Renders the per-loop SVG scores in `scores/` from LilyPond sources in this directory.
+
+## Sources
+- `allemande.ly` — Bach Cello Suite No. 1, Allemande (BWV 1007). Forked from
+  the community LilyPond typeset at
+  [babysnakes/Bach---Cello-Suites](https://github.com/babysnakes/Bach---Cello-Suites)
+  (Bärenreiter-based), with editorial slurs, bow markings and trills added
+  by hand to follow the Peters/Becker edition.
+
+## Build
+Requires LilyPond on `$PATH` (`apt-get install lilypond`).
+
+From the repo root:
+
+```
+python3 tools/scores/build_scores.py
+```
+
+The script reads each loop in `songs.json`, parses the measure range out of
+its `label` (e.g. `"mm 4-6"`), extracts those measures from the matching
+LilyPond source, and writes the cropped SVG to the path in the loop's
+`score` field.
+
+For ranges that don't start at m. 1, the earlier measures are emitted inside
+`\set Score.skipTypesetting = ##t` so LilyPond parses them silently —
+necessary because the source uses `\relative` notation and slicing measures
+out of context shifts later pitches by an octave or more.

--- a/tools/scores/allemande.ly
+++ b/tools/scores/allemande.ly
@@ -1,0 +1,59 @@
+\version "2.18.2"
+
+allemande = \context Staff \relative c {
+
+  \time 2/2
+  \key g \major
+  \set Staff.midiInstrument = "cello"
+
+  %% Next two lines helps spliting the beam to quarters (after
+  %% changing the time to 2/2, can be removed if time is back to 4/4)
+  \set Timing.baseMoment = #(ly:make-moment 1/16)
+  \set Timing.beatStructure = #'(4 4 4 4)
+
+  \repeat volta 2 {
+    \partial 16 b'16 |
+    <b d, g,>4~ b16 a( g fis) g( d e fis) g( a b c) |
+    d( b g fis) g( e d c) b( c d e) fis( g a b) |
+    c( a g fis) g( e fis g) a,( d fis g) a( b c a) |
+    b( g) g( d) d( b) b( g) g8.\downbow b'16\downbow c\upbow( b a g) |
+    \barNumberCheck #5
+    a( b c) a g( fis g) a dis,8.\trill c'16 b a g fis |
+    g e e b b g g e e8. b'16 e g fis a |
+    g fis e fis g cis g fis g cis e, fis g e a, g' |
+    fis8 d16 e fis d g e fis d fis g a b c a |
+    b d, g, d' b' g a fis g e g a b cis d b |
+    \barNumberCheck #10
+    cis e, g, e' cis' a b d cis a d b cis a e' g, |
+    fis8.\trill d'16 a g fis e d a' g e fis d a' c, |
+    b8.\trill g'16 d c b a g d' c a b g d' fis, |
+    e g a b cis d e fis g a cis d e a, g'8 |
+    d,16 g' fis e fis d a d d, fis a c b8.\trill a16 |
+    \barNumberCheck #15
+    <g, d' b'>8. a'16 g fis e d' cis e a, g fis d a cis |
+    d,8. a'16 d fis a cis d a fis d d,8.
+  }
+
+  \repeat volta 2 {
+    a''16 |
+    <d, a'>4~ <d a'>16 fis g a d, e fis g a fis d c |
+    b d g fis g a b c d b a g f e f d' |
+    e,8\trill \appoggiatura d8 c c'16 a,b c d, c'' b c d b c a |
+    \barNumberCheck #20
+    gis8\trill e b'16 d, c b c e fis gis a c b a |
+    d8 b,16 c d e f a, gis8.\trill e'16 b'd c b |
+    <a, e' c'>8. b'16 a g f e f d bes' a bes c d a |
+    gis a b e, f d c b c e a b <e, b'>8. a16 |
+    <a, e' a>8. b'16 c b c g fis g a e d c b a |
+    \barNumberCheck #25
+    g d' fis c' b a g a b c d e d e f d |
+    e8 g, c,16 d' c b a b c e d8. c16 |
+    d8 a b,16 c' b a g fis e g b d c b |
+    c8 g a,16 e' fis g fis a b c d, c b a |
+    g d' fis a c a fis d <g, d' b'>8. d'16 e g a cis |
+    \barNumberCheck #30
+    d a fis e d f g b c g e d c e a c |
+    fis, a c e d8. c,16 b g' a, g d a' g' fis |
+    g g, b d g b d fis g d b g g,8. s16
+  }
+}

--- a/tools/scores/build_scores.py
+++ b/tools/scores/build_scores.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Render per-loop SVG scores for songs.json.
+
+For each loop with a `label` like "mm 4-6" and a `score` path in songs.json,
+extracts the corresponding measures from the LilyPond source in this directory
+and renders a cropped SVG into the path the JSON points at.
+
+Requires: lilypond on PATH.
+
+Run from the repo root:
+    python3 tools/scores/build_scores.py
+"""
+import json, re, subprocess, shutil, tempfile, sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+SRC_LY = HERE / 'allemande.ly'
+
+src = SRC_LY.read_text()
+m = re.search(r'\\repeat\s+volta\s+2\s*\{(.+?)\n\s*\}', src, re.DOTALL)
+if not m:
+    sys.exit(f'first \\repeat volta block not found in {SRC_LY}')
+lines = [l.strip() for l in m.group(1).splitlines() if l.strip()]
+pickup = lines[0]
+measures = [ln for ln in lines[1:] if not ln.startswith('\\barNumberCheck')]
+
+def parse_range(label):
+    nums = re.findall(r'\d+', label)
+    return int(nums[0]), int(nums[1])
+
+def make_ly(start, end):
+    visible = '\n'.join('    ' + m for m in measures[start-1:end])
+    if start == 1:
+        body = f'    {pickup}\n{visible}'
+    else:
+        hidden = '\n'.join('    ' + m for m in measures[:start-1])
+        body = (f'    \\set Score.skipTypesetting = ##t\n'
+                f'    {pickup}\n{hidden}\n'
+                f'    \\set Score.skipTypesetting = ##f\n'
+                f'    \\set Score.currentBarNumber = #{start}\n'
+                f'    \\bar ""\n{visible}')
+    return f'''\\version "2.24.0"
+\\paper {{
+  indent = 0
+  line-width = 180\\mm
+  ragged-right = ##f
+  ragged-last = ##t
+  print-page-number = ##f
+}}
+\\header {{ tagline = "" }}
+\\score {{
+  \\new Staff \\with {{ \\remove "Time_signature_engraver" }} \\relative c {{
+    \\clef "bass"
+    \\key g \\major
+    \\time 2/2
+{body}
+  }}
+  \\layout {{ }}
+}}
+'''
+
+songs = json.loads((REPO / 'songs.json').read_text())
+allemande = songs['songs']['allemande']
+
+with tempfile.TemporaryDirectory() as tmp:
+    tmp = Path(tmp)
+    for loop in allemande['loops']:
+        if not loop.get('score'):
+            continue
+        start, end = parse_range(loop['label'])
+        out_base = tmp / Path(loop['score']).stem
+        ly_path = out_base.with_suffix('.ly')
+        ly_path.write_text(make_ly(start, end))
+        r = subprocess.run(
+            ['lilypond', '-dbackend=svg', '-dcrop=#t', '-dno-point-and-click',
+             '-o', str(out_base), str(ly_path)],
+            capture_output=True, text=True)
+        if r.returncode != 0:
+            print(f'fail {ly_path.name}:', r.stderr[-400:])
+            continue
+        dest = REPO / loop['score']
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(str(out_base) + '.cropped.svg', dest)
+        print(f'  -> {dest.relative_to(REPO)} ({dest.stat().st_size} bytes)')


### PR DESCRIPTION
## Summary
The SVGs under `scores/` are derived artifacts. Until this commit, the LilyPond source with all editorial markings (slurs, bow marks, trill on m. 5) only existed in an ephemeral container — meaning any future edit to bowings or fingerings would have nothing to round-trip from but the SVG itself.

Now committed under `tools/scores/`:
- `allemande.ly` — community Bärenreiter-based LilyPond, with the editorial markings added through m. 5 to follow the Peters/Becker edition.
- `build_scores.py` — reads `songs.json`, parses each loop's label like `"mm 4-6"`, extracts the matching measures (preserving relative-pitch context via `skipTypesetting`), and writes cropped SVGs to the path in each loop's `score` field.
- `README.md` — usage notes.

## Test plan
- [ ] From repo root with `lilypond` installed: `python3 tools/scores/build_scores.py` regenerates all five SVGs and they match what was already committed.

https://claude.ai/code/session_01Fyj6ZZXhaNmrnongBRUghb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fyj6ZZXhaNmrnongBRUghb)_