### PR TITLE
Shared audio.js, cello scale voice, legato fix, revert red drone button

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -25,11 +25,27 @@ const AudioKit = (() => {
   // One AudioContext shared across scale playbacks (the drone makes its own).
   let seqCtx = null;
 
-  // Plays a sequence of semitone offsets from baseMidi as triangle tones.
+  // The shared "cello-ish" voice: a sawtooth shaped by a gentle lowpass and
+  // three formant peaks. Connect a source into `input`; take `output`. Used by
+  // both the drone and the scale note player so their timbre stays identical.
+  function celloFilters(ctx) {
+    const lp = ctx.createBiquadFilter();
+    const fA = ctx.createBiquadFilter();
+    const fB = ctx.createBiquadFilter();
+    const fC = ctx.createBiquadFilter();
+    lp.type = 'lowpass'; lp.frequency.value = 5000; lp.Q.value = 0.7;
+    fA.type = 'peaking'; fA.frequency.value = 250; fA.Q.value = 4; fA.gain.value = 8;
+    fB.type = 'peaking'; fB.frequency.value = 450; fB.Q.value = 3; fB.gain.value = 6;
+    fC.type = 'peaking'; fC.frequency.value = 1800; fC.Q.value = 2; fC.gain.value = 5;
+    lp.connect(fA); fA.connect(fB); fB.connect(fC);
+    return { input: lp, output: fC };
+  }
+
+  // Plays a sequence of semitone offsets from baseMidi using the cello voice.
   // opts: step (onset spacing, s), gate (sounding length, s), attack (s),
   // peak (gain), sustain (0 = plucked decay over the whole gate; >0 = hold at
   // that fraction of peak until a short release — needed for legato/portato),
-  // release (release length, s). Defaults match the song page's plucked feel.
+  // release (release length, s).
   function playSequence(baseMidi, seq, opts = {}) {
     if (!seqCtx) seqCtx = new (window.AudioContext || window.webkitAudioContext)();
     if (seqCtx.state === 'suspended') seqCtx.resume();
@@ -37,15 +53,16 @@ const AudioKit = (() => {
     const step = opts.step != null ? opts.step : 0.42;
     const gate = Math.max(opts.gate != null ? opts.gate : step * 0.92, 0.04);
     const attack = opts.attack != null ? opts.attack : 0.02;
-    const peak = opts.peak != null ? opts.peak : 0.25;
+    const peak = opts.peak != null ? opts.peak : 0.16;
     const sustain = opts.sustain != null ? opts.sustain : 0;
     const release = opts.release != null ? opts.release : 0.05;
     const start = ctx.currentTime + 0.05;
     seq.forEach((semi, i) => {
       const t = start + i * step;
       const osc = ctx.createOscillator();
+      const voice = celloFilters(ctx);
       const gain = ctx.createGain();
-      osc.type = 'triangle';
+      osc.type = 'sawtooth';
       osc.frequency.value = midiToFreq(baseMidi + semi);
       const atk = Math.min(attack, gate * 0.5);
       gain.gain.setValueAtTime(0.0001, t);
@@ -58,7 +75,8 @@ const AudioKit = (() => {
         gain.gain.setValueAtTime(susLevel, Math.max(decayEnd, t + gate - release));
       }
       gain.gain.exponentialRampToValueAtTime(0.0001, t + gate);
-      osc.connect(gain).connect(ctx.destination);
+      osc.connect(voice.input);
+      voice.output.connect(gain).connect(ctx.destination);
       osc.start(t);
       osc.stop(t + gate + 0.05);
     });
@@ -81,20 +99,12 @@ const AudioKit = (() => {
       const rootOsc = ctx.createOscillator();
       const fifthOsc = ctx.createOscillator();
       const fifthGain = ctx.createGain();
-      const filter = ctx.createBiquadFilter();
-      const fA = ctx.createBiquadFilter();
-      const fB = ctx.createBiquadFilter();
-      const fC = ctx.createBiquadFilter();
+      const voice = celloFilters(ctx);
       const gain = ctx.createGain();
 
       rootOsc.type = 'sawtooth'; rootOsc.frequency.value = root;
       fifthOsc.type = 'sawtooth'; fifthOsc.frequency.value = root * FIFTH_RATIO;
       fifthGain.gain.value = fifthOn ? 1 : 0;
-
-      filter.type = 'lowpass'; filter.frequency.value = 5000; filter.Q.value = 0.7;
-      fA.type = 'peaking'; fA.frequency.value = 250; fA.Q.value = 4; fA.gain.value = 8;
-      fB.type = 'peaking'; fB.frequency.value = 450; fB.Q.value = 3; fB.gain.value = 6;
-      fC.type = 'peaking'; fC.frequency.value = 1800; fC.Q.value = 2; fC.gain.value = 5;
 
       const noiseBuf = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate);
       const nd = noiseBuf.getChannelData(0);
@@ -105,9 +115,9 @@ const AudioKit = (() => {
       noiseFilter.type = 'bandpass'; noiseFilter.frequency.value = 2000; noiseFilter.Q.value = 0.6;
       const noiseGain = ctx.createGain(); noiseGain.gain.value = 0.012;
 
-      rootOsc.connect(filter);
-      fifthOsc.connect(fifthGain); fifthGain.connect(filter);
-      filter.connect(fA); fA.connect(fB); fB.connect(fC); fC.connect(gain);
+      rootOsc.connect(voice.input);
+      fifthOsc.connect(fifthGain); fifthGain.connect(voice.input);
+      voice.output.connect(gain);
       noise.connect(noiseFilter); noiseFilter.connect(noiseGain); noiseGain.connect(gain);
       gain.connect(ctx.destination);
 

--- a/audio.js
+++ b/audio.js
@@ -1,0 +1,158 @@
+// Shared audio engine for the song and scales pages. Loaded as a plain script
+// before song.js / scales.js, which call into the AudioKit namespace.
+//
+// Exposes:
+//   AudioKit.midiToFreq(midi)
+//   AudioKit.pitchToMidi(name, defaultOctave = 3)
+//   AudioKit.playSequence(baseMidi, semitoneOffsets, opts)
+//   AudioKit.createDrone()  -> { start, stop, retune, setRoot, setFifth, setVolume, playing }
+const AudioKit = (() => {
+  const FIFTH_RATIO = 1.5;
+
+  function midiToFreq(m) { return 440 * Math.pow(2, (m - 69) / 12); }
+
+  // "A♭", "Eb", "G3", "F#4" → MIDI number; null if unparseable.
+  // Octave is optional and falls back to defaultOctave.
+  function pitchToMidi(name, defaultOctave = 3) {
+    const m = String(name).trim().match(/^([A-Ga-g])([#♯b♭]?)(-?\d+)?$/);
+    if (!m) return null;
+    const semis = { c: 0, d: 2, e: 4, f: 5, g: 7, a: 9, b: 11 }[m[1].toLowerCase()];
+    const accidental = (m[2] === '#' || m[2] === '♯') ? 1 : (m[2] === 'b' || m[2] === '♭') ? -1 : 0;
+    const octave = m[3] !== undefined ? parseInt(m[3], 10) : defaultOctave;
+    return semis + accidental + (octave + 1) * 12;
+  }
+
+  // One AudioContext shared across scale playbacks (the drone makes its own).
+  let seqCtx = null;
+
+  // Plays a sequence of semitone offsets from baseMidi as triangle tones.
+  // opts: step (onset spacing, s), gate (sounding length, s), attack (s),
+  // peak (gain), sustain (0 = plucked decay over the whole gate; >0 = hold at
+  // that fraction of peak until a short release — needed for legato/portato),
+  // release (release length, s). Defaults match the song page's plucked feel.
+  function playSequence(baseMidi, seq, opts = {}) {
+    if (!seqCtx) seqCtx = new (window.AudioContext || window.webkitAudioContext)();
+    if (seqCtx.state === 'suspended') seqCtx.resume();
+    const ctx = seqCtx;
+    const step = opts.step != null ? opts.step : 0.42;
+    const gate = Math.max(opts.gate != null ? opts.gate : step * 0.92, 0.04);
+    const attack = opts.attack != null ? opts.attack : 0.02;
+    const peak = opts.peak != null ? opts.peak : 0.25;
+    const sustain = opts.sustain != null ? opts.sustain : 0;
+    const release = opts.release != null ? opts.release : 0.05;
+    const start = ctx.currentTime + 0.05;
+    seq.forEach((semi, i) => {
+      const t = start + i * step;
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'triangle';
+      osc.frequency.value = midiToFreq(baseMidi + semi);
+      const atk = Math.min(attack, gate * 0.5);
+      gain.gain.setValueAtTime(0.0001, t);
+      gain.gain.linearRampToValueAtTime(peak, t + atk);
+      if (sustain > 0) {
+        // attack → quick decay to the sustain plateau → hold → release
+        const susLevel = Math.max(peak * sustain, 0.0002);
+        const decayEnd = t + Math.min(atk + 0.04, gate * 0.6);
+        gain.gain.linearRampToValueAtTime(susLevel, decayEnd);
+        gain.gain.setValueAtTime(susLevel, Math.max(decayEnd, t + gate - release));
+      }
+      gain.gain.exponentialRampToValueAtTime(0.0001, t + gate);
+      osc.connect(gain).connect(ctx.destination);
+      osc.start(t);
+      osc.stop(t + gate + 0.05);
+    });
+  }
+
+  // Sustained root with an optional perfect fifth. A sub-audible noise layer
+  // keeps Bluetooth codecs from silence-gating the steady tone.
+  function createDrone() {
+    let nodes = null;
+    let rootMidi = 57;
+    let fifthOn = false;
+    let volume = 0.1;
+
+    function start() {
+      if (nodes) return;
+      const ctx = new (window.AudioContext || window.webkitAudioContext)();
+      if (ctx.state === 'suspended') ctx.resume();
+      const root = midiToFreq(rootMidi);
+
+      const rootOsc = ctx.createOscillator();
+      const fifthOsc = ctx.createOscillator();
+      const fifthGain = ctx.createGain();
+      const filter = ctx.createBiquadFilter();
+      const fA = ctx.createBiquadFilter();
+      const fB = ctx.createBiquadFilter();
+      const fC = ctx.createBiquadFilter();
+      const gain = ctx.createGain();
+
+      rootOsc.type = 'sawtooth'; rootOsc.frequency.value = root;
+      fifthOsc.type = 'sawtooth'; fifthOsc.frequency.value = root * FIFTH_RATIO;
+      fifthGain.gain.value = fifthOn ? 1 : 0;
+
+      filter.type = 'lowpass'; filter.frequency.value = 5000; filter.Q.value = 0.7;
+      fA.type = 'peaking'; fA.frequency.value = 250; fA.Q.value = 4; fA.gain.value = 8;
+      fB.type = 'peaking'; fB.frequency.value = 450; fB.Q.value = 3; fB.gain.value = 6;
+      fC.type = 'peaking'; fC.frequency.value = 1800; fC.Q.value = 2; fC.gain.value = 5;
+
+      const noiseBuf = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate);
+      const nd = noiseBuf.getChannelData(0);
+      for (let i = 0; i < nd.length; i++) nd[i] = Math.random() * 2 - 1;
+      const noise = ctx.createBufferSource();
+      noise.buffer = noiseBuf; noise.loop = true;
+      const noiseFilter = ctx.createBiquadFilter();
+      noiseFilter.type = 'bandpass'; noiseFilter.frequency.value = 2000; noiseFilter.Q.value = 0.6;
+      const noiseGain = ctx.createGain(); noiseGain.gain.value = 0.012;
+
+      rootOsc.connect(filter);
+      fifthOsc.connect(fifthGain); fifthGain.connect(filter);
+      filter.connect(fA); fA.connect(fB); fB.connect(fC); fC.connect(gain);
+      noise.connect(noiseFilter); noiseFilter.connect(noiseGain); noiseGain.connect(gain);
+      gain.connect(ctx.destination);
+
+      const now = ctx.currentTime;
+      gain.gain.setValueAtTime(0.0001, now);
+      gain.gain.exponentialRampToValueAtTime(Math.max(volume, 0.0001), now + 0.15);
+
+      rootOsc.start(); fifthOsc.start(); noise.start();
+      nodes = { ctx, rootOsc, fifthOsc, fifthGain, noise, gain };
+    }
+
+    function stop() {
+      if (!nodes) return;
+      const { ctx, rootOsc, fifthOsc, noise, gain } = nodes;
+      const now = ctx.currentTime;
+      gain.gain.cancelScheduledValues(now);
+      gain.gain.setValueAtTime(Math.max(gain.gain.value, 0.0001), now);
+      gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.2);
+      [rootOsc, fifthOsc, noise].forEach(o => { try { o.stop(now + 0.25); } catch (e) {} });
+      setTimeout(() => { try { ctx.close(); } catch (e) {} }, 400);
+      nodes = null;
+    }
+
+    function retune() {
+      if (!nodes) return;
+      const root = midiToFreq(rootMidi);
+      nodes.rootOsc.frequency.setTargetAtTime(root, nodes.ctx.currentTime, 0.03);
+      nodes.fifthOsc.frequency.setTargetAtTime(root * FIFTH_RATIO, nodes.ctx.currentTime, 0.03);
+    }
+
+    function setRoot(midi) { rootMidi = midi; retune(); }
+    function setFifth(on) {
+      fifthOn = on;
+      if (nodes) nodes.fifthGain.gain.setTargetAtTime(on ? 1 : 0, nodes.ctx.currentTime, 0.03);
+    }
+    function setVolume(v) {
+      volume = v;
+      if (nodes) nodes.gain.gain.setTargetAtTime(v, nodes.ctx.currentTime, 0.03);
+    }
+
+    return {
+      start, stop, retune, setRoot, setFifth, setVolume,
+      get playing() { return !!nodes; },
+    };
+  }
+
+  return { FIFTH_RATIO, midiToFreq, pitchToMidi, playSequence, createDrone };
+})();

--- a/scales.html
+++ b/scales.html
@@ -309,6 +309,7 @@
 
   <div id="modes"></div>
 
+  <script src="audio.js"></script>
   <script src="scales.js"></script>
 </body>
 </html>

--- a/scales.js
+++ b/scales.js
@@ -1,10 +1,6 @@
-// Scales practice page — prototype.
-// Circle-of-fifths selector picks the tonal center; each mode gets ascending
-// and descending playback; an optional root+fifth drone.
-//
-// NOTE: the audio helpers (pitchToMidi, playScale, the drone engine) are
-// duplicated from song.js for now. If this graduates past prototype, extract
-// a shared audio module so the two pages can't drift apart.
+// Scales practice page. Circle-of-fifths selector picks the tonal center; each
+// scale gets ascending and descending playback; an optional root+fifth drone.
+// Audio helpers (pitchToMidi, playSequence, the drone engine) live in audio.js.
 
 const NS = 'http://www.w3.org/2000/svg';
 
@@ -62,27 +58,19 @@ let selectedIndex = 0; // default C
 let showExtra = false; // "show additional scales"
 let octaves = 1;
 
-function pitchToMidi(name, defaultOctave = 3) {
-  const m = String(name).trim().match(/^([A-Ga-g])([#♯b♭]?)(-?\d+)?$/);
-  if (!m) return null;
-  const semis = { c: 0, d: 2, e: 4, f: 5, g: 7, a: 9, b: 11 }[m[1].toLowerCase()];
-  const acc = (m[2] === '#' || m[2] === '♯') ? 1 : (m[2] === 'b' || m[2] === '♭') ? -1 : 0;
-  const oct = m[3] !== undefined ? parseInt(m[3], 10) : defaultOctave;
-  return semis + acc + (oct + 1) * 12;
-}
-function midiToFreq(m) { return 440 * Math.pow(2, (m - 69) / 12); }
+const { pitchToMidi } = AudioKit;
 
 // --- scale playback ---
-let audioCtx = null;
 let autoDescend = false;
 let tempoBpm = 120;
 let articulation = 'legato';
 
-// gate = fraction of the beat the note actually sounds; atk = attack time.
+// gate = fraction of the beat the note sounds; sustain = held level (0 = plucked,
+// for staccato); atk/release = envelope edges. Tuned so legato actually connects.
 const ARTIC = {
-  staccato: { gate: 0.35, atk: 0.004 },
-  portato:  { gate: 0.68, atk: 0.012 },
-  legato:   { gate: 0.98, atk: 0.030 },
+  staccato: { gate: 0.32, atk: 0.004, sustain: 0,    release: 0.04 },
+  portato:  { gate: 0.62, atk: 0.010, sustain: 0.55, release: 0.06 },
+  legato:   { gate: 1.0,  atk: 0.025, sustain: 0.9,  release: 0.06 },
 };
 
 // Expand a one-octave interval set (ending on 12) across `octaves` octaves,
@@ -108,105 +96,20 @@ const seqUpDown = (mode) => {
 };
 
 function playSequence(baseMidi, seq) {
-  if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-  if (audioCtx.state === 'suspended') audioCtx.resume();
-  const ctx = audioCtx;
   const step = 60 / tempoBpm;
   const art = ARTIC[articulation] || ARTIC.legato;
-  const gate = Math.max(step * art.gate, 0.05);
-  const start = ctx.currentTime + 0.05;
-  seq.forEach((semi, i) => {
-    const t = start + i * step;
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.type = 'triangle';
-    osc.frequency.value = midiToFreq(baseMidi + semi);
-    gain.gain.setValueAtTime(0.0001, t);
-    gain.gain.linearRampToValueAtTime(0.25, t + Math.min(art.atk, gate * 0.5));
-    gain.gain.exponentialRampToValueAtTime(0.0001, t + gate);
-    osc.connect(gain).connect(ctx.destination);
-    osc.start(t);
-    osc.stop(t + gate + 0.05);
+  AudioKit.playSequence(baseMidi, seq, {
+    step,
+    gate: step * art.gate,
+    attack: art.atk,
+    sustain: art.sustain,
+    release: art.release,
   });
 }
 
-// --- drone (root + optional fifth), same engine as the song page ---
-const FIFTH_RATIO = 1.5;
-let droneNodes = null;
-let fifthOn = false;
-let droneVolume = 0.1;
-let droneRootMidi = pitchToMidi(CIRCLE[selectedIndex].root, 3);
-
-function startDrone() {
-  const ctx = new (window.AudioContext || window.webkitAudioContext)();
-  if (ctx.state === 'suspended') ctx.resume();
-  const root = midiToFreq(droneRootMidi);
-
-  const rootOsc = ctx.createOscillator();
-  const fifthOsc = ctx.createOscillator();
-  const fifthGain = ctx.createGain();
-  const filter = ctx.createBiquadFilter();
-  const fA = ctx.createBiquadFilter();
-  const fB = ctx.createBiquadFilter();
-  const fC = ctx.createBiquadFilter();
-  const gain = ctx.createGain();
-
-  rootOsc.type = 'sawtooth'; rootOsc.frequency.value = root;
-  fifthOsc.type = 'sawtooth'; fifthOsc.frequency.value = root * FIFTH_RATIO;
-  fifthGain.gain.value = fifthOn ? 1 : 0;
-
-  filter.type = 'lowpass'; filter.frequency.value = 5000; filter.Q.value = 0.7;
-  fA.type = 'peaking'; fA.frequency.value = 250; fA.Q.value = 4; fA.gain.value = 8;
-  fB.type = 'peaking'; fB.frequency.value = 450; fB.Q.value = 3; fB.gain.value = 6;
-  fC.type = 'peaking'; fC.frequency.value = 1800; fC.Q.value = 2; fC.gain.value = 5;
-
-  const noiseBuf = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate);
-  const nd = noiseBuf.getChannelData(0);
-  for (let i = 0; i < nd.length; i++) nd[i] = Math.random() * 2 - 1;
-  const noise = ctx.createBufferSource();
-  noise.buffer = noiseBuf; noise.loop = true;
-  const noiseFilter = ctx.createBiquadFilter();
-  noiseFilter.type = 'bandpass'; noiseFilter.frequency.value = 2000; noiseFilter.Q.value = 0.6;
-  const noiseGain = ctx.createGain(); noiseGain.gain.value = 0.012;
-
-  rootOsc.connect(filter);
-  fifthOsc.connect(fifthGain); fifthGain.connect(filter);
-  filter.connect(fA); fA.connect(fB); fB.connect(fC); fC.connect(gain);
-  noise.connect(noiseFilter); noiseFilter.connect(noiseGain); noiseGain.connect(gain);
-  gain.connect(ctx.destination);
-
-  const now = ctx.currentTime;
-  gain.gain.setValueAtTime(0.0001, now);
-  gain.gain.exponentialRampToValueAtTime(Math.max(droneVolume, 0.0001), now + 0.15);
-
-  rootOsc.start(); fifthOsc.start(); noise.start();
-  droneNodes = { ctx, rootOsc, fifthOsc, fifthGain, noise, gain };
-  const btn = document.getElementById('drone-btn');
-  btn.textContent = 'stop drone';
-  btn.classList.add('on');
-}
-
-function stopDrone() {
-  if (!droneNodes) return;
-  const { ctx, rootOsc, fifthOsc, noise, gain } = droneNodes;
-  const now = ctx.currentTime;
-  gain.gain.cancelScheduledValues(now);
-  gain.gain.setValueAtTime(Math.max(gain.gain.value, 0.0001), now);
-  gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.2);
-  [rootOsc, fifthOsc, noise].forEach(o => { try { o.stop(now + 0.25); } catch (e) {} });
-  setTimeout(() => { try { ctx.close(); } catch (e) {} }, 400);
-  droneNodes = null;
-  const btn = document.getElementById('drone-btn');
-  btn.textContent = 'drone';
-  btn.classList.remove('on');
-}
-
-function retuneDrone() {
-  if (!droneNodes) return;
-  const root = midiToFreq(droneRootMidi);
-  droneNodes.rootOsc.frequency.setTargetAtTime(root, droneNodes.ctx.currentTime, 0.03);
-  droneNodes.fifthOsc.frequency.setTargetAtTime(root * FIFTH_RATIO, droneNodes.ctx.currentTime, 0.03);
-}
+// --- drone (root + optional fifth), shared engine in audio.js ---
+const drone = AudioKit.createDrone();
+drone.setRoot(pitchToMidi(CIRCLE[selectedIndex].root, 3));
 
 // --- UI ---
 function buildCircle() {
@@ -270,8 +173,7 @@ function select(i) {
   CIRCLE.forEach((e, j) => e.el.classList.toggle('selected', j === i));
   const c = CIRCLE[i];
   document.getElementById('center-label').textContent = c.alt ? `${c.label} / ${c.alt}` : c.label;
-  droneRootMidi = pitchToMidi(CIRCLE[i].root, 3);
-  retuneDrone();
+  drone.setRoot(pitchToMidi(CIRCLE[i].root, 3));
   buildModes();
   renderKeySig();
 }
@@ -359,24 +261,23 @@ function buildModes() {
 }
 
 function initDroneControls() {
-  document.getElementById('drone-btn').addEventListener('click', () => {
-    droneNodes ? stopDrone() : startDrone();
+  const btn = document.getElementById('drone-btn');
+  btn.addEventListener('click', () => {
+    if (drone.playing) {
+      drone.stop();
+      btn.textContent = 'drone';
+      btn.classList.remove('on');
+    } else {
+      drone.start();
+      btn.textContent = 'stop drone';
+      btn.classList.add('on');
+    }
   });
   const fifth = document.getElementById('drone-fifth');
-  fifth.addEventListener('change', () => {
-    fifthOn = fifth.checked;
-    if (droneNodes) {
-      droneNodes.fifthGain.gain.setTargetAtTime(fifthOn ? 1 : 0, droneNodes.ctx.currentTime, 0.03);
-    }
-  });
+  fifth.addEventListener('change', () => drone.setFifth(fifth.checked));
   const vol = document.getElementById('drone-volume');
-  droneVolume = parseFloat(vol.value);
-  vol.addEventListener('input', () => {
-    droneVolume = parseFloat(vol.value);
-    if (droneNodes) {
-      droneNodes.gain.gain.setTargetAtTime(droneVolume, droneNodes.ctx.currentTime, 0.03);
-    }
-  });
+  drone.setVolume(parseFloat(vol.value));
+  vol.addEventListener('input', () => drone.setVolume(parseFloat(vol.value)));
 }
 
 function initScaleOptions() {

--- a/song.css
+++ b/song.css
@@ -159,7 +159,7 @@ a {
   border: none;
   border-bottom: 1px solid rgba(255, 255, 255, 0.25);
   border-radius: 0;
-  color: red; /* TEMP deploy marker — revert to rgba(255, 255, 255, 0.6) */
+  color: rgba(255, 255, 255, 0.6);
   font-size: 0.85rem;
   font-style: italic;
   letter-spacing: 0.06em;

--- a/song.html
+++ b/song.html
@@ -113,6 +113,7 @@
   </div>
 
   <script src="https://www.youtube.com/iframe_api"></script>
+  <script src="audio.js"></script>
   <script src="song.js"></script>
 </body>
 </html>

--- a/song.js
+++ b/song.js
@@ -24,18 +24,7 @@ const MODES = {
   locrian: [0, 1, 3, 5, 6, 8, 10, 12],
 };
 
-function midiToFreq(m) { return 440 * Math.pow(2, (m - 69) / 12); }
-
-// "A♭", "Eb", "G3", "F#4" → MIDI number; null if unparseable.
-// Octave is optional and falls back to defaultOctave.
-function pitchToMidi(name, defaultOctave = 3) {
-  const m = String(name).trim().match(/^([A-Ga-g])([#♯b♭]?)(-?\d+)?$/);
-  if (!m) return null;
-  const semis = { c: 0, d: 2, e: 4, f: 5, g: 7, a: 9, b: 11 }[m[1].toLowerCase()];
-  const accidental = (m[2] === '#' || m[2] === '♯') ? 1 : (m[2] === 'b' || m[2] === '♭') ? -1 : 0;
-  const octave = m[3] !== undefined ? parseInt(m[3], 10) : defaultOctave;
-  return semis + accidental + (octave + 1) * 12;
-}
+const { pitchToMidi } = AudioKit;
 
 function init(slug) {
   let player;
@@ -60,28 +49,6 @@ function init(slug) {
   const scoreImg = document.getElementById('score-img');
 
   // --- Scale buttons (data-driven via the song's "scales" field) ---
-  let audioCtx = null;
-  function playScale(baseMidi, semitoneOffsets) {
-    if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-    const ctx = audioCtx;
-    if (ctx.state === 'suspended') ctx.resume();
-    const noteDur = 0.42;
-    const start = ctx.currentTime + 0.05;
-    semitoneOffsets.forEach((semi, i) => {
-      const t = start + i * noteDur;
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.type = 'triangle';
-      osc.frequency.value = midiToFreq(baseMidi + semi);
-      gain.gain.setValueAtTime(0.0001, t);
-      gain.gain.linearRampToValueAtTime(0.25, t + 0.02);
-      gain.gain.exponentialRampToValueAtTime(0.0001, t + noteDur * 0.92);
-      osc.connect(gain).connect(ctx.destination);
-      osc.start(t);
-      osc.stop(t + noteDur);
-    });
-  }
-
   function setupScales(scales) {
     const container = document.getElementById('scale-tools');
     const root = scales.root || 'A♭';
@@ -93,102 +60,37 @@ function init(slug) {
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.textContent = item.label || `${root} ${item.mode}`;
-      btn.addEventListener('click', () => playScale(baseMidi, intervals));
+      btn.addEventListener('click', () => AudioKit.playSequence(baseMidi, intervals));
       container.appendChild(btn);
     });
     if (container.children.length) container.style.display = 'flex';
   }
 
-  // --- Drone (borrowed from mojotrio) — sustained root with optional perfect fifth.
-  // Root pitch comes from the song's "drone" field (note name, octave optional);
-  // a missing/null field leaves the drone off. ---
-  const FIFTH_RATIO = 1.5;
+  // --- Drone — sustained root with optional perfect fifth (shared engine in
+  // audio.js). Root pitch comes from the song's "drone" field (note name,
+  // octave optional); a missing/null field leaves the drone off. ---
   const dronePanel = document.getElementById('drone-panel');
   const droneBtn = document.getElementById('drone-btn');
   const fifthToggle = document.getElementById('drone-fifth');
   const volumeInput = document.getElementById('drone-volume');
-  let droneNodes = null;
-  let fifthOn = false;
-  let droneVolume = parseFloat(volumeInput.value);
-  let droneRootMidi = 56; // A♭3 default
   let droneLabel = 'A♭';
+  const drone = AudioKit.createDrone();
+  drone.setRoot(56); // A♭3 default
+  drone.setVolume(parseFloat(volumeInput.value));
 
-  function startDrone() {
-    const ctx = new (window.AudioContext || window.webkitAudioContext)();
-    if (ctx.state === 'suspended') ctx.resume();
-    const root = midiToFreq(droneRootMidi);
-
-    const rootOsc = ctx.createOscillator();
-    const fifthOsc = ctx.createOscillator();
-    const fifthGain = ctx.createGain();
-    const filter = ctx.createBiquadFilter();
-    const fA = ctx.createBiquadFilter();
-    const fB = ctx.createBiquadFilter();
-    const fC = ctx.createBiquadFilter();
-    const gain = ctx.createGain();
-
-    rootOsc.type = 'sawtooth'; rootOsc.frequency.value = root;
-    fifthOsc.type = 'sawtooth'; fifthOsc.frequency.value = root * FIFTH_RATIO;
-    fifthGain.gain.value = fifthOn ? 1 : 0;
-
-    filter.type = 'lowpass'; filter.frequency.value = 5000; filter.Q.value = 0.7;
-    fA.type = 'peaking'; fA.frequency.value = 250; fA.Q.value = 4; fA.gain.value = 8;
-    fB.type = 'peaking'; fB.frequency.value = 450; fB.Q.value = 3; fB.gain.value = 6;
-    fC.type = 'peaking'; fC.frequency.value = 1800; fC.Q.value = 2; fC.gain.value = 5;
-
-    // sub-audible noise prevents Bluetooth codec silence-gating (audible pulsing)
-    const noiseBuf = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate);
-    const nd = noiseBuf.getChannelData(0);
-    for (let i = 0; i < nd.length; i++) nd[i] = Math.random() * 2 - 1;
-    const noise = ctx.createBufferSource();
-    noise.buffer = noiseBuf; noise.loop = true;
-    const noiseFilter = ctx.createBiquadFilter();
-    noiseFilter.type = 'bandpass'; noiseFilter.frequency.value = 2000; noiseFilter.Q.value = 0.6;
-    const noiseGain = ctx.createGain(); noiseGain.gain.value = 0.012;
-
-    rootOsc.connect(filter);
-    fifthOsc.connect(fifthGain); fifthGain.connect(filter);
-    filter.connect(fA); fA.connect(fB); fB.connect(fC); fC.connect(gain);
-    noise.connect(noiseFilter); noiseFilter.connect(noiseGain); noiseGain.connect(gain);
-    gain.connect(ctx.destination);
-
-    const now = ctx.currentTime;
-    gain.gain.setValueAtTime(0.0001, now);
-    gain.gain.exponentialRampToValueAtTime(Math.max(droneVolume, 0.0001), now + 0.15);
-
-    rootOsc.start(); fifthOsc.start(); noise.start();
-    droneNodes = { ctx, rootOsc, fifthOsc, fifthGain, noise, gain };
-    droneBtn.textContent = 'stop';
-    droneBtn.classList.add('on');
-  }
-
-  function stopDrone() {
-    if (!droneNodes) return;
-    const { ctx, rootOsc, fifthOsc, noise, gain } = droneNodes;
-    const now = ctx.currentTime;
-    gain.gain.cancelScheduledValues(now);
-    gain.gain.setValueAtTime(Math.max(gain.gain.value, 0.0001), now);
-    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.2);
-    [rootOsc, fifthOsc, noise].forEach(o => { try { o.stop(now + 0.25); } catch (e) {} });
-    setTimeout(() => { try { ctx.close(); } catch (e) {} }, 400);
-    droneNodes = null;
-    droneBtn.textContent = droneLabel;
-    droneBtn.classList.remove('on');
-  }
-
-  droneBtn.addEventListener('click', () => { droneNodes ? stopDrone() : startDrone(); });
-  fifthToggle.addEventListener('change', () => {
-    fifthOn = fifthToggle.checked;
-    if (droneNodes) {
-      droneNodes.fifthGain.gain.setTargetAtTime(fifthOn ? 1 : 0, droneNodes.ctx.currentTime, 0.03);
+  droneBtn.addEventListener('click', () => {
+    if (drone.playing) {
+      drone.stop();
+      droneBtn.textContent = droneLabel;
+      droneBtn.classList.remove('on');
+    } else {
+      drone.start();
+      droneBtn.textContent = 'stop';
+      droneBtn.classList.add('on');
     }
   });
-  volumeInput.addEventListener('input', () => {
-    droneVolume = parseFloat(volumeInput.value);
-    if (droneNodes) {
-      droneNodes.gain.gain.setTargetAtTime(droneVolume, droneNodes.ctx.currentTime, 0.03);
-    }
-  });
+  fifthToggle.addEventListener('change', () => drone.setFifth(fifthToggle.checked));
+  volumeInput.addEventListener('input', () => drone.setVolume(parseFloat(volumeInput.value)));
 
   function showScore(src) {
     if (!src) { scoreWrapper.classList.remove('active'); return; }
@@ -437,7 +339,7 @@ function init(slug) {
 
       const droneMidi = song.drone != null ? pitchToMidi(song.drone) : null;
       if (droneMidi !== null) {
-        droneRootMidi = droneMidi;
+        drone.setRoot(droneMidi);
         droneLabel = String(song.drone);
         droneBtn.textContent = droneLabel;
         dronePanel.classList.add('active');


### PR DESCRIPTION
## Summary
- **Shared `audio.js`**: extracted the pitch helpers, note-sequence player, and drone engine into one `AudioKit` module used by both the song and scales pages, removing ~150 lines of duplicated audio code so the two can't drift.
- **Fixed scales legato**: the old envelope decayed to near-silence over every note regardless of articulation, so legato sounded plucked like staccato. The player now holds a sustain plateau — legato connects, portato sustains then gaps, staccato stays a short pluck.
- **Reverted the temporary red drone button** color on the song page (`color: red` deploy marker → `rgba(255,255,255,0.6)`).
- **Cello voice for scales**: the note player now runs through the same sawtooth + formant-filter chain as the drone (extracted as `celloFilters`), so scale playback and the drone share one timbre instead of the old plain triangle.

## Verification (headless Chromium)
- Both pages load clean; `AudioKit` present; zero page errors.
- Drone toggles correctly on both pages (song page tested over HTTP with the `earth-song` slug); button color confirmed grey, not red.
- Offline-rendered envelopes: legato sustains (~0.22 mid-note) vs staccato silent by mid-note.
- Cello-voiced scale renders without clipping (max ~0.25 at C4, ~0.31 in the low register; RMS ~0.10, matching the drone's level).

Caveat: this is offline DSP/automation analysis, not real speaker output — the subjective feel of the timbre and articulations is still worth a listen.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_