### PR TITLE
Score toolchain: auto-install LilyPond, workflow skill, allemande m.1 notations

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# SessionStart hook: make sure the score toolchain (LilyPond) is present so
+# `python3 tools/scores/build_scores.py` can rebuild the SVGs in scores/.
+# Runs only in the remote (web) environment; no-op once LilyPond is installed.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+bash "${CLAUDE_PROJECT_DIR:-.}/tools/scores/setup.sh"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/score-workflow/SKILL.md
+++ b/.claude/skills/score-workflow/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: score-workflow
+description: >-
+  How to add or edit the engraved sheet-music scores shown on the song page.
+  Use when transcribing a new piece's notes from IMSLP, or adding fingerings,
+  slurs, articulations, dynamics, bowings, or ornaments to an existing piece
+  from screen captures of a printed edition, then rebuilding the per-loop SVGs.
+  Triggers: "add fingerings/notations to the score", "transcribe the
+  allemande", "rebuild the scores", working in tools/scores/*.ly or scores/.
+---
+
+# Score workflow
+
+## How scores work here
+- **Source of truth** is LilyPond: `tools/scores/<piece>.ly`. Everything that
+  appears in the printed music lives there.
+- The files in `scores/<piece>/*.svg` are **build artifacts** — never hand-edit
+  them; they are regenerated.
+- `songs.json` drives the slicing: each loop's `label` (e.g. `"mm 4-6"`) and
+  `score` path tell `tools/scores/build_scores.py` which measures to render into
+  which SVG.
+- Provenance and build notes live in `tools/scores/README.md`.
+
+## Prerequisite: LilyPond
+`build_scores.py` needs LilyPond. `tools/scores/setup.sh` installs it if missing;
+on Claude Code on the web the `SessionStart` hook (`.claude/`) runs it
+automatically. To check: `lilypond --version`.
+
+## Getting the notes (IMSLP)
+Transcribe pitches and rhythms from the public-domain IMSLP edition into a
+`\relative` LilyPond source. Record the edition/source in `tools/scores/README.md`.
+Keep **one measure per line** (see the hard constraint below).
+
+## Adding notations (fingerings, slurs, dynamics, …)
+Done a few measures at a time from screen captures of the edition being marked:
+
+1. The user sends a tight capture of one or two measures. (A single measure
+   crop is legible enough — that's the proven floor.)
+2. Read off the markings: fingerings, slurs/ties, staccato/accent/tenuto,
+   dynamics, ornaments (trill/mordent/turn), bowings (down/up).
+3. **Anchor to the known notes.** The `.ly` is ground truth — don't re-read
+   pitches; map each marking onto the note that's already there. If a mark seems
+   to land on a pitch that doesn't match the source, flag it rather than guess.
+4. Add with LilyPond syntax on the existing note, e.g.:
+   - fingering `-4` (on a chord note: `<b d, g,-4>`)
+   - dynamics `\f \p \mf \cresc \!`
+   - articulations `-.` (staccato) `->` (accent) `-_` (tenuto)
+   - bowings `\downbow` `\upbow`; trill `\trill`
+   - force a fingering below: `\once \set fingeringOrientations = #'(down)`
+     (must stay on the measure's line — see below)
+5. Treat each batch as a first pass the user verifies; small marks are
+   error-prone. Confirm ambiguous spots (e.g. which note of a chord) before moving on.
+
+## HARD CONSTRAINT: one measure per line
+`build_scores.py` splits the music **by line = by measure**. Any
+`\set` / `\once` / `\override` must sit on the **same line** as the measure it
+applies to. A statement on its own line is counted as an extra measure and
+shifts every later index, corrupting all the SVGs.
+
+## Rebuild and verify
+```
+python3 tools/scores/build_scores.py
+```
+Then verify:
+- `git status` should show **only the SVG(s) you intended to change**. If other
+  `mm-*.svg` files changed, a measure boundary shifted — fix the source (usually
+  a stray line break) and rebuild.
+- Eyeball the changed SVG against the edition. To view it: serve the repo
+  (`python3 -m http.server 8137`) and open `scores/<piece>/<file>.svg`, or render
+  it to a PNG (embed in an `<img>` at a fixed width and screenshot — a raw SVG
+  `fullPage` screenshot can hang).
+
+Work and verify a couple measures at a time; don't batch the whole piece blind.

--- a/scores/allemande/mm-1-4.svg
+++ b/scores/allemande/mm-1-4.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="36.56mm" viewBox="-1.1267 -0.0000 103.5567 20.8036">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="40.88mm" viewBox="-1.1267 -0.0000 103.5567 23.2640">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
@@ -175,9 +175,6 @@ tspan { white-space: pre; }
 <g transform="translate(96.5892, 4.8560)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.9140" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(24.6869, 3.3560)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
 <g transform="translate(18.7212, 2.3560)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
@@ -189,6 +186,9 @@ tspan { white-space: pre; }
 </g>
 <g transform="translate(21.7691, 4.8560)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1496" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(24.6869, 3.3560)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(24.7519, 4.8560)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9782" ry="0.0400" fill="currentColor"/>
@@ -232,11 +232,19 @@ z" fill="currentColor"/>
 <g transform="translate(12.3810, 6.8560)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
+<g transform="translate(12.4014, 11.2911)">
+<path transform="scale(0.0040, -0.0040)" d="M253 245l-50 -163c-30 -99 -121 -255 -218 -255c-45 0 -87 27 -87 69c0 39 17 77 52 77c24 0 44 -20 44 -44c0 -30 -38 -24 -38 -54c0 -10 11 -11 23 -11h6c48 0 61 58 73 108l68 273h-49c-11 0 -19 8 -19 19s8 19 19 19h60c32 96 118 191 213 191c45 0 87 -27 87 -69
+c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-7c-62 0 -70 -88 -86 -154h55c11 0 19 -8 19 -19s-8 -19 -19 -19h-66z" fill="currentColor"/>
+</g>
 <g transform="translate(12.4460, 4.8560)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="6.9806" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.3342, 3.3560)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(12.5721, 9.0258)">
+<path transform="scale(0.0022, -0.0022)" d="M148 501c10 0 41 -15 72 -15c32 0 63 15 76 15c15 0 26 -11 26 -21c0 -4 -1 -7 -4 -10l-264 -291h134v4c0 60 50 41 75 85c7 11 8 24 14 36c3 7 10 10 17 10c11 0 24 -8 24 -25v-110h70c18 0 27 -14 27 -27s-9 -27 -27 -27h-70c2 -45 36 -82 80 -82c14 0 22 -10 22 -21
+s-8 -22 -22 -22c-49 0 -96 14 -145 14s-97 -14 -146 -14c-14 0 -21 11 -21 22s7 21 21 21c44 0 79 37 81 82h-134c-43 0 -57 25 -57 42c0 5 1 10 3 12c73 81 123 182 123 291c0 17 11 31 25 31z" fill="currentColor"/>
+</g>
+<g transform="translate(42.3992, 4.8560)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.5581" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(45.3171, 2.8560)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -244,8 +252,8 @@ z" fill="currentColor"/>
 <g transform="translate(45.3821, 4.8560)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.9144" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.3992, 4.8560)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.5581" ry="0.0400" fill="currentColor"/>
+<g transform="translate(42.3342, 3.3560)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(48.3000, 2.3560)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -262,308 +270,308 @@ z" fill="currentColor"/>
 <g transform="translate(55.5138, 1.3560)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(33.3856, 4.8560)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(36.4335, 4.8560)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.8454" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(33.4506, 4.8560)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.4891" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(36.4335, 4.8560)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.8454" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(36.3685, 4.3560)">
+<g transform="translate(33.3856, 4.8560)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(39.3513, 3.8560)">
+<g transform="translate(36.3685, 4.3560)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(39.4163, 4.8560)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.2018" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 18.0636)">
+<g transform="translate(39.3513, 3.8560)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 20.5240)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6502" y2="0"/>
 </g>
