### PR TITLE
Label scale buttons with mode names

### DIFF
--- a/song.html
+++ b/song.html
@@ -94,8 +94,8 @@
       <button id="play-btn">play piece</button>
     </div>
     <div id="scale-tools" style="display: none; gap: 0.5rem; flex-wrap: wrap; justify-content: center;">
-      <button id="scale-natural" type="button">A♭ natural minor (7♭)</button>
-      <button id="scale-dorian" type="button">A♭ minor — 6♭</button>
+      <button id="scale-natural" type="button">A♭ Aeolian — natural minor (7♭)</button>
+      <button id="scale-dorian" type="button">A♭ Dorian — 6♭</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Relabel the two scale buttons by their mode name: **A♭ Aeolian — natural minor (7♭)** and **A♭ Dorian — 6♭**.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_