### PR TITLE
Scales: per-row note readout, tempo marking, note-value slider, loop

### DIFF
--- a/scales.html
+++ b/scales.html
@@ -179,6 +179,12 @@
       flex: 1 1 11rem;
       font-size: 1.2rem;
     }
+    .note-readout {
+      min-width: 2.2em;
+      text-align: right;
+      color: #9cd8ff;
+      font-size: 1.2rem;
+    }
 
     button {
       background: none;

--- a/scales.html
+++ b/scales.html
@@ -138,6 +138,8 @@
     .ctl { display: inline-flex; align-items: center; gap: 0.5em; }
     .ctl input[type="range"] { width: 6em; }
     .ctl-val { min-width: 1ch; color: #9cd8ff; }
+    .subdiv-val { min-width: 5.5em; color: #9cd8ff; }
+    .note-eq { font-size: 1.25rem; color: rgba(255, 255, 255, 0.8); }
     .ctl .unit { opacity: 0.55; }
     .ctl input[type="number"],
     .ctl select {
@@ -301,9 +303,18 @@
       <span id="octaves-val" class="ctl-val">1</span>
     </label>
     <label class="ctl">
-      tempo
+      <span class="note-eq">&#x2669; =</span>
       <input id="tempo" type="number" min="40" max="300" step="1" value="120">
-      <span class="unit">bpm</span>
+    </label>
+    <label class="ctl">
+      note
+      <input id="subdiv" type="range" min="0" max="3" step="1" value="0">
+      <span id="subdiv-val" class="subdiv-val">&#x2669; quarter</span>
+    </label>
+    <label class="switch">
+      <input id="loop" type="checkbox">
+      <span class="track"><span class="thumb"></span></span>
+      loop
     </label>
     <label class="ctl">
       articulation

--- a/scales.js
+++ b/scales.js
@@ -64,6 +64,16 @@ const { pitchToMidi } = AudioKit;
 let autoDescend = false;
 let tempoBpm = 120;
 let articulation = 'legato';
+let loopOn = false;
+
+// Note value per beat: how many scale notes fit in one quarter-note beat.
+let subdivIndex = 0;
+const SUBDIVS = [
+  { label: '♩', name: 'quarter',   perBeat: 1 },
+  { label: '♪', name: 'eighth',    perBeat: 2 },
+  { label: '♪³', name: 'triplet',  perBeat: 3 },
+  { label: '♬', name: 'sixteenth', perBeat: 4 },
+];
 
 // gate = fraction of the beat the note sounds; sustain = held level (0 = plucked,
 // for staccato); atk/release = envelope edges. Tuned so legato actually connects.
@@ -96,7 +106,7 @@ const seqUpDown = (mode) => {
 };
 
 function playSequence(baseMidi, seq, rowReadout) {
-  const step = 60 / tempoBpm;
+  const step = (60 / tempoBpm) / SUBDIVS[subdivIndex].perBeat;
   const art = ARTIC[articulation] || ARTIC.legato;
   const preferFlats = CIRCLE[selectedIndex].sig < 0;
   const center = document.getElementById('playing-note');
@@ -117,6 +127,7 @@ function playSequence(baseMidi, seq, rowReadout) {
     onEnd: () => {
       if (center) center.textContent = '';
       if (rowReadout) rowReadout.textContent = '';
+      if (loopOn) playSequence(baseMidi, seq, rowReadout);
     },
   });
 }
@@ -328,6 +339,23 @@ function initScaleOptions() {
     const v = parseInt(tempo.value, 10);
     if (Number.isFinite(v) && v > 0) tempoBpm = v;
   });
+
+  const subdiv = document.getElementById('subdiv');
+  const subdivVal = document.getElementById('subdiv-val');
+  const showSubdiv = () => {
+    const s = SUBDIVS[subdivIndex];
+    subdivVal.textContent = `${s.label} ${s.name}`;
+  };
+  subdivIndex = parseInt(subdiv.value, 10);
+  showSubdiv();
+  subdiv.addEventListener('input', () => {
+    subdivIndex = parseInt(subdiv.value, 10);
+    showSubdiv();
+  });
+
+  const loop = document.getElementById('loop');
+  loopOn = loop.checked;
+  loop.addEventListener('change', () => { loopOn = loop.checked; });
 
   const artic = document.getElementById('articulation');
   articulation = artic.value;

--- a/scales.js
+++ b/scales.js
@@ -95,19 +95,29 @@ const seqUpDown = (mode) => {
   return up.concat(down.slice(0, -1).reverse());
 };
 
-function playSequence(baseMidi, seq) {
+function playSequence(baseMidi, seq, rowReadout) {
   const step = 60 / tempoBpm;
   const art = ARTIC[articulation] || ARTIC.legato;
   const preferFlats = CIRCLE[selectedIndex].sig < 0;
-  const readout = document.getElementById('playing-note');
+  const center = document.getElementById('playing-note');
+  // clear the center and any row readouts left over from a previous run
+  if (center) center.textContent = '';
+  document.querySelectorAll('.note-readout').forEach(el => { el.textContent = ''; });
   AudioKit.playSequence(baseMidi, seq, {
     step,
     gate: step * art.gate,
     attack: art.atk,
     sustain: art.sustain,
     release: art.release,
-    onNote: (semi) => { if (readout) readout.textContent = AudioKit.midiToName(baseMidi + semi, preferFlats); },
-    onEnd: () => { if (readout) readout.textContent = ''; },
+    onNote: (semi) => {
+      const name = AudioKit.midiToName(baseMidi + semi, preferFlats);
+      if (center) center.textContent = name;
+      if (rowReadout) rowReadout.textContent = name;
+    },
+    onEnd: () => {
+      if (center) center.textContent = '';
+      if (rowReadout) rowReadout.textContent = '';
+    },
   });
 }
 
@@ -259,16 +269,19 @@ function buildModes() {
     name.className = 'mode-name';
     const display = mode.basicName || mode.name;
     name.textContent = `${label} ${display}`;
+    // Per-row note readout, in case the circle is scrolled off-screen.
+    const readout = document.createElement('span');
+    readout.className = 'note-readout';
     const asc = document.createElement('button');
     asc.type = 'button';
     asc.textContent = autoDescend ? '▲▼ up + down' : '▲ ascending';
     asc.addEventListener('click', () =>
-      playSequence(base, autoDescend ? seqUpDown(mode) : seqAsc(mode)));
+      playSequence(base, autoDescend ? seqUpDown(mode) : seqAsc(mode), readout));
     const desc = document.createElement('button');
     desc.type = 'button';
     desc.textContent = '▼ descending';
-    desc.addEventListener('click', () => playSequence(base, seqDesc(mode)));
-    row.append(name, asc, desc);
+    desc.addEventListener('click', () => playSequence(base, seqDesc(mode), readout));
+    row.append(name, readout, asc, desc);
     wrap.appendChild(row);
   });
 }


### PR DESCRIPTION
## Summary
Two scales-page improvements:

1. **Per-row note readout** — the currently-playing note also appears just left of each row's ascending button (only the row being played updates), so the sounding note stays visible when the circle of fifths is scrolled off-screen.
2. **Tempo marking** — the tempo field now reads as a musical marking `♩ = N` instead of "tempo … bpm".
3. **Note-value slider** — a new up/down slider sets how many notes play per beat: quarter (♩), eighth (♪), triplet (♪³), or sixteenth (♬).
4. **Loop toggle** — a slide switch that repeats the scale until switched off.

## Verification (headless Chromium)
- Per-row readout updates only on the played row and clears at the end; no page errors.
- Tempo label renders `♩ =`; note spacing at 120 bpm measured 504 / 256 / 160 / 128 ms for quarter / eighth / triplet / sixteenth.
- Loop repeats (tonic reappeared 11× in 2.5s at a fast setting) and stops cleanly after the current pass when toggled off.
- Controls lay out as `octaves | ♩ = 120 | note ▭ ♩ quarter | loop | articulation | play down after up`.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_