-<g transform="translate(0.0000, 17.0636)">
+<g transform="translate(0.0000, 19.5240)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6502" y2="0"/>
 </g>
-<g transform="translate(0.0000, 16.0636)">
+<g transform="translate(0.0000, 18.5240)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6502" y2="0"/>
 </g>
-<g transform="translate(0.0000, 15.0636)">
+<g transform="translate(0.0000, 17.5240)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6502" y2="0"/>
 </g>
-<g transform="translate(0.0000, 14.0636)">
+<g transform="translate(0.0000, 16.5240)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6502" y2="0"/>
 </g>
-<g transform="translate(0.0000, 13.0636)">
+<g transform="translate(0.0000, 15.5240)">
 <rect x="74.4040" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 13.0636)">
+<g transform="translate(0.0000, 15.5240)">
 <rect x="42.3829" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 13.0636)">
+<g transform="translate(0.0000, 15.5240)">
 <rect x="7.5740" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(47.2174, 16.0636)">
+<g transform="translate(47.2174, 18.5240)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(84.5102, 16.0636)">
+<g transform="translate(84.5102, 18.5240)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(55.6136, 16.0636)">
+<g transform="translate(55.6136, 18.5240)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.8760" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(60.3720, 16.0636)">
+<g transform="translate(60.3720, 18.5240)">
 <rect x="-0.0650" y="1.1861" width="0.1300" height="2.5901" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(60.3070, 17.0636)">
