### PR TITLE
Show currently-playing scale note in the circle's center

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -22,8 +22,19 @@ const AudioKit = (() => {
     return semis + accidental + (octave + 1) * 12;
   }
 
+  const SHARP_NAMES = ['C', 'C♯', 'D', 'D♯', 'E', 'F', 'F♯', 'G', 'G♯', 'A', 'A♯', 'B'];
+  const FLAT_NAMES = ['C', 'D♭', 'D', 'E♭', 'E', 'F', 'G♭', 'G', 'A♭', 'A', 'B♭', 'B'];
+
+  // MIDI number → pitch-class name. preferFlats picks the accidental spelling.
+  function midiToName(midi, preferFlats) {
+    const pc = ((Math.round(midi) % 12) + 12) % 12;
+    return (preferFlats ? FLAT_NAMES : SHARP_NAMES)[pc];
+  }
+
   // One AudioContext shared across scale playbacks (the drone makes its own).
   let seqCtx = null;
+  // Pending visual-callback timers, cleared when a new sequence starts.
+  let seqTimers = [];
 
   // The shared "cello-ish" voice: a sawtooth shaped by a gentle lowpass and
   // three formant peaks. Connect a source into `input`; take `output`. Used by
@@ -45,7 +56,8 @@ const AudioKit = (() => {
   // opts: step (onset spacing, s), gate (sounding length, s), attack (s),
   // peak (gain), sustain (0 = plucked decay over the whole gate; >0 = hold at
   // that fraction of peak until a short release — needed for legato/portato),
-  // release (release length, s).
+  // release (release length, s), onNote(semi, i) fired as each note sounds,
+  // onEnd() fired after the last note finishes.
   function playSequence(baseMidi, seq, opts = {}) {
     if (!seqCtx) seqCtx = new (window.AudioContext || window.webkitAudioContext)();
     if (seqCtx.state === 'suspended') seqCtx.resume();
@@ -56,7 +68,13 @@ const AudioKit = (() => {
     const peak = opts.peak != null ? opts.peak : 0.16;
     const sustain = opts.sustain != null ? opts.sustain : 0;
     const release = opts.release != null ? opts.release : 0.05;
-    const start = ctx.currentTime + 0.05;
+    const onNote = typeof opts.onNote === 'function' ? opts.onNote : null;
+    const onEnd = typeof opts.onEnd === 'function' ? opts.onEnd : null;
+    // Drop any visual callbacks still pending from a previous sequence.
+    seqTimers.forEach(id => clearTimeout(id));
+    seqTimers = [];
+    const now = ctx.currentTime;
+    const start = now + 0.05;
     seq.forEach((semi, i) => {
       const t = start + i * step;
       const osc = ctx.createOscillator();
@@ -79,7 +97,12 @@ const AudioKit = (() => {
       voice.output.connect(gain).connect(ctx.destination);
       osc.start(t);
       osc.stop(t + gate + 0.05);
+      if (onNote) seqTimers.push(setTimeout(() => onNote(semi, i), Math.max(0, (t - now) * 1000)));
     });
+    if (onEnd) {
+      const endT = start + (seq.length - 1) * step + gate;
+      seqTimers.push(setTimeout(onEnd, Math.max(0, (endT - now) * 1000)));
+    }
   }
 
   // Sustained root with an optional perfect fifth. A sub-audible noise layer
@@ -164,5 +187,5 @@ const AudioKit = (() => {
     };
   }
 
-  return { FIFTH_RATIO, midiToFreq, pitchToMidi, playSequence, createDrone };
+  return { FIFTH_RATIO, midiToFreq, pitchToMidi, midiToName, playSequence, createDrone };
 })();

--- a/scales.html
+++ b/scales.html
@@ -79,6 +79,13 @@
     .node.selected .sig { fill: #9cd8ff; }
     .node.selected .minor { fill: #9cd8ff; font-weight: 500; }
 
+    #playing-note {
+      fill: #9cd8ff;
+      font-size: 44px;
+      font-weight: 500;
+      pointer-events: none;
+    }
+
     .node .sig {
       fill: rgba(255, 255, 255, 0.5);
       font-size: 13px;

--- a/scales.js
+++ b/scales.js
@@ -98,12 +98,16 @@ const seqUpDown = (mode) => {
 function playSequence(baseMidi, seq) {
   const step = 60 / tempoBpm;
   const art = ARTIC[articulation] || ARTIC.legato;
+  const preferFlats = CIRCLE[selectedIndex].sig < 0;
+  const readout = document.getElementById('playing-note');
   AudioKit.playSequence(baseMidi, seq, {
     step,
     gate: step * art.gate,
     attack: art.atk,
     sustain: art.sustain,
     release: art.release,
+    onNote: (semi) => { if (readout) readout.textContent = AudioKit.midiToName(baseMidi + semi, preferFlats); },
+    onEnd: () => { if (readout) readout.textContent = ''; },
   });
 }
 
@@ -166,6 +170,15 @@ function buildCircle() {
     svg.appendChild(g);
     entry.el = g;
   });
+
+  // Center readout for the note currently sounding during scale playback.
+  const playing = document.createElementNS(NS, 'text');
+  playing.setAttribute('id', 'playing-note');
+  playing.setAttribute('x', cx);
+  playing.setAttribute('y', cy);
+  playing.setAttribute('text-anchor', 'middle');
+  playing.setAttribute('dominant-baseline', 'central');
+  svg.appendChild(playing);
 }
 
 function select(i) {


### PR DESCRIPTION
## Summary
- During scale playback, the currently-sounding note now appears large in the **center of the circle of fifths**, spelled to the selected key (sharps for sharp keys, flats for flat keys), and clears when the scale finishes.

## Implementation
- `audio.js` `playSequence` gained optional `onNote(semi, i)` / `onEnd()` callbacks, timed off the audio clock; pending visual timers are cleared if a new sequence starts mid-play. Added a `midiToName(midi, preferFlats)` helper.
- `scales.js` renders a center `<text>` in the circle SVG and updates it per note. The song page is untouched (it doesn't pass the callbacks).

## Verification (headless Chromium)
- C major → readout cycles `C D E F G A B C` then clears; A♭ major → `A♭ B♭ C D♭ E♭ F G A♭` (flats follow the key); no page errors.
- Screenshot confirms a large blue note centered in the circle during playback.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_