### PR TITLE
Add earth song practice entry

### DIFF
--- a/songs.json
+++ b/songs.json
@@ -11,6 +11,13 @@
         { "start": "0:24.0", "end": "0:30.6", "label": "mm 8-10",  "score": "scores/mm-8-10.svg" },
         { "start": "0:30.6", "end": "0:36.9", "label": "mm 10-12", "score": "scores/mm-10-12.svg" }
       ]
+    },
+    "earth-song": {
+      "title": "earth song",
+      "videoId": "XAi3VTSdTxU",
+      "loops": [
+        { "start": "0:00", "end": "1:00" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `earth-song` entry to `songs.json` pointing at YouTube `XAi3VTSdTxU` with a single default loop (0:00–1:00).
- `index.html` builds the practice-page link automatically from `songs.json`, so no other changes needed.

## Test plan
- [ ] Visit the index — confirm "earth song" appears in the song list.
- [ ] Click it — confirm `song.html?s=earth-song` loads the YouTube video and the default loop is editable.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_