### PR TITLE
Add harmonic minor under other scales

### DIFF
--- a/scales.js
+++ b/scales.js
@@ -51,6 +51,7 @@ const MODES = [
   { name: 'Lydian',                  group: 'mode',  intervals: [0, 2, 4, 6, 7, 9, 11, 12], letterSteps: [0, 1, 2, 3, 4, 5, 6, 7] },
   { name: 'Mixolydian',              group: 'mode',  intervals: [0, 2, 4, 5, 7, 9, 10, 12], letterSteps: [0, 1, 2, 3, 4, 5, 6, 7] },
   { name: 'Locrian',                 group: 'mode',  intervals: [0, 1, 3, 5, 6, 8, 10, 12], letterSteps: [0, 1, 2, 3, 4, 5, 6, 7] },
+  { name: 'Harmonic minor',          group: 'other', intervals: [0, 2, 3, 5, 7, 8, 11, 12], letterSteps: [0, 1, 2, 3, 4, 5, 6, 7] },
   { name: 'Major pentatonic',        group: 'other', intervals: [0, 2, 4, 7, 9, 12], letterSteps: [0, 1, 2, 4, 5, 7] },
   { name: 'Minor pentatonic',        group: 'other', intervals: [0, 3, 5, 7, 10, 12], letterSteps: [0, 2, 3, 4, 6, 7] },
   { name: 'Whole tone',              group: 'other', intervals: [0, 2, 4, 6, 8, 10, 12], letterSteps: [0, 1, 2, 3, 4, 5, 7] },


### PR DESCRIPTION
Adds the harmonic minor scale (`[0,2,3,5,7,8,11]`) to the "other scales" group, with correct letter-based spelling.

## Verification (headless Chromium)
- Appears under the **other scales** group heading.
- A harmonic minor → A B C D E F G♯ A (correct raised 7th).
- C harmonic minor → C D E♭ F G A♭ B C.
- No page errors.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_