+<g transform="translate(60.3070, 19.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(58.1178, 16.0636)">
+<g transform="translate(58.1178, 18.5240)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="3.2518" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(58.0528, 16.0636)">
+<g transform="translate(58.0528, 18.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(67.5697, 18.0636)">
+<g transform="translate(67.5697, 20.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(62.8112, 17.0636)">
+<g transform="translate(62.8112, 19.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(62.8762, 16.0636)">
+<g transform="translate(62.8762, 18.5240)">
 <rect x="-0.0650" y="1.1861" width="0.1300" height="2.9659" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(65.0655, 18.0636)">
+<g transform="translate(65.0655, 20.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(65.1305, 16.0636)">
+<g transform="translate(65.1305, 18.5240)">
 <rect x="-0.0650" y="2.1861" width="0.1300" height="2.3041" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(72.2258, 19.2220)">
+<g transform="translate(72.2258, 21.6825)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="10.1068 -1.3584 10.1068 -0.9584 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(67.5697, 20.5636)">
+<g transform="translate(67.5697, 23.0240)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="14.7630 -1.8900 14.7630 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(48.5360, 13.5636)">
+<g transform="translate(48.5360, 16.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(48.6010, 16.0636)">
+<g transform="translate(48.6010, 18.5240)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="4.3236" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(55.5486, 16.0636)">
+<g transform="translate(55.5486, 18.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(50.7902, 14.5636)">
+<g transform="translate(50.7902, 17.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(50.8552, 16.0636)">
+<g transform="translate(50.8552, 18.5240)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.6619" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(53.2944, 14.5636)">
+<g transform="translate(53.2944, 17.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(53.3594, 16.0636)">
+<g transform="translate(53.3594, 18.5240)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.0377" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(82.2427, 14.5636)">
+<g transform="translate(82.2427, 17.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(82.3077, 16.0636)">
+<g transform="translate(82.3077, 18.5240)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1313" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 16.0636)">
+<g transform="translate(7.9000, 18.5240)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7594 -4.0450C2.5406 -4.9329 6.8827 -3.8268 8.0221 -2.1950L8.0221 -2.1950C6.8531 -3.7105 2.5109 -4.8166 0.7594 -4.0450z"/>
 </g>
-<g transform="translate(17.6669, 16.0636)">
+<g transform="translate(17.6669, 18.5240)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -2.5450C2.1296 -3.8263 6.4373 -3.8263 7.9147 -2.5450L7.9147 -2.5450C6.4373 -3.7063 2.1296 -3.7063 0.6521 -2.5450z"/>
 </g>
-<g transform="translate(27.1837, 16.0636)">
+<g transform="translate(27.1837, 18.5240)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4997 0.4550C1.5465 -1.4066 6.5003 -3.2613 8.5123 -2.5450L8.5123 -2.5450C6.5423 -3.1490 1.5886 -1.2942 0.4997 0.4550z"/>
 </g>
