### PR TITLE
Gapless scale looping + smoother articulation continuum

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -74,15 +74,25 @@ const AudioKit = (() => {
     return { input: lp, output: fC };
   }
 
+  // Current audio-clock time (creates the shared context if needed). Lets the
+  // caller schedule contiguous loop passes against the same timeline.
+  function currentTime() {
+    if (!seqCtx) seqCtx = new (window.AudioContext || window.webkitAudioContext)();
+    return seqCtx.currentTime;
+  }
+
   // Plays a sequence of semitone offsets from baseMidi using the cello voice.
   // opts: step (onset spacing, s), gate (sounding length, s), attack (s),
   // peak (gain), sustain (0 = plucked decay over the whole gate; >0 = hold at
   // that fraction of peak until a short release — needed for legato/portato),
   // release (release length, s), onNote(semi, i) fired as each note sounds,
-  // onEnd() fired after the last note finishes.
+  // when (absolute audio-clock start time; default = now + 0.05), chain (true =
+  // keep the previous sequence's voices instead of stopping them, for gapless
+  // looping). Returns the audio-clock time the next contiguous note would start
+  // (= start + seq.length * step), so a loop can schedule the next pass exactly.
   function playSequence(baseMidi, seq, opts = {}) {
     if (!seqCtx) seqCtx = new (window.AudioContext || window.webkitAudioContext)();
-    if (seqCtx.state === 'suspended') seqCtx.resume();
+    if (seqCtx.state === 'suspended') { try { seqCtx.resume(); } catch (e) {} }
     const ctx = seqCtx;
     const step = opts.step != null ? opts.step : 0.42;
     const gate = Math.max(opts.gate != null ? opts.gate : step * 0.92, 0.04);
@@ -91,11 +101,10 @@ const AudioKit = (() => {
     const sustain = opts.sustain != null ? opts.sustain : 0;
     const release = opts.release != null ? opts.release : 0.05;
     const onNote = typeof opts.onNote === 'function' ? opts.onNote : null;
-    const onEnd = typeof opts.onEnd === 'function' ? opts.onEnd : null;
-    // Never layer a second scale over the first: stop whatever's playing.
-    stopSequence();
+    // Never layer a second scale over the first, unless chaining a loop pass.
+    if (!opts.chain) stopSequence();
     const now = ctx.currentTime;
-    const start = now + 0.05;
+    const start = opts.when != null ? Math.max(opts.when, now) : now + 0.05;
     seq.forEach((semi, i) => {
       const t = start + i * step;
       const osc = ctx.createOscillator();
@@ -118,13 +127,18 @@ const AudioKit = (() => {
       voice.output.connect(gain).connect(ctx.destination);
       osc.start(t);
       osc.stop(t + gate + 0.05);
-      activeVoices.push({ osc, gain });
-      if (onNote) seqTimers.push(setTimeout(() => onNote(semi, i), Math.max(0, (t - now) * 1000)));
+      const rec = { osc, gain };
+      activeVoices.push(rec);
+      osc.onended = () => { const k = activeVoices.indexOf(rec); if (k >= 0) activeVoices.splice(k, 1); };
+      if (onNote) {
+        const id = setTimeout(() => {
+          const k = seqTimers.indexOf(id); if (k >= 0) seqTimers.splice(k, 1);
+          onNote(semi, i);
+        }, Math.max(0, (t - now) * 1000));
+        seqTimers.push(id);
+      }
     });
-    if (onEnd) {
-      const endT = start + (seq.length - 1) * step + gate;
-      seqTimers.push(setTimeout(onEnd, Math.max(0, (endT - now) * 1000)));
-    }
+    return start + seq.length * step;
   }
 
   // Sustained root with an optional perfect fifth. A sub-audible noise layer
@@ -209,5 +223,5 @@ const AudioKit = (() => {
     };
   }
 
-  return { FIFTH_RATIO, midiToFreq, pitchToMidi, midiToName, playSequence, stopSequence, createDrone };
+  return { FIFTH_RATIO, midiToFreq, pitchToMidi, midiToName, playSequence, stopSequence, currentTime, createDrone };
 })();

--- a/scales.js
+++ b/scales.js
@@ -70,6 +70,7 @@ let loopOn = false;
 let repeatEnds = false; // when looping, repeat the turnaround (top/bottom) notes
 let playingButton = null; // the play button whose scale is currently sounding
 let currentPlay = null; // { baseMidi, makeSeq, rowReadout } for re-triggering a loop
+let loopTimerId = null; // pending timer that schedules the next loop pass
 
 // Note value per beat: how many scale notes fit in one quarter-note beat.
 let subdivIndex = 0;
@@ -80,12 +81,13 @@ const SUBDIVS = [
   { label: '♬', name: 'sixteenth', perBeat: 4 },
 ];
 
-// gate = fraction of the beat the note sounds; sustain = held level (0 = plucked,
-// for staccato); atk/release = envelope edges. Tuned so legato actually connects.
+// gate = fraction of the beat the note sounds; sustain = held level; atk/release
+// = envelope edges. A smooth continuum: staccato is gently detached (not clipped),
+// portato sits midway, legato fully connects.
 const ARTIC = {
-  staccato: { gate: 0.32, atk: 0.004, sustain: 0,    release: 0.04 },
-  portato:  { gate: 0.62, atk: 0.010, sustain: 0.55, release: 0.06 },
-  legato:   { gate: 1.0,  atk: 0.025, sustain: 0.9,  release: 0.06 },
+  staccato: { gate: 0.60, atk: 0.008, sustain: 0.50, release: 0.05 },
+  portato:  { gate: 0.80, atk: 0.015, sustain: 0.70, release: 0.06 },
+  legato:   { gate: 1.0,  atk: 0.025, sustain: 0.90, release: 0.06 },
 };
 
 // Expand a one-octave interval set (ending on 12) across `octaves` octaves,
@@ -116,13 +118,20 @@ function clearReadouts() {
   document.querySelectorAll('.note-readout').forEach(el => { el.textContent = ''; });
 }
 
-// Stop whatever scale is sounding and reset the play-button state.
-function stopPlayback() {
-  AudioKit.stopSequence();
+// Reset the play-button/UI state without cancelling audio (lets the last note
+// ring out naturally at the end of a pass).
+function finishPlayback() {
+  if (loopTimerId) { clearTimeout(loopTimerId); loopTimerId = null; }
   if (playingButton) playingButton.classList.remove('playing');
   playingButton = null;
   currentPlay = null;
   clearReadouts();
+}
+
+// User-initiated stop: silence any scheduled notes and reset.
+function stopPlayback() {
+  AudioKit.stopSequence();
+  finishPlayback();
 }
 
 // Click handler for a play button: toggles stop if it's already this button's
@@ -130,50 +139,66 @@ function stopPlayback() {
 function togglePlay(button, baseMidi, makeSeq, rowReadout) {
   if (playingButton === button) { stopPlayback(); return; }
   if (playingButton) playingButton.classList.remove('playing');
+  if (loopTimerId) { clearTimeout(loopTimerId); loopTimerId = null; }
   playingButton = button;
   button.classList.add('playing');
   currentPlay = { baseMidi, makeSeq, rowReadout };
-  runSequence(baseMidi, makeSeq, rowReadout);
+  clearReadouts();
+  schedulePass(baseMidi, makeSeq, rowReadout, null, false);
 }
 
 // Re-trigger the current looping scale so a toggled option takes effect now
 // instead of only after a manual stop/restart.
 function restartIfLooping() {
   if (playingButton && loopOn && currentPlay) {
-    runSequence(currentPlay.baseMidi, currentPlay.makeSeq, currentPlay.rowReadout);
+    if (loopTimerId) { clearTimeout(loopTimerId); loopTimerId = null; }
+    clearReadouts();
+    schedulePass(currentPlay.baseMidi, currentPlay.makeSeq, currentPlay.rowReadout, null, false);
   }
 }
 
-function runSequence(baseMidi, makeSeq, rowReadout) {
+// Play one pass, then either schedule the next pass exactly on the audio clock
+// (gapless loop) or finish. `when` is the absolute start time (null = default
+// lead-in); `chain` keeps the previous pass's tail so the seam is seamless.
+function schedulePass(baseMidi, makeSeq, rowReadout, when, chain) {
   const seq = makeSeq();
   const step = (60 / tempoBpm) / SUBDIVS[subdivIndex].perBeat;
   const art = ARTIC[articulation] || ARTIC.legato;
   const preferFlats = CIRCLE[selectedIndex].sig < 0;
   const center = document.getElementById('playing-note');
-  clearReadouts();
   // When looping without repeating the turnaround, drop a trailing note that
   // duplicates the first (e.g. up-then-down) so the bottom isn't struck twice.
   const noRepeat = loopOn && !repeatEnds && seq.length > 1 && seq[0] === seq[seq.length - 1];
   const toPlay = noRepeat ? seq.slice(0, -1) : seq;
-  AudioKit.playSequence(baseMidi, toPlay, {
+  const nextStart = AudioKit.playSequence(baseMidi, toPlay, {
     step,
     gate: step * art.gate,
     attack: art.atk,
     sustain: art.sustain,
     release: art.release,
+    when,
+    chain,
     onNote: (semi) => {
       const name = AudioKit.midiToName(baseMidi + semi, preferFlats);
       if (center) center.textContent = name;
       if (rowReadout) rowReadout.textContent = name;
     },
-    onEnd: () => {
-      if (loopOn && playingButton) {
-        runSequence(baseMidi, makeSeq, rowReadout); // re-evaluate trim/options each pass
-      } else {
-        stopPlayback();
-      }
-    },
   });
+  if (loopOn) {
+    // Set up the next pass a touch before the seam so its notes are scheduled
+    // ahead of time and the loop stays perfectly continuous.
+    const lead = Math.min(0.1, toPlay.length * step * 0.5);
+    const delay = Math.max(0, (nextStart - lead - AudioKit.currentTime()) * 1000);
+    loopTimerId = setTimeout(() => {
+      if (loopOn && playingButton) {
+        schedulePass(baseMidi, makeSeq, rowReadout, nextStart, true);
+      } else {
+        loopTimerId = setTimeout(finishPlayback, Math.max(0, (nextStart - AudioKit.currentTime()) * 1000));
+      }
+    }, delay);
+  } else {
+    loopTimerId = setTimeout(finishPlayback, Math.max(0, (nextStart - AudioKit.currentTime()) * 1000));
+  }
 }
 
 // --- drone (root + optional fifth), shared engine in audio.js ---


### PR DESCRIPTION
## Summary
- **Gapless looping** — loop passes are now scheduled at exact contiguous times on the audio clock (`playSequence` gained `when`/`chain` and returns the next contiguous start time; the scales page schedules the next pass slightly ahead of the seam). The seam between passes now equals the normal note spacing for **every** articulation.
  - Fixes the legato "slight pause" between last and first note.
  - Fixes the staccato seam feeling "too short" (the old replay timed off `gate`, so short articulations rushed the loop point).
- **Smoother articulation continuum** — staccato is now gently detached with body (was clipped/plucked), portato sits midway, legato fully connects:
  - staccato `gate 0.60 / sustain 0.50` (≈ the old portato)
  - portato `gate 0.80 / sustain 0.70` (halfway between staccato and legato)
  - legato `gate 1.0 / sustain 0.90` (unchanged)
- Active voices and visual timers now self-prune; `resume()` is guarded.

## Verification (headless Chromium)
- Loop start grid captured: each pass's start exactly equals the prior pass's returned next-start (`contiguous`), and a clean three-pass measurement gives **seam = 0.125s = step** for both legato and staccato (seam spacing == normal note spacing).
- Staccato envelope now sustains: amplitude early≈late≈0.12 through the note, ~0 after — detached but not clipped.
- Toggle-stop and scale-switching still behave (one active button, no stacking); no page errors.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_