### PR TITLE
Default scale tempo to 112 bpm

### DIFF
--- a/scales.html
+++ b/scales.html
@@ -308,7 +308,7 @@
     </label>
     <label class="ctl">
       <span class="note-eq">&#x2669; =</span>
-      <input id="tempo" type="number" min="40" max="300" step="1" value="120">
+      <input id="tempo" type="number" min="40" max="300" step="1" value="112">
     </label>
     <label class="ctl">
       note

--- a/scales.js
+++ b/scales.js
@@ -64,7 +64,7 @@ const { pitchToMidi } = AudioKit;
 
 // --- scale playback ---
 let autoDescend = false;
-let tempoBpm = 120;
+let tempoBpm = 112;
 let articulation = 'legato';
 let loopOn = false;
 let repeatEnds = false; // when looping, repeat the turnaround (top/bottom) notes


### PR DESCRIPTION
Sets the default quarter-note tempo (♩ =) on the scales page to 112 bpm (was 120).

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_