### PR TITLE
Move drone controls to a bottom footnote

### DIFF
--- a/song.css
+++ b/song.css
@@ -132,36 +132,58 @@ a {
 }
 
 #drone-panel {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
   display: none;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.5rem;
-  z-index: 10;
+  flex-flow: row wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem 1.1rem;
+  margin-top: auto;
+  padding-top: 1.5rem;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.4);
+  letter-spacing: 0.05em;
 }
 
 #drone-panel.active {
   display: flex;
 }
 
+.drone-tag {
+  font-style: italic;
+  letter-spacing: 0.12em;
+  text-transform: lowercase;
+}
+
 #drone-btn {
-  font-size: 1rem;
-  padding: 0.4em 0.8em;
+  background: none;
+  border: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 0;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.85rem;
+  font-style: italic;
+  letter-spacing: 0.06em;
+  padding: 0.05em 0.1em 0.2em;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+#drone-btn:hover {
+  color: #d8d8ff;
+  border-bottom-color: #d8d8ff;
 }
 
 #drone-btn.on {
-  border-color: #c8743c;
   color: #f0b48a;
+  border-bottom-color: #c8743c;
 }
 
 .drone-fifth {
   display: inline-flex;
   align-items: center;
   gap: 0.45em;
-  font-size: 1rem;
-  color: #bbb;
+  font-size: inherit;
+  color: inherit;
   cursor: pointer;
   user-select: none;
 }
@@ -212,11 +234,11 @@ a {
 .drone-vol {
   display: inline-flex;
   align-items: center;
-  gap: 0.45em;
-  font-size: 1rem;
-  color: #bbb;
+  gap: 0.5em;
+  font-size: inherit;
+  color: inherit;
 }
 
 .drone-vol input[type="range"] {
-  width: 6.5em;
+  width: 6em;
 }

--- a/song.html
+++ b/song.html
@@ -64,19 +64,6 @@
 <body>
   <a class="back" href="index.html">← back</a>
 
-  <div id="drone-panel">
-    <button id="drone-btn" type="button">A♭ drone</button>
-    <label class="drone-fifth">
-      <input id="drone-fifth" type="checkbox">
-      <span class="track"><span class="thumb"></span></span>
-      add 5th
-    </label>
-    <label class="drone-vol">
-      vol
-      <input id="drone-volume" type="range" min="0" max="0.7" step="0.01" value="0.35">
-    </label>
-  </div>
-
   <div class="title">
     <span id="song-title">loading…</span>
     <img src="feather.svg" alt="" class="feather">
@@ -113,6 +100,20 @@
   </div>
 
   <div id="footer-area"></div>
+
+  <div id="drone-panel">
+    <span class="drone-tag">drone</span>
+    <button id="drone-btn" type="button">A♭</button>
+    <label class="drone-fifth">
+      <input id="drone-fifth" type="checkbox">
+      <span class="track"><span class="thumb"></span></span>
+      add 5th
+    </label>
+    <label class="drone-vol">
+      vol
+      <input id="drone-volume" type="range" min="0" max="0.7" step="0.01" value="0.35">
+    </label>
+  </div>
 
   <script src="https://www.youtube.com/iframe_api"></script>
   <script>
@@ -233,7 +234,7 @@
 
         rootOsc.start(); fifthOsc.start(); noise.start();
         droneNodes = { ctx, rootOsc, fifthOsc, fifthGain, noise, gain };
-        droneBtn.textContent = 'stop drone';
+        droneBtn.textContent = 'stop';
         droneBtn.classList.add('on');
       }
 
@@ -247,7 +248,7 @@
         [rootOsc, fifthOsc, noise].forEach(o => { try { o.stop(now + 0.25); } catch (e) {} });
         setTimeout(() => { try { ctx.close(); } catch (e) {} }, 400);
         droneNodes = null;
-        droneBtn.textContent = 'A♭ drone';
+        droneBtn.textContent = 'A♭';
         droneBtn.classList.remove('on');
       }
 


### PR DESCRIPTION
## Summary
- Move the drone controls from the fixed top-right box to a small, understated footnote row pinned at the bottom of the page.
- Restyle: muted small type, the "A♭" toggle as an underlined text link (not a boxed button), with the "add 5th" switch and "vol" slider inline.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_