### PR TITLE
Reorder: play down after up between loop and repeat top &amp; bottom

### DIFF
--- a/scales.html
+++ b/scales.html
@@ -321,6 +321,11 @@
       loop
     </label>
     <label class="switch">
+      <input id="auto-descend" type="checkbox">
+      <span class="track"><span class="thumb"></span></span>
+      play down after up
+    </label>
+    <label class="switch">
       <input id="repeat-ends" type="checkbox">
       <span class="track"><span class="thumb"></span></span>
       repeat top &amp; bottom
@@ -332,11 +337,6 @@
         <option value="portato">portato</option>
         <option value="legato" selected>legato</option>
       </select>
-    </label>
-    <label class="switch">
-      <input id="auto-descend" type="checkbox">
-      <span class="track"><span class="thumb"></span></span>
-      play down after up
     </label>
   </div>
 


### PR DESCRIPTION
Moves the "play down after up" toggle to sit between "loop" and "repeat top & bottom" in the scales controls. HTML-only reorder; no logic or IDs changed.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_