### PR TITLE
Add scales practice page prototype

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
 
         // Special pages
         const extras = [
+          { href: 'scales.html', title: 'scales' },
           { href: 'john.html', title: 'john' },
         ];
 

--- a/scales.html
+++ b/scales.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>scales</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      background: #000;
+      color: #fff;
+      font-family: "Cormorant Garamond", serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+      padding: 2.5rem 1rem 4rem;
+      box-sizing: border-box;
+    }
+    a { color: #9cd8ff; }
+    .back {
+      position: fixed;
+      top: 1rem;
+      left: 1rem;
+      font-size: 1rem;
+      color: #666;
+      text-decoration: none;
+    }
+    .back:hover { color: #d8d8ff; }
+
+    h1 {
+      margin: 0;
+      font-size: 2.2rem;
+      font-weight: 500;
+      letter-spacing: 0.06em;
+      text-transform: lowercase;
+    }
+    .hint {
+      margin: -0.5rem 0 0;
+      font-size: 1rem;
+      color: rgba(255, 255, 255, 0.5);
+      font-style: italic;
+      text-align: center;
+    }
+
+    #circle {
+      width: min(360px, 92vw);
+      height: auto;
+    }
+    .node circle {
+      fill: #161616;
+      stroke: #555;
+      stroke-width: 1.5;
+      transition: fill 0.15s, stroke 0.15s;
+    }
+    .node text {
+      fill: #cfcfcf;
+      font-size: 18px;
+      font-weight: 500;
+      pointer-events: none;
+    }
+    .node { cursor: pointer; }
+    .node:hover circle { stroke: #9cd8ff; }
+    .node:focus { outline: none; }
+    .node:focus-visible circle { stroke: #9cd8ff; stroke-width: 2.5; }
+    .node.selected circle { fill: #9cd8ff; stroke: #9cd8ff; }
+    .node.selected text { fill: #06121c; }
+
+    .center {
+      font-size: 1.4rem;
+      letter-spacing: 0.04em;
+    }
+    .center #center-label { color: #9cd8ff; font-size: 1.7rem; }
+
+    #modes {
+      width: min(460px, 94vw);
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+    .mode-row {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.35rem 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      flex-wrap: wrap;
+    }
+    .mode-name {
+      flex: 1 1 11rem;
+      font-size: 1.2rem;
+    }
+
+    button {
+      background: none;
+      border: 1px solid #666;
+      color: #ddd;
+      font-family: inherit;
+      font-size: 1rem;
+      padding: 0.35em 0.7em;
+      cursor: pointer;
+    }
+    button:hover { border-color: #9cd8ff; color: #fff; }
+
+    .drone {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 0.6rem 1.1rem;
+      font-size: 0.95rem;
+      color: rgba(255, 255, 255, 0.55);
+    }
+    #drone-btn.on { border-color: #c8743c; color: #f0b48a; }
+    .drone-fifth {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45em;
+      cursor: pointer;
+      user-select: none;
+    }
+    .drone-fifth input {
+      position: absolute;
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+    .drone-fifth .track {
+      width: 2.4em;
+      height: 1.2em;
+      border: 1px solid #666;
+      border-radius: 1em;
+      position: relative;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .drone-fifth .thumb {
+      position: absolute;
+      top: 50%;
+      left: 0.15em;
+      width: 0.9em;
+      height: 0.9em;
+      transform: translateY(-50%);
+      background: #ddd;
+      border-radius: 50%;
+      transition: left 0.15s, background 0.15s;
+    }
+    .drone-fifth input:checked + .track { background: #7a4322; border-color: #c8743c; }
+    .drone-fifth input:checked + .track .thumb { left: calc(100% - 1.05em); background: #f0b48a; }
+    .drone-vol { display: inline-flex; align-items: center; gap: 0.5em; }
+    .drone-vol input[type="range"] { width: 6em; }
+  </style>
+</head>
+<body>
+  <a class="back" href="index.html">← back</a>
+
+  <h1>scales</h1>
+  <p class="hint">pick a tonal center on the circle of fifths, then play each mode up or down</p>
+
+  <svg id="circle" viewBox="0 0 320 320" aria-label="circle of fifths"></svg>
+
+  <div class="center">tonal center: <span id="center-label">—</span></div>
+
+  <div class="drone">
+    <button id="drone-btn" type="button">drone</button>
+    <label class="drone-fifth">
+      <input id="drone-fifth" type="checkbox">
+      <span class="track"><span class="thumb"></span></span>
+      add 5th
+    </label>
+    <label class="drone-vol">
+      vol
+      <input id="drone-volume" type="range" min="0" max="0.4" step="0.01" value="0.1">
+    </label>
+  </div>
+
+  <div id="modes"></div>
+
+  <script src="scales.js"></script>
+</body>
+</html>

--- a/scales.js
+++ b/scales.js
@@ -1,0 +1,239 @@
+// Scales practice page — prototype.
+// Circle-of-fifths selector picks the tonal center; each mode gets ascending
+// and descending playback; an optional root+fifth drone.
+//
+// NOTE: the audio helpers (pitchToMidi, playScale, the drone engine) are
+// duplicated from song.js for now. If this graduates past prototype, extract
+// a shared audio module so the two pages can't drift apart.
+
+const NS = 'http://www.w3.org/2000/svg';
+
+// Tonal centers clockwise around the circle of fifths, starting at the top.
+const CIRCLE = [
+  { label: 'C', root: 'C' },
+  { label: 'G', root: 'G' },
+  { label: 'D', root: 'D' },
+  { label: 'A', root: 'A' },
+  { label: 'E', root: 'E' },
+  { label: 'B', root: 'B' },
+  { label: 'G♭', root: 'Gb' },
+  { label: 'D♭', root: 'Db' },
+  { label: 'A♭', root: 'Ab' },
+  { label: 'E♭', root: 'Eb' },
+  { label: 'B♭', root: 'Bb' },
+  { label: 'F', root: 'F' },
+];
+
+// Semitone offsets from the tonic, including the octave.
+const MODES = [
+  { name: 'Ionian (major)',          intervals: [0, 2, 4, 5, 7, 9, 11, 12] },
+  { name: 'Dorian',                  intervals: [0, 2, 3, 5, 7, 9, 10, 12] },
+  { name: 'Phrygian',                intervals: [0, 1, 3, 5, 7, 8, 10, 12] },
+  { name: 'Lydian',                  intervals: [0, 2, 4, 6, 7, 9, 11, 12] },
+  { name: 'Mixolydian',              intervals: [0, 2, 4, 5, 7, 9, 10, 12] },
+  { name: 'Aeolian (natural minor)', intervals: [0, 2, 3, 5, 7, 8, 10, 12] },
+  { name: 'Locrian',                 intervals: [0, 1, 3, 5, 6, 8, 10, 12] },
+];
+
+let selectedIndex = 8; // default A♭
+
+function pitchToMidi(name, defaultOctave = 3) {
+  const m = String(name).trim().match(/^([A-Ga-g])([#♯b♭]?)(-?\d+)?$/);
+  if (!m) return null;
+  const semis = { c: 0, d: 2, e: 4, f: 5, g: 7, a: 9, b: 11 }[m[1].toLowerCase()];
+  const acc = (m[2] === '#' || m[2] === '♯') ? 1 : (m[2] === 'b' || m[2] === '♭') ? -1 : 0;
+  const oct = m[3] !== undefined ? parseInt(m[3], 10) : defaultOctave;
+  return semis + acc + (oct + 1) * 12;
+}
+function midiToFreq(m) { return 440 * Math.pow(2, (m - 69) / 12); }
+
+// --- scale playback ---
+let audioCtx = null;
+function playScale(baseMidi, intervals, descending) {
+  if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  if (audioCtx.state === 'suspended') audioCtx.resume();
+  const ctx = audioCtx;
+  const seq = descending ? intervals.slice().reverse() : intervals;
+  const noteDur = 0.38;
+  const start = ctx.currentTime + 0.05;
+  seq.forEach((semi, i) => {
+    const t = start + i * noteDur;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'triangle';
+    osc.frequency.value = midiToFreq(baseMidi + semi);
+    gain.gain.setValueAtTime(0.0001, t);
+    gain.gain.linearRampToValueAtTime(0.25, t + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t + noteDur * 0.92);
+    osc.connect(gain).connect(ctx.destination);
+    osc.start(t);
+    osc.stop(t + noteDur);
+  });
+}
+
+// --- drone (root + optional fifth), same engine as the song page ---
+const FIFTH_RATIO = 1.5;
+let droneNodes = null;
+let fifthOn = false;
+let droneVolume = 0.1;
+let droneRootMidi = pitchToMidi(CIRCLE[selectedIndex].root, 3);
+
+function startDrone() {
+  const ctx = new (window.AudioContext || window.webkitAudioContext)();
+  if (ctx.state === 'suspended') ctx.resume();
+  const root = midiToFreq(droneRootMidi);
+
+  const rootOsc = ctx.createOscillator();
+  const fifthOsc = ctx.createOscillator();
+  const fifthGain = ctx.createGain();
+  const filter = ctx.createBiquadFilter();
+  const fA = ctx.createBiquadFilter();
+  const fB = ctx.createBiquadFilter();
+  const fC = ctx.createBiquadFilter();
+  const gain = ctx.createGain();
+
+  rootOsc.type = 'sawtooth'; rootOsc.frequency.value = root;
+  fifthOsc.type = 'sawtooth'; fifthOsc.frequency.value = root * FIFTH_RATIO;
+  fifthGain.gain.value = fifthOn ? 1 : 0;
+
+  filter.type = 'lowpass'; filter.frequency.value = 5000; filter.Q.value = 0.7;
+  fA.type = 'peaking'; fA.frequency.value = 250; fA.Q.value = 4; fA.gain.value = 8;
+  fB.type = 'peaking'; fB.frequency.value = 450; fB.Q.value = 3; fB.gain.value = 6;
+  fC.type = 'peaking'; fC.frequency.value = 1800; fC.Q.value = 2; fC.gain.value = 5;
+
+  const noiseBuf = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate);
+  const nd = noiseBuf.getChannelData(0);
+  for (let i = 0; i < nd.length; i++) nd[i] = Math.random() * 2 - 1;
+  const noise = ctx.createBufferSource();
+  noise.buffer = noiseBuf; noise.loop = true;
+  const noiseFilter = ctx.createBiquadFilter();
+  noiseFilter.type = 'bandpass'; noiseFilter.frequency.value = 2000; noiseFilter.Q.value = 0.6;
+  const noiseGain = ctx.createGain(); noiseGain.gain.value = 0.012;
+
+  rootOsc.connect(filter);
+  fifthOsc.connect(fifthGain); fifthGain.connect(filter);
+  filter.connect(fA); fA.connect(fB); fB.connect(fC); fC.connect(gain);
+  noise.connect(noiseFilter); noiseFilter.connect(noiseGain); noiseGain.connect(gain);
+  gain.connect(ctx.destination);
+
+  const now = ctx.currentTime;
+  gain.gain.setValueAtTime(0.0001, now);
+  gain.gain.exponentialRampToValueAtTime(Math.max(droneVolume, 0.0001), now + 0.15);
+
+  rootOsc.start(); fifthOsc.start(); noise.start();
+  droneNodes = { ctx, rootOsc, fifthOsc, fifthGain, noise, gain };
+  const btn = document.getElementById('drone-btn');
+  btn.textContent = 'stop drone';
+  btn.classList.add('on');
+}
+
+function stopDrone() {
+  if (!droneNodes) return;
+  const { ctx, rootOsc, fifthOsc, noise, gain } = droneNodes;
+  const now = ctx.currentTime;
+  gain.gain.cancelScheduledValues(now);
+  gain.gain.setValueAtTime(Math.max(gain.gain.value, 0.0001), now);
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.2);
+  [rootOsc, fifthOsc, noise].forEach(o => { try { o.stop(now + 0.25); } catch (e) {} });
+  setTimeout(() => { try { ctx.close(); } catch (e) {} }, 400);
+  droneNodes = null;
+  const btn = document.getElementById('drone-btn');
+  btn.textContent = 'drone';
+  btn.classList.remove('on');
+}
+
+function retuneDrone() {
+  if (!droneNodes) return;
+  const root = midiToFreq(droneRootMidi);
+  droneNodes.rootOsc.frequency.setTargetAtTime(root, droneNodes.ctx.currentTime, 0.03);
+  droneNodes.fifthOsc.frequency.setTargetAtTime(root * FIFTH_RATIO, droneNodes.ctx.currentTime, 0.03);
+}
+
+// --- UI ---
+function buildCircle() {
+  const svg = document.getElementById('circle');
+  const cx = 160, cy = 160, r = 120;
+  CIRCLE.forEach((entry, i) => {
+    const ang = (-90 + i * 30) * Math.PI / 180;
+    const x = cx + r * Math.cos(ang);
+    const y = cy + r * Math.sin(ang);
+    const g = document.createElementNS(NS, 'g');
+    g.setAttribute('class', 'node');
+    g.setAttribute('tabindex', '0');
+    g.setAttribute('role', 'button');
+    g.setAttribute('aria-label', entry.label);
+    const c = document.createElementNS(NS, 'circle');
+    c.setAttribute('cx', x); c.setAttribute('cy', y); c.setAttribute('r', 24);
+    const t = document.createElementNS(NS, 'text');
+    t.setAttribute('x', x); t.setAttribute('y', y);
+    t.setAttribute('text-anchor', 'middle');
+    t.setAttribute('dominant-baseline', 'central');
+    t.textContent = entry.label;
+    g.append(c, t);
+    g.addEventListener('click', () => select(i));
+    g.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); select(i); }
+    });
+    svg.appendChild(g);
+    entry.el = g;
+  });
+}
+
+function select(i) {
+  selectedIndex = i;
+  CIRCLE.forEach((e, j) => e.el.classList.toggle('selected', j === i));
+  document.getElementById('center-label').textContent = CIRCLE[i].label;
+  droneRootMidi = pitchToMidi(CIRCLE[i].root, 3);
+  retuneDrone();
+  buildModes();
+}
+
+function buildModes() {
+  const root = CIRCLE[selectedIndex].root;
+  const label = CIRCLE[selectedIndex].label;
+  const base = pitchToMidi(root, 4);
+  const wrap = document.getElementById('modes');
+  wrap.innerHTML = '';
+  MODES.forEach(mode => {
+    const row = document.createElement('div');
+    row.className = 'mode-row';
+    const name = document.createElement('span');
+    name.className = 'mode-name';
+    name.textContent = `${label} ${mode.name}`;
+    const asc = document.createElement('button');
+    asc.type = 'button';
+    asc.textContent = '▲ ascending';
+    asc.addEventListener('click', () => playScale(base, mode.intervals, false));
+    const desc = document.createElement('button');
+    desc.type = 'button';
+    desc.textContent = '▼ descending';
+    desc.addEventListener('click', () => playScale(base, mode.intervals, true));
+    row.append(name, asc, desc);
+    wrap.appendChild(row);
+  });
+}
+
+function initDroneControls() {
+  document.getElementById('drone-btn').addEventListener('click', () => {
+    droneNodes ? stopDrone() : startDrone();
+  });
+  const fifth = document.getElementById('drone-fifth');
+  fifth.addEventListener('change', () => {
+    fifthOn = fifth.checked;
+    if (droneNodes) {
+      droneNodes.fifthGain.gain.setTargetAtTime(fifthOn ? 1 : 0, droneNodes.ctx.currentTime, 0.03);
+    }
+  });
+  const vol = document.getElementById('drone-volume');
+  droneVolume = parseFloat(vol.value);
+  vol.addEventListener('input', () => {
+    droneVolume = parseFloat(vol.value);
+    if (droneNodes) {
+      droneNodes.gain.gain.setTargetAtTime(droneVolume, droneNodes.ctx.currentTime, 0.03);
+    }
+  });
+}
+
+buildCircle();
+initDroneControls();
+select(selectedIndex);


### PR DESCRIPTION
## Summary
Prototype **scales practice page** (`scales.html` + `scales.js`), indexed on the home page.

- **Circle-of-fifths control**: an SVG ring of the 12 tonal centers (C → G → D … clockwise by fifths). Click (or keyboard-select) a note to set the tonal center; defaults to A♭.
- **Modes**: for the selected center, each of the 7 diatonic modes (Ionian → Locrian) gets **▲ ascending** and **▼ descending** playback buttons.
- **Drone**: a root+fifth drone reusing the song page's engine — "add 5th" toggle + volume (default 0.1, max 0.4, matching the recent loudness fix). The drone retunes live when you pick a new center.
- Added to `index.html`'s extras list as **scales**.

## Notes
- The audio helpers (`pitchToMidi`, `playScale`, drone engine) are **duplicated** from `song.js` for this prototype. If it graduates, the clean follow-up is to extract a shared `audio.js` module so they can't drift. Flagged in a comment at the top of `scales.js`.
- Verified all 12 circle roots parse to valid MIDI and octaves line up (A♭4=68, C4=60); `scales.js` passes `node --check`.
- Could **not** test audio/visuals in a browser from this environment — please click around once it deploys.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_