-<g transform="translate(7.9000, 17.0636)">
+<g transform="translate(7.9000, 19.5240)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.1195 -0.2000 17.1195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(7.9000, 17.8736)">
+<g transform="translate(7.9000, 20.3340)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.1195 -0.2000 17.1195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(37.7006, 16.0636)">
+<g transform="translate(37.7006, 18.5240)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -3.0450C2.1296 -4.3263 6.4373 -4.3263 7.9147 -3.0450L7.9147 -3.0450C6.4373 -4.2063 2.1296 -4.2063 0.6521 -3.0450z"/>
 </g>
-<g transform="translate(48.5360, 16.0636)">
+<g transform="translate(48.5360, 18.5240)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -3.5450C1.6921 -3.8556 2.7332 -3.3937 3.0826 -2.5450L3.0826 -2.5450C2.6846 -3.2841 1.6434 -3.7459 0.8284 -3.5450z"/>
 </g>
-<g transform="translate(27.1837, 19.2536)">
+<g transform="translate(27.1837, 21.7140)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.8695 -2.3900 17.8695 -1.9900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(27.1837, 20.0636)">
+<g transform="translate(27.1837, 22.5240)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.8695 -2.3900 17.8695 -1.9900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(53.2944, 16.0636)">
+<g transform="translate(53.2944, 18.5240)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8755 -2.5450C1.8179 -2.7574 2.8721 -2.1261 3.1297 -1.1950L3.1297 -1.1950C2.8104 -2.0231 1.7562 -2.6545 0.8755 -2.5450z"/>
 </g>
-<g transform="translate(58.0528, 16.0636)">
+<g transform="translate(58.0528, 18.5240)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -1.2285C1.6921 -1.6008 2.7332 -1.1390 3.0826 -0.2285L3.0826 -0.2285C2.6846 -1.0293 1.6434 -1.4911 0.8284 -1.2285z"/>
 </g>
-<g transform="translate(62.8112, 16.0636)">
+<g transform="translate(62.8112, 18.5240)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -0.2285C1.6921 -0.6008 2.7332 -0.1390 3.0826 0.7715L3.0826 0.7715C2.6846 -0.0293 1.6434 -0.4911 0.8284 -0.2285z"/>
 </g>
-<g transform="translate(48.5360, 17.2536)">
+<g transform="translate(48.5360, 19.7140)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="16.6195 2.3000 16.6195 2.7000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(48.5360, 18.0636)">
+<g transform="translate(48.5360, 20.5240)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="16.6195 2.3000 16.6195 2.7000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(74.7300, 16.0636)">
+<g transform="translate(74.7300, 18.5240)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7372 -4.0450C2.4923 -5.0335 7.0090 -4.1317 8.2499 -2.5450L8.2499 -2.5450C6.9855 -4.0140 2.4688 -4.9158 0.7372 -4.0450z"/>
 </g>
-<g transform="translate(75.3822, 11.6027)">
+<g transform="translate(75.3822, 14.0631)">
 <path transform="scale(0.0040, -0.0040)" d="M128 508c2 7 9 12 17 12c10 0 18 -7 18 -17c0 -2 -1 -4 -1 -6l-145 -485c-2 -7 -9 -12 -17 -12s-15 5 -17 12l-145 485v6c0 10 7 17 17 17c8 0 15 -5 17 -12l88 -295l40 -164l40 164z" fill="currentColor"/>
 </g>
-<g transform="translate(69.3239, 17.5636)">
+<g transform="translate(69.3239, 20.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(67.6347, 16.0636)">
+<g transform="translate(67.6347, 18.5240)">
 <rect x="-0.0650" y="2.1861" width="0.1300" height="2.3065" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(72.2258, 13.5636)">
+<g transform="translate(72.2258, 16.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(72.8779, 12.8186)">
+<g transform="translate(72.8779, 15.2790)">
 <path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
 </g>
-<g transform="translate(72.2908, 16.0636)">
+<g transform="translate(72.2908, 18.5240)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="6.2749" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(74.7300, 13.0636)">
+<g transform="translate(74.7300, 15.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(68.2218, 13.7636)">
+<g transform="translate(68.2218, 16.2240)">
 <path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
 </g>
