### PR TITLE
Scales page: harmonic minor, auto-descend, default C

### DIFF
--- a/scales.html
+++ b/scales.html
@@ -76,6 +76,13 @@
     }
     .center #center-label { color: #9cd8ff; font-size: 1.7rem; }
 
+    .scale-opts {
+      display: flex;
+      justify-content: center;
+      font-size: 0.95rem;
+      color: rgba(255, 255, 255, 0.55);
+      margin-top: -0.5rem;
+    }
     #modes {
       width: min(460px, 94vw);
       display: flex;
@@ -116,20 +123,20 @@
       color: rgba(255, 255, 255, 0.55);
     }
     #drone-btn.on { border-color: #c8743c; color: #f0b48a; }
-    .drone-fifth {
+    .switch {
       display: inline-flex;
       align-items: center;
       gap: 0.45em;
       cursor: pointer;
       user-select: none;
     }
-    .drone-fifth input {
+    .switch input {
       position: absolute;
       opacity: 0;
       width: 0;
       height: 0;
     }
-    .drone-fifth .track {
+    .switch .track {
       width: 2.4em;
       height: 1.2em;
       border: 1px solid #666;
@@ -137,7 +144,7 @@
       position: relative;
       transition: background 0.15s, border-color 0.15s;
     }
-    .drone-fifth .thumb {
+    .switch .thumb {
       position: absolute;
       top: 50%;
       left: 0.15em;
@@ -148,8 +155,8 @@
       border-radius: 50%;
       transition: left 0.15s, background 0.15s;
     }
-    .drone-fifth input:checked + .track { background: #7a4322; border-color: #c8743c; }
-    .drone-fifth input:checked + .track .thumb { left: calc(100% - 1.05em); background: #f0b48a; }
+    .switch input:checked + .track { background: #7a4322; border-color: #c8743c; }
+    .switch input:checked + .track .thumb { left: calc(100% - 1.05em); background: #f0b48a; }
     .drone-vol { display: inline-flex; align-items: center; gap: 0.5em; }
     .drone-vol input[type="range"] { width: 6em; }
   </style>
@@ -166,7 +173,7 @@
 
   <div class="drone">
     <button id="drone-btn" type="button">drone</button>
-    <label class="drone-fifth">
+    <label class="switch">
       <input id="drone-fifth" type="checkbox">
       <span class="track"><span class="thumb"></span></span>
       add 5th
@@ -174,6 +181,14 @@
     <label class="drone-vol">
       vol
       <input id="drone-volume" type="range" min="0" max="0.4" step="0.01" value="0.1">
+    </label>
+  </div>
+
+  <div class="scale-opts">
+    <label class="switch">
+      <input id="auto-descend" type="checkbox">
+      <span class="track"><span class="thumb"></span></span>
+      play down after up
     </label>
   </div>
 

--- a/scales.js
+++ b/scales.js
@@ -32,10 +32,11 @@ const MODES = [
   { name: 'Lydian',                  intervals: [0, 2, 4, 6, 7, 9, 11, 12] },
   { name: 'Mixolydian',              intervals: [0, 2, 4, 5, 7, 9, 10, 12] },
   { name: 'Aeolian (natural minor)', intervals: [0, 2, 3, 5, 7, 8, 10, 12] },
+  { name: 'Harmonic minor',          intervals: [0, 2, 3, 5, 7, 8, 11, 12] },
   { name: 'Locrian',                 intervals: [0, 1, 3, 5, 6, 8, 10, 12] },
 ];
 
-let selectedIndex = 8; // default A♭
+let selectedIndex = 0; // default C
 
 function pitchToMidi(name, defaultOctave = 3) {
   const m = String(name).trim().match(/^([A-Ga-g])([#♯b♭]?)(-?\d+)?$/);
@@ -49,11 +50,18 @@ function midiToFreq(m) { return 440 * Math.pow(2, (m - 69) / 12); }
 
 // --- scale playback ---
 let audioCtx = null;
-function playScale(baseMidi, intervals, descending) {
+let autoDescend = false;
+
+// Sequence builders (arrays of semitone offsets from the tonic).
+const ascSeq = (iv) => iv;
+const descSeq = (iv) => iv.slice().reverse();
+// up then back down, with the octave as a single turnaround note.
+const upDownSeq = (iv) => iv.concat(iv.slice(0, -1).reverse());
+
+function playSequence(baseMidi, seq) {
   if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
   if (audioCtx.state === 'suspended') audioCtx.resume();
   const ctx = audioCtx;
-  const seq = descending ? intervals.slice().reverse() : intervals;
   const noteDur = 0.38;
   const start = ctx.currentTime + 0.05;
   seq.forEach((semi, i) => {
@@ -202,12 +210,13 @@ function buildModes() {
     name.textContent = `${label} ${mode.name}`;
     const asc = document.createElement('button');
     asc.type = 'button';
-    asc.textContent = '▲ ascending';
-    asc.addEventListener('click', () => playScale(base, mode.intervals, false));
+    asc.textContent = autoDescend ? '▲▼ up + down' : '▲ ascending';
+    asc.addEventListener('click', () =>
+      playSequence(base, autoDescend ? upDownSeq(mode.intervals) : ascSeq(mode.intervals)));
     const desc = document.createElement('button');
     desc.type = 'button';
     desc.textContent = '▼ descending';
-    desc.addEventListener('click', () => playScale(base, mode.intervals, true));
+    desc.addEventListener('click', () => playSequence(base, descSeq(mode.intervals)));
     row.append(name, asc, desc);
     wrap.appendChild(row);
   });
@@ -234,6 +243,15 @@ function initDroneControls() {
   });
 }
 
+function initScaleOptions() {
+  const ad = document.getElementById('auto-descend');
+  ad.addEventListener('change', () => {
+    autoDescend = ad.checked;
+    buildModes();
+  });
+}
+
 buildCircle();
 initDroneControls();
+initScaleOptions();
 select(selectedIndex);


### PR DESCRIPTION
## Summary
- **Harmonic minor** added to the modes list (♭6, raised ♮7), grouped with the natural minor.
- **Auto-descend toggle** ("play down after up"): when on, the ascending button plays the scale up then back down in one pass (octave as a single turnaround), and its label switches to "▲▼ up + down". The separate descending button stays.
- **Default tonal center is now C** (was A♭).

## Notes
- Generalized the toggle CSS to a shared `.switch` class (used by both "add 5th" and the new toggle).
- Verified `node --check` and that the up+down sequence is correct (`0 2 3 5 7 8 11 12 11 8 7 5 3 2 0`). Couldn't test in a browser here — please click through after deploy.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_