### PR TITLE
Scales: stop-on-retrigger, loop turnaround option, pentatonics, readout fit

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -33,8 +33,30 @@ const AudioKit = (() => {
 
   // One AudioContext shared across scale playbacks (the drone makes its own).
   let seqCtx = null;
-  // Pending visual-callback timers, cleared when a new sequence starts.
+  // Pending visual-callback timers, cleared when a sequence is stopped/replaced.
   let seqTimers = [];
+  // Oscillators currently scheduled, so a new (or stopped) sequence can silence
+  // them instead of layering a second scale on top of the first.
+  let activeVoices = [];
+
+  // Stop the current scale: cancel pending visual callbacks and fade out any
+  // scheduled oscillators. Safe to call when nothing is playing.
+  function stopSequence() {
+    seqTimers.forEach(id => clearTimeout(id));
+    seqTimers = [];
+    if (seqCtx) {
+      const now = seqCtx.currentTime;
+      activeVoices.forEach(({ osc, gain }) => {
+        try {
+          gain.gain.cancelScheduledValues(now);
+          gain.gain.setValueAtTime(Math.max(gain.gain.value, 0.0001), now);
+          gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.05);
+          osc.stop(now + 0.06);
+        } catch (e) {}
+      });
+    }
+    activeVoices = [];
+  }
 
   // The shared "cello-ish" voice: a sawtooth shaped by a gentle lowpass and
   // three formant peaks. Connect a source into `input`; take `output`. Used by
@@ -70,9 +92,8 @@ const AudioKit = (() => {
     const release = opts.release != null ? opts.release : 0.05;
     const onNote = typeof opts.onNote === 'function' ? opts.onNote : null;
     const onEnd = typeof opts.onEnd === 'function' ? opts.onEnd : null;
-    // Drop any visual callbacks still pending from a previous sequence.
-    seqTimers.forEach(id => clearTimeout(id));
-    seqTimers = [];
+    // Never layer a second scale over the first: stop whatever's playing.
+    stopSequence();
     const now = ctx.currentTime;
     const start = now + 0.05;
     seq.forEach((semi, i) => {
@@ -97,6 +118,7 @@ const AudioKit = (() => {
       voice.output.connect(gain).connect(ctx.destination);
       osc.start(t);
       osc.stop(t + gate + 0.05);
+      activeVoices.push({ osc, gain });
       if (onNote) seqTimers.push(setTimeout(() => onNote(semi, i), Math.max(0, (t - now) * 1000)));
     });
     if (onEnd) {
@@ -187,5 +209,5 @@ const AudioKit = (() => {
     };
   }
 
-  return { FIFTH_RATIO, midiToFreq, pitchToMidi, midiToName, playSequence, createDrone };
+  return { FIFTH_RATIO, midiToFreq, pitchToMidi, midiToName, playSequence, stopSequence, createDrone };
 })();

--- a/scales.html
+++ b/scales.html
@@ -179,13 +179,16 @@
     }
     .mode-name {
       flex: 1 1 11rem;
+      min-width: 0;
       font-size: 1.2rem;
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.6em;
     }
     .note-readout {
-      min-width: 2.2em;
-      text-align: right;
+      flex: 0 0 auto;
       color: #9cd8ff;
-      font-size: 1.2rem;
     }
 
     button {
@@ -198,6 +201,7 @@
       cursor: pointer;
     }
     button:hover { border-color: #9cd8ff; color: #fff; }
+    button.playing { border-color: #9cd8ff; color: #9cd8ff; background: rgba(156, 216, 255, 0.12); }
 
     .drone {
       display: flex;
@@ -315,6 +319,11 @@
       <input id="loop" type="checkbox">
       <span class="track"><span class="thumb"></span></span>
       loop
+    </label>
+    <label class="switch">
+      <input id="repeat-ends" type="checkbox">
+      <span class="track"><span class="thumb"></span></span>
+      repeat top &amp; bottom
     </label>
     <label class="ctl">
       articulation

--- a/scales.js
+++ b/scales.js
@@ -48,6 +48,8 @@ const MODES = [
   { name: 'Lydian',                  group: 'mode',  intervals: [0, 2, 4, 6, 7, 9, 11, 12] },
   { name: 'Mixolydian',              group: 'mode',  intervals: [0, 2, 4, 5, 7, 9, 10, 12] },
   { name: 'Locrian',                 group: 'mode',  intervals: [0, 1, 3, 5, 6, 8, 10, 12] },
+  { name: 'Major pentatonic',        group: 'other', intervals: [0, 2, 4, 7, 9, 12] },
+  { name: 'Minor pentatonic',        group: 'other', intervals: [0, 3, 5, 7, 10, 12] },
   { name: 'Whole tone',              group: 'other', intervals: [0, 2, 4, 6, 8, 10, 12] },
   { name: 'Chromatic',               group: 'other', intervals: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] },
 ];
@@ -65,6 +67,8 @@ let autoDescend = false;
 let tempoBpm = 120;
 let articulation = 'legato';
 let loopOn = false;
+let repeatEnds = false; // when looping, repeat the turnaround (top/bottom) notes
+let playingButton = null; // the play button whose scale is currently sounding
 
 // Note value per beat: how many scale notes fit in one quarter-note beat.
 let subdivIndex = 0;
@@ -105,15 +109,42 @@ const seqUpDown = (mode) => {
   return up.concat(down.slice(0, -1).reverse());
 };
 
-function playSequence(baseMidi, seq, rowReadout) {
+function clearReadouts() {
+  const center = document.getElementById('playing-note');
+  if (center) center.textContent = '';
+  document.querySelectorAll('.note-readout').forEach(el => { el.textContent = ''; });
+}
+
+// Stop whatever scale is sounding and reset the play-button state.
+function stopPlayback() {
+  AudioKit.stopSequence();
+  if (playingButton) playingButton.classList.remove('playing');
+  playingButton = null;
+  clearReadouts();
+}
+
+// Click handler for a play button: toggles stop if it's already this button's
+// scale, otherwise switches to the new scale (never stacks two at once).
+function togglePlay(button, baseMidi, makeSeq, rowReadout) {
+  if (playingButton === button) { stopPlayback(); return; }
+  if (playingButton) playingButton.classList.remove('playing');
+  playingButton = button;
+  button.classList.add('playing');
+  runSequence(baseMidi, makeSeq, rowReadout);
+}
+
+function runSequence(baseMidi, makeSeq, rowReadout) {
+  const seq = makeSeq();
   const step = (60 / tempoBpm) / SUBDIVS[subdivIndex].perBeat;
   const art = ARTIC[articulation] || ARTIC.legato;
   const preferFlats = CIRCLE[selectedIndex].sig < 0;
   const center = document.getElementById('playing-note');
-  // clear the center and any row readouts left over from a previous run
-  if (center) center.textContent = '';
-  document.querySelectorAll('.note-readout').forEach(el => { el.textContent = ''; });
-  AudioKit.playSequence(baseMidi, seq, {
+  clearReadouts();
+  // When looping without repeating the turnaround, drop a trailing note that
+  // duplicates the first (e.g. up-then-down) so the bottom isn't struck twice.
+  const noRepeat = loopOn && !repeatEnds && seq.length > 1 && seq[0] === seq[seq.length - 1];
+  const toPlay = noRepeat ? seq.slice(0, -1) : seq;
+  AudioKit.playSequence(baseMidi, toPlay, {
     step,
     gate: step * art.gate,
     attack: art.atk,
@@ -125,9 +156,11 @@ function playSequence(baseMidi, seq, rowReadout) {
       if (rowReadout) rowReadout.textContent = name;
     },
     onEnd: () => {
-      if (center) center.textContent = '';
-      if (rowReadout) rowReadout.textContent = '';
-      if (loopOn) playSequence(baseMidi, seq, rowReadout);
+      if (loopOn && playingButton) {
+        runSequence(baseMidi, makeSeq, rowReadout); // re-evaluate trim/options each pass
+      } else {
+        stopPlayback();
+      }
     },
   });
 }
@@ -259,6 +292,7 @@ function renderKeySig() {
 }
 
 function buildModes() {
+  stopPlayback(); // rebuilding replaces the buttons; don't leave an orphan scale
   const root = CIRCLE[selectedIndex].root;
   const label = CIRCLE[selectedIndex].label;
   const base = pitchToMidi(root, 4);
@@ -278,21 +312,25 @@ function buildModes() {
     row.className = 'mode-row';
     const name = document.createElement('span');
     name.className = 'mode-name';
+    const labelEl = document.createElement('span');
+    labelEl.className = 'mode-label';
     const display = mode.basicName || mode.name;
-    name.textContent = `${label} ${display}`;
-    // Per-row note readout, in case the circle is scrolled off-screen.
+    labelEl.textContent = `${label} ${display}`;
+    // Per-row note readout, shown in the empty space before the button so the
+    // sounding note stays visible when the circle is scrolled off-screen.
     const readout = document.createElement('span');
     readout.className = 'note-readout';
+    name.append(labelEl, readout);
     const asc = document.createElement('button');
     asc.type = 'button';
     asc.textContent = autoDescend ? '▲▼ up + down' : '▲ ascending';
     asc.addEventListener('click', () =>
-      playSequence(base, autoDescend ? seqUpDown(mode) : seqAsc(mode), readout));
+      togglePlay(asc, base, () => (autoDescend ? seqUpDown(mode) : seqAsc(mode)), readout));
     const desc = document.createElement('button');
     desc.type = 'button';
     desc.textContent = '▼ descending';
-    desc.addEventListener('click', () => playSequence(base, seqDesc(mode), readout));
-    row.append(name, readout, asc, desc);
+    desc.addEventListener('click', () => togglePlay(desc, base, () => seqDesc(mode), readout));
+    row.append(name, asc, desc);
     wrap.appendChild(row);
   });
 }
@@ -356,6 +394,10 @@ function initScaleOptions() {
   const loop = document.getElementById('loop');
   loopOn = loop.checked;
   loop.addEventListener('change', () => { loopOn = loop.checked; });
+
+  const repeat = document.getElementById('repeat-ends');
+  repeatEnds = repeat.checked;
+  repeat.addEventListener('change', () => { repeatEnds = repeat.checked; });
 
   const artic = document.getElementById('articulation');
   articulation = artic.value;


### PR DESCRIPTION
## Summary
- **Stop on retrigger / no stacking** — pressing a play button again stops that scale, and starting another scale stops the first instead of layering audio. `AudioKit` gained `stopSequence()` plus active-voice tracking; `playSequence` stops any current voices before scheduling.
- **Loop turnaround option** — new "repeat top & bottom" toggle. When **off** (default), a looped up-and-down scale no longer strikes the bottom note twice at the loop seam (the duplicated trailing tonic is dropped). When **on**, the full sequence repeats.
- **Pentatonic scales** — added major and minor pentatonic (under "show additional scales").
- **Readout fit** — the per-row playing-note readout now sits in the empty space inside the name box, so it no longer widens the row.

## Verification (headless Chromium)
- Pentatonic rows present: `C Major pentatonic`, `C Minor pentatonic`.
- Toggle-stop: button shows playing after 1st press, stops on 2nd (center cleared). Switching scales leaves exactly one button active.
- Loop seam: up+down + loop + repeat OFF → played seq `first=0, last=2` (bottom not doubled); repeat ON → `first=0, last=0`; no-loop → full sequence `last=0`.
- Row geometry unchanged: row width 460px, readout right edge == name box right edge.
- No page errors; controls lay out as `octaves | ♩ = 120 | note ▭ quarter | loop | repeat top & bottom | articulation | play down after up`.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_