### PR TITLE
Add A♭ drone with optional fifth to song margin

### DIFF
--- a/song.css
+++ b/song.css
@@ -130,3 +130,81 @@ input[type="range"] {
 a {
   color: #9cd8ff;
 }
+
+#drone-panel {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  display: none;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+  z-index: 10;
+}
+
+#drone-panel.active {
+  display: flex;
+}
+
+#drone-btn {
+  font-size: 1rem;
+  padding: 0.4em 0.8em;
+}
+
+#drone-btn.on {
+  border-color: #c8743c;
+  color: #f0b48a;
+}
+
+.drone-fifth {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+  font-size: 1rem;
+  color: #bbb;
+  cursor: pointer;
+  user-select: none;
+}
+
+.drone-fifth input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.drone-fifth .track {
+  width: 2.4em;
+  height: 1.2em;
+  border: 1px solid #666;
+  border-radius: 1em;
+  position: relative;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.drone-fifth .thumb {
+  position: absolute;
+  top: 50%;
+  left: 0.15em;
+  width: 0.9em;
+  height: 0.9em;
+  transform: translateY(-50%);
+  background: #ddd;
+  border-radius: 50%;
+  transition: left 0.15s, background 0.15s;
+}
+
+.drone-fifth input:checked + .track {
+  background: #7a4322;
+  border-color: #c8743c;
+}
+
+.drone-fifth input:checked + .track .thumb {
+  left: calc(100% - 1.05em);
+  background: #f0b48a;
+}
+
+.drone-fifth input:focus-visible + .track {
+  outline: 2px solid #9cd8ff;
+  outline-offset: 2px;
+}

--- a/song.html
+++ b/song.html
@@ -64,6 +64,15 @@
 <body>
   <a class="back" href="index.html">← back</a>
 
+  <div id="drone-panel">
+    <button id="drone-btn" type="button">A♭ drone</button>
+    <label class="drone-fifth">
+      <input id="drone-fifth" type="checkbox">
+      <span class="track"><span class="thumb"></span></span>
+      add 5th
+    </label>
+  </div>
+
   <div class="title">
     <span id="song-title">loading…</span>
     <img src="feather.svg" alt="" class="feather">
@@ -161,6 +170,88 @@
         .addEventListener('click', () => playScale([0, 2, 3, 5, 7, 8, 10, 12]));
       document.getElementById('scale-dorian')
         .addEventListener('click', () => playScale([0, 2, 3, 5, 7, 9, 10, 12]));
+
+      // A♭ drone (borrowed from mojotrio) — sustained root with optional perfect fifth
+      const DRONE_ROOT_MIDI = 56; // A♭3
+      const FIFTH_RATIO = 1.5;
+      const dronePanel = document.getElementById('drone-panel');
+      const droneBtn = document.getElementById('drone-btn');
+      const fifthToggle = document.getElementById('drone-fifth');
+      let droneNodes = null;
+      let fifthOn = false;
+
+      function midiToFreq(m) { return 440 * Math.pow(2, (m - 69) / 12); }
+
+      function startDrone() {
+        const ctx = new (window.AudioContext || window.webkitAudioContext)();
+        if (ctx.state === 'suspended') ctx.resume();
+        const root = midiToFreq(DRONE_ROOT_MIDI);
+
+        const rootOsc = ctx.createOscillator();
+        const fifthOsc = ctx.createOscillator();
+        const fifthGain = ctx.createGain();
+        const filter = ctx.createBiquadFilter();
+        const fA = ctx.createBiquadFilter();
+        const fB = ctx.createBiquadFilter();
+        const fC = ctx.createBiquadFilter();
+        const gain = ctx.createGain();
+
+        rootOsc.type = 'sawtooth'; rootOsc.frequency.value = root;
+        fifthOsc.type = 'sawtooth'; fifthOsc.frequency.value = root * FIFTH_RATIO;
+        fifthGain.gain.value = fifthOn ? 1 : 0;
+
+        filter.type = 'lowpass'; filter.frequency.value = 5000; filter.Q.value = 0.7;
+        fA.type = 'peaking'; fA.frequency.value = 250; fA.Q.value = 4; fA.gain.value = 8;
+        fB.type = 'peaking'; fB.frequency.value = 450; fB.Q.value = 3; fB.gain.value = 6;
+        fC.type = 'peaking'; fC.frequency.value = 1800; fC.Q.value = 2; fC.gain.value = 5;
+
+        // sub-audible noise prevents Bluetooth codec silence-gating (audible pulsing)
+        const noiseBuf = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate);
+        const nd = noiseBuf.getChannelData(0);
+        for (let i = 0; i < nd.length; i++) nd[i] = Math.random() * 2 - 1;
+        const noise = ctx.createBufferSource();
+        noise.buffer = noiseBuf; noise.loop = true;
+        const noiseFilter = ctx.createBiquadFilter();
+        noiseFilter.type = 'bandpass'; noiseFilter.frequency.value = 2000; noiseFilter.Q.value = 0.6;
+        const noiseGain = ctx.createGain(); noiseGain.gain.value = 0.012;
+
+        rootOsc.connect(filter);
+        fifthOsc.connect(fifthGain); fifthGain.connect(filter);
+        filter.connect(fA); fA.connect(fB); fB.connect(fC); fC.connect(gain);
+        noise.connect(noiseFilter); noiseFilter.connect(noiseGain); noiseGain.connect(gain);
+        gain.connect(ctx.destination);
+
+        const now = ctx.currentTime;
+        gain.gain.setValueAtTime(0.0001, now);
+        gain.gain.exponentialRampToValueAtTime(0.35, now + 0.15);
+
+        rootOsc.start(); fifthOsc.start(); noise.start();
+        droneNodes = { ctx, rootOsc, fifthOsc, fifthGain, noise, gain };
+        droneBtn.textContent = 'stop drone';
+        droneBtn.classList.add('on');
+      }
+
+      function stopDrone() {
+        if (!droneNodes) return;
+        const { ctx, rootOsc, fifthOsc, noise, gain } = droneNodes;
+        const now = ctx.currentTime;
+        gain.gain.cancelScheduledValues(now);
+        gain.gain.setValueAtTime(Math.max(gain.gain.value, 0.0001), now);
+        gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.2);
+        [rootOsc, fifthOsc, noise].forEach(o => { try { o.stop(now + 0.25); } catch (e) {} });
+        setTimeout(() => { try { ctx.close(); } catch (e) {} }, 400);
+        droneNodes = null;
+        droneBtn.textContent = 'A♭ drone';
+        droneBtn.classList.remove('on');
+      }
+
+      droneBtn.addEventListener('click', () => { droneNodes ? stopDrone() : startDrone(); });
+      fifthToggle.addEventListener('change', () => {
+        fifthOn = fifthToggle.checked;
+        if (droneNodes) {
+          droneNodes.fifthGain.gain.setTargetAtTime(fifthOn ? 1 : 0, droneNodes.ctx.currentTime, 0.03);
+        }
+      });
 
       function showScore(src) {
         if (!src) { scoreWrapper.classList.remove('active'); return; }
@@ -405,6 +496,10 @@
 
           if (song.scales) {
             document.getElementById('scale-tools').style.display = 'flex';
+          }
+
+          if (song.drone) {
+            dronePanel.classList.add('active');
           }
 
           // Build loop elements from JSON

--- a/songs.json
+++ b/songs.json
@@ -17,6 +17,7 @@
       "videoId": "XAi3VTSdTxU",
       "fineTune": true,
       "scales": true,
+      "drone": true,
       "loops": [
         { "start": "0:00", "end": "0:33", "label": "preface" },
         { "start": "0:33", "end": "0:46", "label": "call intro" },


### PR DESCRIPTION
## Summary
- Add a fixed **drone panel in the page margin** (top-right), gated behind a per-song `"drone": true` flag (enabled for earth song).
- **A♭ drone** button toggles a sustained A♭3 tone on/off.
- **add 5th** toggle (slider switch) layers in the perfect fifth (E♭) live, without restarting the drone.
- Audio engine borrowed from the [mojotrio](https://github.com/johnmbillings/mojotrio) drone tool: sawtooth root + fifth → lowpass → peaking formant EQ, plus sub-audible bandpass noise to stop Bluetooth codecs silence-gating (which causes pulsing).

## Notes
- Could not verify sound/UI in a real browser from the build environment — please give it a listen and confirm placement/feel.

## Test plan
- [ ] Open earth song; confirm a drone control appears in the top-right margin
- [ ] Click "A♭ drone" — sustained A♭ plays, button shows "stop drone" and highlights
- [ ] Flip "add 5th" while playing — fifth fades in/out smoothly
- [ ] Click "stop drone" — tone fades out
- [ ] Confirm the panel does NOT appear on the allemande page

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_