### PR TITLE
Add labeled loops for earth song

### DIFF
--- a/songs.json
+++ b/songs.json
@@ -17,7 +17,9 @@
       "videoId": "XAi3VTSdTxU",
       "fineTune": true,
       "loops": [
-        { "start": "0:00", "end": "1:00" }
+        { "start": "0:00", "end": "0:33", "label": "preface" },
+        { "start": "0:33", "end": "0:46", "label": "call intro" },
+        { "start": "0:46", "end": "0:59", "label": "first phrase" }
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Replace the earth song placeholder loop with three labeled loops:
  - preface: 0:00–0:33
  - call intro: 0:33–0:46
  - first phrase: 0:46–0:59

## Test plan
- [ ] Open `song.html?s=earth-song` and confirm the three labeled loops appear and play their ranges.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_