### PR TITLE
Fit scale rows on one line on mobile

### DIFF
--- a/scales.html
+++ b/scales.html
@@ -202,6 +202,17 @@
     }
     button:hover { border-color: #9cd8ff; color: #fff; }
     button.playing { border-color: #9cd8ff; color: #9cd8ff; background: rgba(156, 216, 255, 0.12); }
+    .btn-label { margin-left: 0.4em; }
+
+    /* On phones, keep each scale row on one line: collapse the play buttons to
+       just their arrows so the name + ascending + descending + note all fit. */
+    @media (max-width: 600px) {
+      .mode-row { flex-wrap: nowrap; gap: 0.4rem; }
+      .mode-name { min-width: 0; }
+      .mode-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .mode-row button { padding: 0.35em 0.55em; }
+      .btn-label { display: none; }
+    }
 
     .drone {
       display: flex;

--- a/scales.js
+++ b/scales.js
@@ -359,16 +359,31 @@ function buildModes() {
     name.append(labelEl, readout);
     const asc = document.createElement('button');
     asc.type = 'button';
-    asc.textContent = autoDescend ? '▲▼ up + down' : '▲ ascending';
+    asc.append(makeArrow(autoDescend ? '▲▼' : '▲'), makeLabel(autoDescend ? 'up + down' : 'ascending'));
     asc.addEventListener('click', () =>
       togglePlay(asc, base, () => (autoDescend ? seqUpDown(mode) : seqAsc(mode)), readout));
     const desc = document.createElement('button');
     desc.type = 'button';
-    desc.textContent = '▼ descending';
+    desc.append(makeArrow('▼'), makeLabel('descending'));
     desc.addEventListener('click', () => togglePlay(desc, base, () => seqDesc(mode), readout));
     row.append(name, asc, desc);
     wrap.appendChild(row);
   });
+}
+
+// Build a play button's parts: the arrow always shows; the word label is hidden
+// on narrow screens (via CSS) so the row fits on one line on mobile.
+function makeArrow(glyph) {
+  const s = document.createElement('span');
+  s.className = 'btn-arrow';
+  s.textContent = glyph;
+  return s;
+}
+function makeLabel(text) {
+  const s = document.createElement('span');
+  s.className = 'btn-label';
+  s.textContent = text;
+  return s;
 }
 
 function initDroneControls() {


### PR DESCRIPTION
## Summary
Fixes scale rows wrapping on mobile. On narrow screens (≤600px) the play buttons collapse to just their arrows (▲ / ▼ / ▲▼) so the scale name, ascending button, descending button, and note readout all fit on a single line. Full word labels ("ascending"/"descending"/"up + down") remain on wider screens.

Implementation: each button's arrow and word are now separate spans; a mobile media query hides the word span, keeps the row `nowrap`, tightens button padding, and gives the name an ellipsis safety net.

## Verification (headless Chromium)
- Mobile 390px: 12 rows, **no wrapping** (all single-line, 43px tall), arrow-only buttons, even for the longest names (e.g. "C Major pentatonic").
- Desktop 1000px: no wrapping, **full word labels shown**.
- Screenshot confirms clean single-line rows with the note readout fitting between name and arrows; no page errors.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_