-<g transform="translate(74.7950, 16.0636)">
+<g transform="translate(74.7950, 18.5240)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="6.4890" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(77.2343, 13.5636)">
+<g transform="translate(77.2343, 16.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(77.2993, 16.0636)">
+<g transform="translate(77.2993, 18.5240)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="5.7031" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(79.7385, 14.0636)">
+<g transform="translate(79.7385, 16.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(79.8035, 16.0636)">
+<g transform="translate(79.8035, 18.5240)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="4.9172" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(19.9861, 16.0636)">
+<g transform="translate(19.9861, 18.5240)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.1626, 15.0636)">
+<g transform="translate(15.1626, 17.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(15.2276, 16.0636)">
+<g transform="translate(15.2276, 18.5240)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(17.6669, 14.5636)">
+<g transform="translate(17.6669, 17.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(17.7319, 16.0636)">
+<g transform="translate(17.7319, 18.5240)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(19.9211, 15.5636)">
+<g transform="translate(19.9211, 18.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(22.4253, 15.0636)">
+<g transform="translate(22.4253, 17.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(22.4903, 16.0636)">
+<g transform="translate(22.4903, 18.5240)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(24.9295, 14.5636)">
+<g transform="translate(24.9295, 17.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(24.9945, 16.0636)">
+<g transform="translate(24.9945, 18.5240)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 13.0636)">
+<g transform="translate(7.9000, 15.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 15.0636)">
+<g transform="translate(0.8000, 17.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 15.0636)">
+<g transform="translate(4.3000, 17.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 12.9889)">
+<g transform="translate(-1.1267, 15.4493)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>3</tspan>
 </text>
 </g>
-<g transform="translate(7.9650, 16.0636)">
+<g transform="translate(7.9650, 18.5240)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(10.1542, 14.0636)">
+<g transform="translate(10.1542, 16.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(10.2192, 16.0636)">
+<g transform="translate(10.2192, 18.5240)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(12.6584, 14.5636)">
+<g transform="translate(12.6584, 17.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.7234, 16.0636)">
+<g transform="translate(12.7234, 18.5240)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(40.2698, 16.0636)">
+<g transform="translate(40.2698, 18.5240)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="4.7137" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(35.1963, 14.5636)">
+<g transform="translate(35.1963, 17.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(35.2613, 16.0636)">
+<g transform="translate(35.2613, 18.5240)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.3261" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(37.7006, 14.0636)">
+<g transform="translate(37.7006, 16.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(37.7656, 16.0636)">
+<g transform="translate(37.7656, 18.5240)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="4.5199" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(40.2048, 13.5636)">
+<g transform="translate(40.2048, 16.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(42.7090, 13.0636)">
+<g transform="translate(42.7090, 15.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(42.7740, 16.0636)">
+<g transform="translate(42.7740, 18.5240)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="4.9075" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(44.9632, 14.0636)">
+<g transform="translate(44.9632, 16.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(45.0282, 16.0636)">
+<g transform="translate(45.0282, 18.5240)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6318" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(30.0029, 16.0636)">
+<g transform="translate(30.0029, 18.5240)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="3.4692" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(29.9379, 16.0636)">
+<g transform="translate(29.9379, 18.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(32.6921, 15.0636)">
+<g transform="translate(32.6921, 17.5240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(27.2487, 16.0636)">
+<g transform="translate(27.2487, 18.5240)">
 <rect x="-0.0650" y="1.6861" width="0.1300" height="2.3059" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(32.7571, 16.0636)">
+<g transform="translate(32.7571, 18.5240)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="4.1324" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(27.1837, 17.5636)">
+<g transform="translate(27.1837, 20.0240)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 </svg>

--- a/tools/scores/README.md
+++ b/tools/scores/README.md
@@ -10,7 +10,10 @@ Renders the per-loop SVG scores in `scores/` from LilyPond sources in this direc
   by hand to follow the Peters/Becker edition.
 
 ## Build
-Requires LilyPond on `$PATH` (`apt-get install lilypond`).
+Requires LilyPond on `$PATH`. Run `tools/scores/setup.sh` to install it if
+missing (`apt-get install lilypond`); in Claude Code on the web this runs
+automatically via the `SessionStart` hook in `.claude/`, so a fresh session is
+ready to rebuild scores without manual setup.
 
 From the repo root:
 
@@ -27,3 +30,16 @@ For ranges that don't start at m. 1, the earlier measures are emitted inside
 `\set Score.skipTypesetting = ##t` so LilyPond parses them silently —
 necessary because the source uses `\relative` notation and slicing measures
 out of context shifts later pitches by an octave or more.
