### PR TITLE
Apply "repeat top & bottom" immediately to a running loop

### DIFF
--- a/scales.js
+++ b/scales.js
@@ -69,6 +69,7 @@ let articulation = 'legato';
 let loopOn = false;
 let repeatEnds = false; // when looping, repeat the turnaround (top/bottom) notes
 let playingButton = null; // the play button whose scale is currently sounding
+let currentPlay = null; // { baseMidi, makeSeq, rowReadout } for re-triggering a loop
 
 // Note value per beat: how many scale notes fit in one quarter-note beat.
 let subdivIndex = 0;
@@ -120,6 +121,7 @@ function stopPlayback() {
   AudioKit.stopSequence();
   if (playingButton) playingButton.classList.remove('playing');
   playingButton = null;
+  currentPlay = null;
   clearReadouts();
 }
 
@@ -130,7 +132,16 @@ function togglePlay(button, baseMidi, makeSeq, rowReadout) {
   if (playingButton) playingButton.classList.remove('playing');
   playingButton = button;
   button.classList.add('playing');
+  currentPlay = { baseMidi, makeSeq, rowReadout };
   runSequence(baseMidi, makeSeq, rowReadout);
+}
+
+// Re-trigger the current looping scale so a toggled option takes effect now
+// instead of only after a manual stop/restart.
+function restartIfLooping() {
+  if (playingButton && loopOn && currentPlay) {
+    runSequence(currentPlay.baseMidi, currentPlay.makeSeq, currentPlay.rowReadout);
+  }
 }
 
 function runSequence(baseMidi, makeSeq, rowReadout) {
@@ -397,7 +408,10 @@ function initScaleOptions() {
 
   const repeat = document.getElementById('repeat-ends');
   repeatEnds = repeat.checked;
-  repeat.addEventListener('change', () => { repeatEnds = repeat.checked; });
+  repeat.addEventListener('change', () => {
+    repeatEnds = repeat.checked;
+    restartIfLooping(); // apply immediately to a running loop
+  });
 
   const artic = document.getElementById('articulation');
   articulation = artic.value;


### PR DESCRIPTION
## Summary
Toggling **"repeat top & bottom"** while a scale is looping now re-triggers the current loop immediately, so the change takes effect at once instead of only after a manual stop/restart (and even then, because the difference is at the loop seam, it previously took a couple of passes to surface).

## Verification (headless Chromium)
- Looping up+down with repeat OFF plays the trimmed sequence (`last=2`).
- Toggling repeat ON mid-loop re-triggers within ~0.75s (vs a ~3.5s pass) and the played sequence becomes full (`last=0`).
- Toggling back OFF re-triggers trimmed again (`last=2`).
- No page errors.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_