### PR TITLE
Add scale comparison buttons for earth song

### DIFF
--- a/song.html
+++ b/song.html
@@ -93,6 +93,10 @@
     <div>
       <button id="play-btn">play piece</button>
     </div>
+    <div id="scale-tools" style="display: none; gap: 0.5rem; flex-wrap: wrap; justify-content: center;">
+      <button id="scale-natural" type="button">A♭ natural minor (7♭)</button>
+      <button id="scale-dorian" type="button">A♭ minor — 6♭</button>
+    </div>
   </div>
 
   <div id="footer-area"></div>
@@ -129,6 +133,34 @@
       const audioWrapper = document.getElementById('audio-wrapper');
       const scoreWrapper = document.getElementById('score-wrapper');
       const scoreImg = document.getElementById('score-img');
+
+      let audioCtx = null;
+      function playScale(semitoneOffsets) {
+        if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        const ctx = audioCtx;
+        if (ctx.state === 'suspended') ctx.resume();
+        const baseMidi = 68; // A♭4
+        const noteDur = 0.42;
+        const start = ctx.currentTime + 0.05;
+        semitoneOffsets.forEach((semi, i) => {
+          const t = start + i * noteDur;
+          const freq = 440 * Math.pow(2, (baseMidi + semi - 69) / 12);
+          const osc = ctx.createOscillator();
+          const gain = ctx.createGain();
+          osc.type = 'triangle';
+          osc.frequency.value = freq;
+          gain.gain.setValueAtTime(0.0001, t);
+          gain.gain.linearRampToValueAtTime(0.25, t + 0.02);
+          gain.gain.exponentialRampToValueAtTime(0.0001, t + noteDur * 0.92);
+          osc.connect(gain).connect(ctx.destination);
+          osc.start(t);
+          osc.stop(t + noteDur);
+        });
+      }
+      document.getElementById('scale-natural')
+        .addEventListener('click', () => playScale([0, 2, 3, 5, 7, 8, 10, 12]));
+      document.getElementById('scale-dorian')
+        .addEventListener('click', () => playScale([0, 2, 3, 5, 7, 9, 10, 12]));
 
       function showScore(src) {
         if (!src) { scoreWrapper.classList.remove('active'); return; }
@@ -370,6 +402,10 @@
           }
 
           fineTune = !!song.fineTune;
+
+          if (song.scales) {
+            document.getElementById('scale-tools').style.display = 'flex';
+          }
 
           // Build loop elements from JSON
           (song.loops || []).forEach((loop) => {

--- a/songs.json
+++ b/songs.json
@@ -16,6 +16,7 @@
       "title": "earth song",
       "videoId": "XAi3VTSdTxU",
       "fineTune": true,
+      "scales": true,
       "loops": [
         { "start": "0:00", "end": "0:33", "label": "preface" },
         { "start": "0:33", "end": "0:46", "label": "call intro" },

--- a/songs.json
+++ b/songs.json
@@ -22,7 +22,9 @@
         { "start": "0:46", "end": "0:59", "label": "first phrase" },
         { "start": "0:59", "end": "1:14", "label": "second phrase" },
         { "start": "1:14", "end": "1:27", "label": "did you…" },
-        { "start": "1:27", "end": "1:36.0", "label": "Ah…" }
+        { "start": "1:27", "end": "1:41", "label": "Ah…" },
+        { "start": "1:41", "end": "1:55" },
+        { "start": "1:55", "end": "6:45" }
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Add two Web Audio buttons to the song page that play scales starting on A♭, gated behind a per-song `"scales": true` flag (enabled for earth song).
- **A♭ natural minor (7♭):** A♭ B♭ C♭ D♭ E♭ F♭ G♭ A♭
- **A♭ minor — 6♭:** A♭ B♭ C♭ D♭ E♭ F♮ G♭ A♭ (this is A♭ Dorian)
- The two scales differ only in the 6th degree (F♭ vs F♮) — the F♮ is what a 6-flat signature gives you, which is why the piece sounds minor but is written with 6 flats.

## Test plan
- [ ] Open the earth song page; confirm two scale buttons appear under "play piece"
- [ ] Click each button and listen — second scale's 6th note is a half-step higher
- [ ] Confirm buttons do NOT appear on the allemande page

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_