+
+### One measure per line (important)
+The splitter treats **each line of the music as one measure**. Keep one measure
+per line, and keep any `\set` / `\once` / `\override` on the **same line** as the
+measure it applies to (e.g. `\once \set fingeringOrientations = #'(down) <…>4 …`).
+A setting on its own line counts as an extra "measure" and shifts every later
+index, corrupting all the SVGs. After a build, `git status` should show only the
+SVG(s) you meant to change — if others changed, a measure boundary shifted.
+
+## Adding notes or notations
+See the `score-workflow` skill (`.claude/skills/score-workflow/`) for the full
+process: transcribing notes from IMSLP, then adding fingerings/articulations/
+dynamics a few measures at a time from edition screen captures, and rebuilding.

--- a/tools/scores/allemande.ly
+++ b/tools/scores/allemande.ly
@@ -13,7 +13,7 @@ allemande = \context Staff \relative c {
 
   \repeat volta 2 {
     \partial 16 b'16 |
-    <b d, g,>4~ b16 a( g fis) g( d e fis) g( a b c) |
+    \once \set fingeringOrientations = #'(down) <b d, g,-4>4\f~ b16 a( g fis) g( d e fis) g( a b c) |
     d( b g fis) g( e d c) b( c d e) fis( g a b) |
     c( a g fis) g( e fis g) a,( d fis g) a( b c a) |
     b( g) g( d) d( b) b( g) g8.\downbow b'16\downbow c\upbow( b a g) |

--- a/tools/scores/setup.sh
+++ b/tools/scores/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Ensure LilyPond is installed. It's required to rebuild the per-loop SVG scores
+# in scores/ from the LilyPond sources in tools/scores/ (see README.md here and
+# the score-workflow skill). Safe to run repeatedly; no-op once installed.
+set -euo pipefail
+
+if command -v lilypond >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "lilypond not found and apt-get unavailable; install LilyPond manually." >&2
+  exit 0
+fi
+
+SUDO=""
+[ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && SUDO="sudo"
+
+echo "Installing LilyPond (needed to rebuild score SVGs)…"
+if ! DEBIAN_FRONTEND=noninteractive $SUDO apt-get install -y lilypond >/dev/null 2>&1; then
+  $SUDO apt-get update >/dev/null 2>&1 || true
+  DEBIAN_FRONTEND=noninteractive $SUDO apt-get install -y lilypond
+fi
+echo "LilyPond installed: $(lilypond --version 2>/dev/null | head -1)"


### PR DESCRIPTION
## Summary
Sets up the score-editing workflow so it "just works" in future sessions, and proves it end-to-end on the allemande's first measure.

- **Auto-install LilyPond** — `tools/scores/setup.sh` installs it if missing; a `SessionStart` hook (`.claude/hooks/session-start.sh` + `.claude/settings.json`) runs it automatically in web sessions, so a fresh container can rebuild scores without manual setup.
- **`score-workflow` skill** (`.claude/skills/score-workflow/`) — documents the process: transcribe notes from IMSLP → add fingerings/articulations/dynamics a few measures at a time from edition screen captures → rebuild SVGs → verify. Calls out the **one-measure-per-line** constraint of `build_scores.py`.
- **Allemande m. 1** — added the `f` dynamic and finger `4` (below the low G) read from the edition crop, and regenerated `mm-1-4.svg`.
- README updated with setup + the line-per-measure rule.

## Verification (in this session)
- LilyPond 2.24.3 installed; hook runs clean (fast no-op when present, skips when not remote); `settings.json` is valid JSON.
- Rebuild is deterministic: after the m.1 edit, **only `mm-1-4.svg`** changed.
- Rendered `mm-1-4.svg` shows the `f` and the `4` below the low G, matching the edition; slurs/bowings intact.
- `node tools/check-assets.mjs` passes.

## Note for review
The `f` is certain. The fingering reads as **4 on the opening low G** — that's my best read of the crop; confirm the exact chord note if needed (easy to adjust). The hook runs **synchronously**, so it guarantees LilyPond is ready before the session starts but adds startup time on a fresh container; we can switch it to async if you'd prefer faster startup.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_