### PR TITLE
Scales page: melodic minor (with descending form) + natural minor default

### DIFF
--- a/scales.js
+++ b/scales.js
@@ -32,6 +32,8 @@ function sigLabel(n) {
 
 // Semitone offsets from the tonic, including the octave.
 // basic: shown when "show modes" is off (with the friendlier basicName).
+// descIntervals: distinct descending form (melodic minor goes up raised,
+// down as natural minor); when absent, descending is just the reverse.
 const MODES = [
   { name: 'Ionian (major)',          basicName: 'Major',         basic: true, intervals: [0, 2, 4, 5, 7, 9, 11, 12] },
   { name: 'Dorian',                  intervals: [0, 2, 3, 5, 7, 9, 10, 12] },
@@ -39,7 +41,7 @@ const MODES = [
   { name: 'Lydian',                  intervals: [0, 2, 4, 6, 7, 9, 11, 12] },
   { name: 'Mixolydian',              intervals: [0, 2, 4, 5, 7, 9, 10, 12] },
   { name: 'Aeolian (natural minor)', intervals: [0, 2, 3, 5, 7, 8, 10, 12] },
-  { name: 'Harmonic minor',          basicName: 'Harmonic minor', basic: true, intervals: [0, 2, 3, 5, 7, 8, 11, 12] },
+  { name: 'Melodic minor',           basicName: 'Melodic minor', basic: true, intervals: [0, 2, 3, 5, 7, 9, 11, 12], descIntervals: [0, 2, 3, 5, 7, 8, 10, 12] },
   { name: 'Locrian',                 intervals: [0, 1, 3, 5, 6, 8, 10, 12] },
 ];
 
@@ -60,11 +62,14 @@ function midiToFreq(m) { return 440 * Math.pow(2, (m - 69) / 12); }
 let audioCtx = null;
 let autoDescend = false;
 
-// Sequence builders (arrays of semitone offsets from the tonic).
-const ascSeq = (iv) => iv;
-const descSeq = (iv) => iv.slice().reverse();
+// Sequence builders (arrays of semitone offsets from the tonic). A mode may
+// carry a distinct descIntervals (e.g. melodic minor); otherwise descending
+// is just the ascending form reversed.
+const seqAsc = (mode) => mode.intervals;
+const seqDesc = (mode) => (mode.descIntervals || mode.intervals).slice().reverse();
 // up then back down, with the octave as a single turnaround note.
-const upDownSeq = (iv) => iv.concat(iv.slice(0, -1).reverse());
+const seqUpDown = (mode) =>
+  mode.intervals.concat((mode.descIntervals || mode.intervals).slice(0, -1).reverse());
 
 function playSequence(baseMidi, seq) {
   if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -230,11 +235,11 @@ function buildModes() {
     asc.type = 'button';
     asc.textContent = autoDescend ? '▲▼ up + down' : '▲ ascending';
     asc.addEventListener('click', () =>
-      playSequence(base, autoDescend ? upDownSeq(mode.intervals) : ascSeq(mode.intervals)));
+      playSequence(base, autoDescend ? seqUpDown(mode) : seqAsc(mode)));
     const desc = document.createElement('button');
     desc.type = 'button';
     desc.textContent = '▼ descending';
-    desc.addEventListener('click', () => playSequence(base, descSeq(mode.intervals)));
+    desc.addEventListener('click', () => playSequence(base, seqDesc(mode)));
     row.append(name, asc, desc);
     wrap.appendChild(row);
   });

--- a/scales.js
+++ b/scales.js
@@ -40,7 +40,7 @@ const MODES = [
   { name: 'Phrygian',                intervals: [0, 1, 3, 5, 7, 8, 10, 12] },
   { name: 'Lydian',                  intervals: [0, 2, 4, 6, 7, 9, 11, 12] },
   { name: 'Mixolydian',              intervals: [0, 2, 4, 5, 7, 9, 10, 12] },
-  { name: 'Aeolian (natural minor)', intervals: [0, 2, 3, 5, 7, 8, 10, 12] },
+  { name: 'Aeolian (natural minor)', basicName: 'Natural minor', basic: true, intervals: [0, 2, 3, 5, 7, 8, 10, 12] },
   { name: 'Melodic minor',           basicName: 'Melodic minor', basic: true, intervals: [0, 2, 3, 5, 7, 9, 11, 12], descIntervals: [0, 2, 3, 5, 7, 8, 10, 12] },
   { name: 'Locrian',                 intervals: [0, 1, 3, 5, 6, 8, 10, 12] },
 ];


### PR DESCRIPTION
## Summary
- Replace **harmonic minor** with **melodic minor** as the featured minor on the scales page (per the user — they meant melodic minor).
- Melodic minor has a **distinct descending form**: ascending raises the 6th and 7th (`0 2 3 5 7 9 11 12`), descending reverts to natural minor (`12 10 8 7 5 3 2 0`). The ▼ descending button and the up-then-down toggle honor this (`0 2 3 5 7 9 11 12 10 8 7 5 3 2 0`).
- Default (modes hidden) set is now **Major, Natural minor, Melodic minor**.

## Implementation
- Added optional `descIntervals` to a mode; sequence builders (`seqAsc`/`seqDesc`/`seqUpDown`) take the mode and use the descending form when present.
- Tagged Aeolian as `basic` with `basicName` "Natural minor".
- Verified sequences via `node`; couldn't test UI in-browser here.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_