### PR TITLE
Enable fine-tune trim buttons for earth song

### DIFF
--- a/songs.json
+++ b/songs.json
@@ -15,6 +15,7 @@
     "earth-song": {
       "title": "earth song",
       "videoId": "XAi3VTSdTxU",
+      "fineTune": true,
       "loops": [
         { "start": "0:00", "end": "1:00" }
       ]


### PR DESCRIPTION
## Summary
- Set `"fineTune": true` on the `earth-song` entry so its loop start/end inputs render the −/+ 0.1s nudge (trim) buttons.

## Test plan
- [ ] Open `song.html?s=earth-song` and confirm −/+ buttons appear next to start and end, adjusting times by 0.1s.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_