### PR TITLE
Extend earth song loops past Ah

### DIFF
--- a/songs.json
+++ b/songs.json
@@ -22,7 +22,9 @@
         { "start": "0:46", "end": "0:59", "label": "first phrase" },
         { "start": "0:59", "end": "1:14", "label": "second phrase" },
         { "start": "1:14", "end": "1:27", "label": "did you…" },
-        { "start": "1:27", "end": "1:36.0", "label": "Ah…" }
+        { "start": "1:27", "end": "1:41", "label": "Ah…" },
+        { "start": "1:41", "end": "1:55" },
+        { "start": "1:55", "end": "6:45" }
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Keep labeled loops through "Ah…" but extend its end to 1:41 (was 1:36.0).
- Add two unlabeled loops pending labels: 1:41–1:55 and 1:55–6:45.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_