### PR TITLE
Lower drone default volume and tighten slider range

### DIFF
--- a/song.html
+++ b/song.html
@@ -108,7 +108,7 @@
     </label>
     <label class="drone-vol">
       vol
-      <input id="drone-volume" type="range" min="0" max="0.7" step="0.01" value="0.35">
+      <input id="drone-volume" type="range" min="0" max="0.4" step="0.01" value="0.1">
     </label>
   </div>
 


### PR DESCRIPTION
## Summary
- Drone default gain `0.35 → 0.1` and slider max `0.7 → 0.4`, so the drone blends with loudness-normalized video audio out of the box and the usable range spreads across the slider instead of bunching at the far left.
- Timbre/EQ unchanged (deferred headroom/clipping tweaks for later).

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_