### PR TITLE
Document song schema in songs.json and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# john.learndoteach.org
+
+A small static site (GitHub Pages) of music practice pages: a looping
+video/audio player with labelled sections, optional score images, scale
+helpers, and a drone.
+
+## Architecture
+
+The site is data-driven. There is **one shared song template**, `song.html`,
+and **one data file**, `songs.json`. A song page is just the template loaded
+with a slug:
+
+```
+song.html?s=earth-song
+```
+
+`song.html` fetches `songs.json`, looks up `data.songs[slug]`, and renders
+itself from that object. `index.html` builds the song list by iterating
+`data.songs`. Nothing reads the top level of `songs.json` other than the
+`songs` (and reserved `concerts`) keys, so extra keys like `_format` are
+ignored by the app.
+
+Because of this, **features are turned on per-song by adding a field to the
+song's entry** — there is no per-song HTML. Each optional feature is gated by
+an `if (song.<field>)` check in `song.html`.
+
+## Adding or editing a song
+
+Add an entry under `"songs"` in `songs.json`:
+
+```json
+"my-song": {
+  "title": "my song",
+  "videoId": "YouTubeIdHere",
+  "loops": [
+    { "start": "0:00", "end": "0:12", "label": "intro" }
+  ]
+}
+```
+
+It appears automatically on the home page and at `song.html?s=my-song`.
+
+### Song fields
+
+| Field | Meaning |
+|-------|---------|
+| `title` | Display name (required). |
+| `videoId` | YouTube id. Use this **or** `audio`. |
+| `audio` | Audio file URL. Use this **or** `videoId`. |
+| `loops` | Array of `{ start, end, label?, score? }`. Times are `M:SS` or `M:SS.s`. `label` shows above the loop; `score` is an image shown while that loop plays. |
+| `fineTune` | `true` adds ±0.1s nudge buttons to loop times. |
+| `scales` | `true` shows the A♭ scale-comparison buttons (Aeolian vs Dorian). |
+| `drone` | A **note name** to enable a sustained drone, e.g. `"A♭"`, `"Eb3"`, `"G2"`. Octave is optional and defaults to 3. Omit the field (or set `null`) to leave the drone off. |
+| `speedMin` | Minimum value for the speed slider. |
+| `footer` | HTML note shown below the controls. |
+| `lyrics` | Preformatted lyrics text shown at the bottom. |
+
+### The drone
+
+The drone (borrowed from the [mojotrio](https://github.com/johnmbillings/mojotrio)
+drone tool) plays a sustained root with an optional perfect fifth and a volume
+control, shown as a footnote at the bottom of the page. Its pitch comes
+entirely from the song's `drone` field: `song.html` parses the note name to a
+MIDI number (`pitchToMidi`), so the same field both enables the drone and sets
+its note and label. The fifth is derived as root × 1.5.
+
+## Deployment
+
+GitHub Pages serves the `main` branch root. A `.nojekyll` file disables Jekyll
+so files are served as-is (this is a plain static site, not a Jekyll site).
+Pushing/merging to `main` redeploys.

--- a/songs.json
+++ b/songs.json
@@ -1,4 +1,19 @@
 {
+  "_format": {
+    "_note": "Ignored by the app (song.html / index.html only read \"songs\" and \"concerts\"). Quick reference for editors; see README.md for details.",
+    "song fields": {
+      "title": "display name (required)",
+      "videoId": "YouTube id — use this OR \"audio\"",
+      "audio": "audio file URL — use this OR \"videoId\"",
+      "loops": "[{ start, end, label?, score? }] — times as M:SS or M:SS.s",
+      "fineTune": "true to show 0.1s nudge buttons on loop times",
+      "scales": "true to show the A♭ scale-comparison buttons",
+      "drone": "note name to enable a drone, e.g. \"A♭\" or \"Eb3\" (octave optional, defaults to 3); omit or null = off",
+      "speedMin": "minimum value for the speed slider",
+      "footer": "HTML note shown below the controls",
+      "lyrics": "preformatted lyrics text"
+    }
+  },
   "concerts": {},
   "songs": {
     "allemande": {


### PR DESCRIPTION
## Summary
- Add an ignored `"_format"` key to `songs.json` — a one-line-per-field cheat sheet right where authors edit data. Safe because `song.html`/`index.html` only read `data.songs`.
- Add `README.md` documenting the template + data architecture, how to add a song, every song field, the drone, and the `.nojekyll` deploy setup.

Kept the JSON key terse and the README canonical to avoid the two drifting.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_