### PR TITLE
Add volume slider to A♭ drone

### DIFF
--- a/song.css
+++ b/song.css
@@ -208,3 +208,15 @@ a {
   outline: 2px solid #9cd8ff;
   outline-offset: 2px;
 }
+
+.drone-vol {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+  font-size: 1rem;
+  color: #bbb;
+}
+
+.drone-vol input[type="range"] {
+  width: 6.5em;
+}

--- a/song.html
+++ b/song.html
@@ -71,6 +71,10 @@
       <span class="track"><span class="thumb"></span></span>
       add 5th
     </label>
+    <label class="drone-vol">
+      vol
+      <input id="drone-volume" type="range" min="0" max="0.7" step="0.01" value="0.35">
+    </label>
   </div>
 
   <div class="title">
@@ -177,8 +181,10 @@
       const dronePanel = document.getElementById('drone-panel');
       const droneBtn = document.getElementById('drone-btn');
       const fifthToggle = document.getElementById('drone-fifth');
+      const volumeInput = document.getElementById('drone-volume');
       let droneNodes = null;
       let fifthOn = false;
+      let droneVolume = parseFloat(volumeInput.value);
 
       function midiToFreq(m) { return 440 * Math.pow(2, (m - 69) / 12); }
 
@@ -223,7 +229,7 @@
 
         const now = ctx.currentTime;
         gain.gain.setValueAtTime(0.0001, now);
-        gain.gain.exponentialRampToValueAtTime(0.35, now + 0.15);
+        gain.gain.exponentialRampToValueAtTime(Math.max(droneVolume, 0.0001), now + 0.15);
 
         rootOsc.start(); fifthOsc.start(); noise.start();
         droneNodes = { ctx, rootOsc, fifthOsc, fifthGain, noise, gain };
@@ -250,6 +256,12 @@
         fifthOn = fifthToggle.checked;
         if (droneNodes) {
           droneNodes.fifthGain.gain.setTargetAtTime(fifthOn ? 1 : 0, droneNodes.ctx.currentTime, 0.03);
+        }
+      });
+      volumeInput.addEventListener('input', () => {
+        droneVolume = parseFloat(volumeInput.value);
+        if (droneNodes) {
+          droneNodes.gain.gain.setTargetAtTime(droneVolume, droneNodes.ctx.currentTime, 0.03);
         }
       });
 


### PR DESCRIPTION
## Summary
- Add a **vol** slider to the drone panel (top-right margin).
- It sets the drone's master gain and adjusts it live (smooth ramp) while the drone is playing. Default 0.35, range 0–0.7.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_