### PR TITLE
Allemande score: absolute octaves + mm. 1-2 engraving fixes

### DIFF
--- a/.claude/skills/score-workflow/SKILL.md
+++ b/.claude/skills/score-workflow/SKILL.md
@@ -27,9 +27,12 @@ on Claude Code on the web the `SessionStart` hook (`.claude/`) runs it
 automatically. To check: `lilypond --version`.
 
 ## Getting the notes (IMSLP)
-Transcribe pitches and rhythms from the public-domain IMSLP edition into a
-`\relative` LilyPond source. Record the edition/source in `tools/scores/README.md`.
-Keep **one measure per line** (see the hard constraint below).
+Transcribe pitches and rhythms from the public-domain IMSLP edition into an
+**absolute-octave** LilyPond source (`\absolute`, not `\relative`). Absolute
+octaves keep each measure self-contained, so polyphony or a voice split never
+shifts the octave of later notes — the bug class that plagued the relative
+source. Record the edition/source in `tools/scores/README.md`. Keep **one
+measure per line** (see the hard constraint below).
 
 ## Adding notations (fingerings, slurs, dynamics, …)
 Done a few measures at a time from screen captures of the edition being marked:

--- a/scores/allemande/mm-1-4.svg
+++ b/scores/allemande/mm-1-4.svg
@@ -1,585 +1,631 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="39.29mm" viewBox="-1.1267 -0.0000 103.5567 22.3575">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="41.49mm" viewBox="-1.1267 -0.0000 103.5567 23.6118">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
-<g transform="translate(0.0000, 7.3658)">
+<g transform="translate(0.0000, 8.5928)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 6.3658)">
+<g transform="translate(0.0000, 7.5928)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 5.3658)">
+<g transform="translate(0.0000, 6.5928)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 4.3658)">
+<g transform="translate(0.0000, 5.5928)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 3.3658)">
+<g transform="translate(0.0000, 4.5928)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 2.3658)">
-<rect x="55.1878" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 3.5928)">
+<rect x="55.0859" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 2.3658)">
-<rect x="50.9568" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 3.5928)">
+<rect x="50.8462" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(54.0158, 5.3658)">
+<g transform="translate(53.9115, 6.5928)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(102.2399, 5.3658)">
+<g transform="translate(102.2399, 6.5928)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(10.8829, 5.3658)">
+<g transform="translate(10.8893, 6.5928)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(67.0103, 5.3658)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.4488" ry="0.0400" fill="currentColor"/>
+<g transform="translate(69.6732, 6.5928)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.4408" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(72.7261, 5.3658)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.5130" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(72.6611, 5.3658)">
+<g transform="translate(69.6082, 6.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(69.7432, 5.3658)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.7186" ry="0.0400" fill="currentColor"/>
+<g transform="translate(66.9340, 6.5928)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1312" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(69.6782, 4.8658)">
+<g transform="translate(66.8690, 5.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(81.6748, 5.3658)">
-<rect x="-0.0650" y="0.6861" width="0.1300" height="2.8338" ry="0.0400" fill="currentColor"/>
+<g transform="translate(75.6517, 6.5928)">
+<rect x="-0.0650" y="0.6861" width="0.1300" height="3.1165" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(81.6098, 5.8658)">
+<g transform="translate(79.7969, 6.5928)">
+<rect x="-0.0650" y="-3.0058" width="0.1300" height="3.8197" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(78.5577, 7.5928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(78.6919, 5.3658)">
-<rect x="-0.0650" y="1.1861" width="0.1300" height="2.6177" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(78.6269, 6.3658)">
+<g transform="translate(75.5867, 7.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(75.7090, 5.3658)">
-<rect x="-0.0650" y="0.6861" width="0.1300" height="2.3075" ry="0.0400" fill="currentColor"/>
+<g transform="translate(72.6625, 6.5928)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="3.2787" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(75.6440, 5.8658)">
+<g transform="translate(72.5975, 6.5928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(78.6269, 8.3658)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.9702 -2.2000 20.9702 -1.8000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(90.5329, 7.7828)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0577 -1.2000 9.0577 -0.8000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(78.6269, 9.1758)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.9702 -2.2000 20.9702 -1.8000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(90.5329, 8.5928)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0577 -1.2000 9.0577 -0.8000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(55.5788, 5.3658)">
-<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.3203" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(58.2467, 2.8658)">
+<g transform="translate(55.4120, 3.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(58.3117, 5.3658)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.5901" ry="0.0400" fill="currentColor"/>
+<g transform="translate(55.4770, 6.5928)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1329" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(66.9453, 3.8658)">
+<g transform="translate(63.9447, 6.5928)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8049" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(58.1512, 4.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(60.9796, 3.8658)">
+<g transform="translate(58.2162, 6.5928)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.5120" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(60.8905, 5.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(61.0446, 5.3658)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.8599" ry="0.0400" fill="currentColor"/>
+<g transform="translate(60.9555, 6.5928)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.8912" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(63.9625, 4.3658)">
+<g transform="translate(63.8797, 5.5928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(64.0275, 5.3658)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.6543" ry="0.0400" fill="currentColor"/>
+<g transform="translate(99.5657, 6.5928)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3210" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(99.5070, 2.8658)">
+<g transform="translate(99.5007, 4.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(99.5720, 5.3658)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1301" ry="0.0400" fill="currentColor"/>
+<g transform="translate(96.5764, 6.5928)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1496" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(12.3810, 5.3658)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M1.5042 -3.0000C2.3599 -3.8110 5.2846 -3.8110 6.1402 -3.0000L6.1402 -3.0000C5.2846 -3.6910 2.3599 -3.6910 1.5042 -3.0000z"/>
-</g>
-<g transform="translate(21.7041, 5.3658)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7134 -3.0450C2.1731 -4.0154 5.5487 -3.5345 6.6792 -2.1950L6.6792 -2.1950C5.5317 -3.4157 2.1561 -3.8966 0.7134 -3.0450z"/>
-</g>
-<g transform="translate(30.6527, 5.3658)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6696 -2.5450C2.3739 -3.8636 7.7754 -3.6463 9.3682 -2.1950L9.3682 -2.1950C7.7705 -3.5264 2.3691 -3.7437 0.6696 -2.5450z"/>
-</g>
-<g transform="translate(18.7212, 5.5558)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0386 0.8000 9.0386 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(18.7212, 6.3658)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0386 0.8000 9.0386 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(42.3342, 5.3658)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5802 -2.5450C2.0143 -4.2138 7.6291 -5.1550 9.5289 -4.0450L9.5289 -4.0450C7.6489 -5.0366 2.0341 -4.0955 0.5802 -2.5450z"/>
-</g>
-<g transform="translate(55.5138, 5.3658)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7686 -4.5450C2.7375 -5.4402 7.9934 -3.9783 9.2172 -2.1950L9.2172 -2.1950C7.9612 -3.8627 2.7053 -5.3246 0.7686 -4.5450z"/>
-</g>
-<g transform="translate(30.6527, 7.3658)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.7202 -1.2000 20.7202 -0.8000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(30.6527, 8.1758)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.7202 -1.2000 20.7202 -0.8000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(66.9453, 5.3658)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7495 -2.5450C2.6948 -3.5341 8.1302 -2.2843 9.4482 -0.5450L9.4482 -0.5450C8.1033 -2.1674 2.6679 -3.4171 0.7495 -2.5450z"/>
-</g>
-<g transform="translate(78.6269, 5.3658)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5873 -0.3056C2.0461 -2.2577 7.6572 -3.1042 9.5359 -1.6556L9.5359 -1.6556C7.6751 -2.9855 2.0640 -2.1390 0.5873 -0.3056z"/>
-</g>
-<g transform="translate(55.5138, 5.5558)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.2202 1.8000 20.2202 2.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(55.5138, 6.3658)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.2202 1.8000 20.2202 2.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(90.5584, 5.3658)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5873 -2.1950C2.0461 -3.8384 7.6572 -4.6849 9.5359 -3.5450L9.5359 -3.5450C7.6751 -4.5662 2.0640 -3.7197 0.5873 -2.1950z"/>
-</g>
-<g transform="translate(90.5584, 4.3658)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(84.5926, 5.3658)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(84.6576, 5.3658)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="3.0498" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(87.5755, 4.8658)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(87.6405, 5.3658)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.2659" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(90.6234, 5.3658)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.4819" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(93.5413, 3.8658)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(93.6063, 5.3658)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.6980" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(96.5242, 3.3658)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(96.7665, 1.1360)">
+<g transform="translate(96.7538, 1.9222)">
 <path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
 c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
 </g>
-<g transform="translate(96.5892, 5.3658)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.9140" ry="0.0400" fill="currentColor"/>
+<g transform="translate(21.6341, 6.5928)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M1.2778 -5.4681C2.6805 -6.5119 6.0600 -6.2110 7.2563 -4.9358L7.2563 -4.9358C6.0493 -6.0915 2.6699 -6.3924 1.2778 -5.4681z"/>
 </g>
-<g transform="translate(18.7212, 2.8658)">
+<g transform="translate(19.8190, 1.5928)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0577 0.6100 9.0577 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(19.8190, 2.4028)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0577 0.6100 9.0577 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(33.2368, 6.5928)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5839 -1.1950C2.6628 -3.2587 15.9032 -5.3626 18.5194 -4.0450L18.5194 -4.0450C15.9220 -5.2441 2.6816 -3.1402 0.5839 -1.1950z"/>
+</g>
+<g transform="translate(30.4976, 8.5928)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.8077 -0.2000 8.8077 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(30.4976, 9.4028)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.8077 -0.2000 8.8077 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(55.4120, 6.5928)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7367 -4.5450C3.5250 -5.7772 18.8041 -2.7478 20.9114 -0.5450L20.9114 -0.5450C18.7807 -2.6301 3.5017 -5.6595 0.7367 -4.5450z"/>
+</g>
+<g transform="translate(42.2046, 7.5928)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0577 -1.0100 9.0577 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(42.2046, 8.4028)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0577 -1.0100 9.0577 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(55.4120, 6.5928)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.5577 0.9900 8.5577 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(55.4120, 7.4028)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.5577 0.9900 8.5577 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(78.5577, 6.5928)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M1.2435 -3.7458C3.7464 -5.4690 19.1309 -5.3173 21.5994 -3.5450L21.5994 -3.5450C19.1297 -5.1973 3.7452 -5.3491 1.2435 -3.7458z"/>
+</g>
+<g transform="translate(66.8690, 8.5928)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.8077 0.8000 8.8077 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(66.8690, 9.4028)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.8077 0.8000 8.8077 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(79.7319, 3.5928)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0577 -1.0100 9.0577 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(79.7319, 4.4028)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0577 -1.0100 9.0577 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(84.5362, 6.5928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.7862, 5.3658)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3211" ry="0.0400" fill="currentColor"/>
+<g transform="translate(88.7647, 6.5928)">
+<rect x="-0.0650" y="-3.8042" width="0.1300" height="3.1181" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(21.7041, 3.3658)">
+<g transform="translate(87.5254, 6.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(21.8952, 1.9220)">
-<path transform="scale(0.0022, -0.0022)" d="M148 501c10 0 41 -15 72 -15c32 0 63 15 76 15c15 0 26 -11 26 -21c0 -4 -1 -7 -4 -10l-264 -291h134v4c0 60 50 41 75 85c7 11 8 24 14 36c3 7 10 10 17 10c11 0 24 -8 24 -25v-110h70c18 0 27 -14 27 -27s-9 -27 -27 -27h-70c2 -45 36 -82 80 -82c14 0 22 -10 22 -21
-s-8 -22 -22 -22c-49 0 -96 14 -145 14s-97 -14 -146 -14c-14 0 -21 11 -21 22s7 21 21 21c44 0 79 37 81 82h-134c-43 0 -57 25 -57 42c0 5 1 10 3 12c73 81 123 182 123 291c0 17 11 31 25 31z" fill="currentColor"/>
+<g transform="translate(85.7754, 6.5928)">
+<rect x="-0.0650" y="-3.5381" width="0.1300" height="3.3520" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(21.7691, 5.3658)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1496" ry="0.0400" fill="currentColor"/>
+<g transform="translate(82.7862, 6.5928)">
+<rect x="-0.0650" y="-3.2719" width="0.1300" height="3.5858" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(24.6869, 3.8658)">
+<g transform="translate(81.5470, 7.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(24.7519, 5.3658)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9782" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(27.6698, 4.3658)">
+<g transform="translate(90.5329, 5.5928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(27.7348, 5.3658)">
+<g transform="translate(90.5979, 6.5928)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8067" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(30.6527, 3.8658)">
+<g transform="translate(93.5222, 5.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(30.7177, 5.3658)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1208" ry="0.0400" fill="currentColor"/>
+<g transform="translate(93.5872, 6.5928)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9782" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 2.8658)">
+<g transform="translate(96.5114, 4.5928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 4.3658)">
-<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
-c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
-</g>
-<g transform="translate(4.3000, 4.3658)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(7.9650, 5.3658)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(8.0300, 6.3258)">
+<g transform="translate(18.7748, 9.9278)">
 <path transform="scale(0.0040, -0.0040)" d="M0 205c91 51 211 131 211 233c0 24 -5 48 -14 70c-79 -89 -197 -160 -197 -282v-21zM267 663c0 -44 -16 -82 -39 -116c16 -35 25 -71 25 -109c0 -181 -253 -257 -253 -438h-16v500h16v-70c97 49 224 128 224 233c0 21 -5 42 -13 62c-3 16 10 27 23 27c32 0 33 -83 33 -89
 z" fill="currentColor"/>
 </g>
-<g transform="translate(12.3810, 2.8658)">
+<g transform="translate(18.7098, 6.5928)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="3.1889" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(18.6448, 6.5928)">
+<path stroke-width="0.1000" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M-1.3000 0.3412C-0.9986 0.7236 -0.5014 0.7236 -0.2000 0.3412L-0.2000 0.3412C-0.5014 0.6236 -0.9986 0.6236 -1.3000 0.3412z"/>
+</g>
+<g transform="translate(19.8840, 6.5928)">
+<rect x="-0.0650" y="-4.9942" width="0.1300" height="2.3081" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(18.6448, 6.5928)">
+<path stroke-width="0.1000" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M-1.3000 -3.0000C-0.9986 -3.3824 -0.5014 -3.3824 -0.2000 -3.0000L-0.2000 -3.0000C-0.5014 -3.2824 -0.9986 -3.2824 -1.3000 -3.0000z"/>
+</g>
+<g transform="translate(18.6448, 6.5928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.3810, 5.3658)">
+<g transform="translate(18.6448, 4.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.3810, 7.3658)">
+<g transform="translate(27.6125, 5.5928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.4014, 10.3846)">
-<path transform="scale(0.0040, -0.0040)" d="M253 245l-50 -163c-30 -99 -121 -255 -218 -255c-45 0 -87 27 -87 69c0 39 17 77 52 77c24 0 44 -20 44 -44c0 -30 -38 -24 -38 -54c0 -10 11 -11 23 -11h6c48 0 61 58 73 108l68 273h-49c-11 0 -19 8 -19 19s8 19 19 19h60c32 96 118 191 213 191c45 0 87 -27 87 -69
-c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-7c-62 0 -70 -88 -86 -154h55c11 0 19 -8 19 -19s-8 -19 -19 -19h-66z" fill="currentColor"/>
-</g>
-<g transform="translate(12.4460, 5.3658)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.9806" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(42.3342, 3.8658)">
+<g transform="translate(24.6233, 5.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(42.3992, 5.3658)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.5581" ry="0.0400" fill="currentColor"/>
+<g transform="translate(22.8733, 6.5928)">
+<rect x="-0.0650" y="-4.7281" width="0.1300" height="2.5420" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(45.3171, 3.3658)">
+<g transform="translate(21.8252, 1.1248)">
+<path transform="scale(0.0022, -0.0022)" d="M148 501c10 0 41 -15 72 -15c32 0 63 15 76 15c15 0 26 -11 26 -21c0 -4 -1 -7 -4 -10l-264 -291h134v4c0 60 50 41 75 85c7 11 8 24 14 36c3 7 10 10 17 10c11 0 24 -8 24 -25v-110h70c18 0 27 -14 27 -27s-9 -27 -27 -27h-70c2 -45 36 -82 80 -82c14 0 22 -10 22 -21
+s-8 -22 -22 -22c-49 0 -96 14 -145 14s-97 -14 -146 -14c-14 0 -21 11 -21 22s7 21 21 21c44 0 79 37 81 82h-134c-43 0 -57 25 -57 42c0 5 1 10 3 12c73 81 123 182 123 291c0 17 11 31 25 31z" fill="currentColor"/>
+</g>
+<g transform="translate(21.6341, 4.5928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(45.3821, 5.3658)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.9144" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(48.3000, 2.8658)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(48.3650, 5.3658)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.2707" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(51.2829, 2.3658)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(51.3479, 5.3658)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.6270" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(55.5138, 1.8658)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(33.3856, 5.3658)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(33.4506, 5.3658)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.4891" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(36.3685, 4.8658)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(36.4335, 5.3658)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.8454" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(39.3513, 4.3658)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(39.4163, 5.3658)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.2018" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 19.6175)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6502" y2="0"/>
-</g>
-<g transform="translate(0.0000, 18.6175)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6502" y2="0"/>
-</g>
-<g transform="translate(0.0000, 17.6175)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6502" y2="0"/>
-</g>
-<g transform="translate(0.0000, 16.6175)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6502" y2="0"/>
-</g>
-<g transform="translate(0.0000, 15.6175)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6502" y2="0"/>
-</g>
-<g transform="translate(0.0000, 14.6175)">
-<rect x="74.4040" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 14.6175)">
-<rect x="42.3829" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 14.6175)">
-<rect x="7.5740" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(47.2174, 17.6175)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(84.5102, 17.6175)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(55.6136, 17.6175)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8760" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(60.3720, 17.6175)">
-<rect x="-0.0650" y="1.1861" width="0.1300" height="2.5901" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(60.3070, 18.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(58.1178, 17.6175)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="3.2518" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(58.0528, 17.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(67.5697, 19.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(62.8112, 18.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(62.8762, 17.6175)">
-<rect x="-0.0650" y="1.1861" width="0.1300" height="2.9659" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(65.0655, 19.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(65.1305, 17.6175)">
-<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3041" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(72.2258, 20.7759)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="10.1068 -1.3584 10.1068 -0.9584 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(67.5697, 22.1175)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="14.7630 -1.8900 14.7630 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(48.5360, 15.1175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(48.6010, 17.6175)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.3236" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(55.5486, 17.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(50.7902, 16.1175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(50.8552, 17.6175)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.6619" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(53.2944, 16.1175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(53.3594, 17.6175)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.0377" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(82.2427, 16.1175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(82.3077, 17.6175)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1313" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 17.6175)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7594 -4.0450C2.5406 -4.9329 6.8827 -3.8268 8.0221 -2.1950L8.0221 -2.1950C6.8531 -3.7105 2.5109 -4.8166 0.7594 -4.0450z"/>
-</g>
-<g transform="translate(17.6669, 17.6175)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -2.5450C2.1296 -3.8263 6.4373 -3.8263 7.9147 -2.5450L7.9147 -2.5450C6.4373 -3.7063 2.1296 -3.7063 0.6521 -2.5450z"/>
-</g>
-<g transform="translate(27.1837, 17.6175)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4997 0.4550C1.5465 -1.4066 6.5003 -3.2613 8.5123 -2.5450L8.5123 -2.5450C6.5423 -3.1490 1.5886 -1.2942 0.4997 0.4550z"/>
-</g>
-<g transform="translate(7.9000, 18.6175)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.1195 -0.2000 17.1195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(7.9000, 19.4275)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.1195 -0.2000 17.1195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(37.7006, 17.6175)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -3.0450C2.1296 -4.3263 6.4373 -4.3263 7.9147 -3.0450L7.9147 -3.0450C6.4373 -4.2063 2.1296 -4.2063 0.6521 -3.0450z"/>
-</g>
-<g transform="translate(48.5360, 17.6175)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -3.5450C1.6921 -3.8556 2.7332 -3.3937 3.0826 -2.5450L3.0826 -2.5450C2.6846 -3.2841 1.6434 -3.7459 0.8284 -3.5450z"/>
-</g>
-<g transform="translate(27.1837, 20.8075)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.8695 -2.3900 17.8695 -1.9900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(27.1837, 21.6175)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.8695 -2.3900 17.8695 -1.9900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(53.2944, 17.6175)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8755 -2.5450C1.8179 -2.7574 2.8721 -2.1261 3.1297 -1.1950L3.1297 -1.1950C2.8104 -2.0231 1.7562 -2.6545 0.8755 -2.5450z"/>
-</g>
-<g transform="translate(58.0528, 17.6175)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -1.2285C1.6921 -1.6008 2.7332 -1.1390 3.0826 -0.2285L3.0826 -0.2285C2.6846 -1.0293 1.6434 -1.4911 0.8284 -1.2285z"/>
-</g>
-<g transform="translate(62.8112, 17.6175)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -0.2285C1.6921 -0.6008 2.7332 -0.1390 3.0826 0.7715L3.0826 0.7715C2.6846 -0.0293 1.6434 -0.4911 0.8284 -0.2285z"/>
-</g>
-<g transform="translate(48.5360, 18.8075)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="16.6195 2.3000 16.6195 2.7000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(48.5360, 19.6175)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="16.6195 2.3000 16.6195 2.7000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(74.7300, 17.6175)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7372 -4.0450C2.4923 -5.0335 7.0090 -4.1317 8.2499 -2.5450L8.2499 -2.5450C6.9855 -4.0140 2.4688 -4.9158 0.7372 -4.0450z"/>
-</g>
-<g transform="translate(75.3822, 13.1566)">
-<path transform="scale(0.0040, -0.0040)" d="M128 508c2 7 9 12 17 12c10 0 18 -7 18 -17c0 -2 -1 -4 -1 -6l-145 -485c-2 -7 -9 -12 -17 -12s-15 5 -17 12l-145 485v6c0 10 7 17 17 17c8 0 15 -5 17 -12l88 -295l40 -164l40 164z" fill="currentColor"/>
-</g>
-<g transform="translate(69.3239, 19.1175)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(67.6347, 17.6175)">
-<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3065" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(72.2258, 15.1175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(72.8779, 14.3725)">
-<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
-</g>
-<g transform="translate(72.2908, 17.6175)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.2749" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(74.7300, 14.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(68.2218, 15.3175)">
-<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
-</g>
-<g transform="translate(74.7950, 17.6175)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="6.4890" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(77.2343, 15.1175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(77.2993, 17.6175)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="5.7031" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(79.7385, 15.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(79.8035, 17.6175)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.9172" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(19.9861, 17.6175)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(15.1626, 16.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(15.2276, 17.6175)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(17.6669, 16.1175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(17.7319, 17.6175)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(19.9211, 17.1175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(22.4253, 16.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(22.4903, 17.6175)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(24.9295, 16.1175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(24.9945, 17.6175)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 14.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(0.8000, 16.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
-c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
-</g>
-<g transform="translate(4.3000, 16.6175)">
+<g transform="translate(4.3000, 5.5928)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 14.5428)">
+<g transform="translate(8.0300, 7.5528)">
+<path transform="scale(0.0040, -0.0040)" d="M0 205c91 51 211 131 211 233c0 24 -5 48 -14 70c-79 -89 -197 -160 -197 -282v-21zM267 663c0 -44 -16 -82 -39 -116c16 -35 25 -71 25 -109c0 -181 -253 -257 -253 -438h-16v500h16v-70c97 49 224 128 224 233c0 21 -5 42 -13 62c-3 16 10 27 23 27c32 0 33 -83 33 -89
+z" fill="currentColor"/>
+</g>
+<g transform="translate(7.9650, 6.5928)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(0.8000, 5.5928)">
+<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
+c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
+</g>
+<g transform="translate(7.9205, 11.1389)">
+<path transform="scale(0.0040, -0.0040)" d="M253 245l-50 -163c-30 -99 -121 -255 -218 -255c-45 0 -87 27 -87 69c0 39 17 77 52 77c24 0 44 -20 44 -44c0 -30 -38 -24 -38 -54c0 -10 11 -11 23 -11h6c48 0 61 58 73 108l68 273h-49c-11 0 -19 8 -19 19s8 19 19 19h60c32 96 118 191 213 191c45 0 87 -27 87 -69
+c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-7c-62 0 -70 -88 -86 -154h55c11 0 19 -8 19 -19s-8 -19 -19 -19h-66z" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 4.0928)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(25.8625, 6.5928)">
+<rect x="-0.0650" y="-4.4619" width="0.1300" height="2.7758" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(12.3897, 4.0928)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(12.3897, 6.5928)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(12.3897, 8.5928)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(12.4547, 6.5928)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.9806" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(39.2153, 5.5928)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(39.2803, 6.5928)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(42.2046, 5.0928)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(42.2696, 6.5928)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1181" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(45.1938, 4.5928)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(45.2588, 6.5928)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.3520" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(48.1831, 4.0928)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(48.2481, 6.5928)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.5858" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(51.1723, 3.5928)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(51.2373, 6.5928)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8197" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(30.5626, 6.5928)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(36.2911, 6.5928)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(30.4976, 5.0928)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(33.2368, 6.5928)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(33.3018, 6.5928)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(28.8518, 6.5928)">
+<rect x="-0.0650" y="-4.1958" width="0.1300" height="3.0097" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(36.2261, 6.0928)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 20.3718)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6635" y2="0"/>
+</g>
+<g transform="translate(0.0000, 19.3718)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6635" y2="0"/>
+</g>
+<g transform="translate(0.0000, 18.3718)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6635" y2="0"/>
+</g>
+<g transform="translate(0.0000, 17.3718)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6635" y2="0"/>
+</g>
+<g transform="translate(0.0000, 16.3718)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6635" y2="0"/>
+</g>
+<g transform="translate(84.5235, 18.3718)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(47.2307, 18.3718)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 15.3718)">
+<rect x="74.4173" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 15.3718)">
+<rect x="42.3829" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 15.3718)">
+<rect x="7.5740" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(67.6480, 18.3718)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.7842" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(61.5595, 18.3718)">
+<rect x="-0.0650" y="-2.6753" width="0.1300" height="3.4892" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(60.3203, 19.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(59.3053, 18.3718)">
+<rect x="-0.0650" y="-2.9909" width="0.1300" height="2.8048" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(58.0661, 18.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(62.8245, 19.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(64.0638, 18.3718)">
+<rect x="-0.0650" y="-2.3247" width="0.1300" height="3.1386" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(65.0788, 20.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(66.3180, 18.3718)">
+<rect x="-0.0650" y="-2.0091" width="0.1300" height="3.8230" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(67.5830, 20.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(68.2351, 16.0718)">
+<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
+</g>
+<g transform="translate(69.3372, 19.8718)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(48.5493, 15.8718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(74.7433, 18.5618)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 0.6100 7.6026 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(74.7433, 19.3718)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 0.6100 7.6026 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(48.6143, 18.3718)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1347" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(50.8035, 16.8718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(50.8685, 18.3718)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.5103" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(53.3077, 16.8718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(53.3727, 18.3718)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.9275" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(55.5619, 18.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(55.6269, 18.3718)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8031" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 18.3718)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7594 -4.0450C2.5406 -4.9329 6.8827 -3.8268 8.0221 -2.1950L8.0221 -2.1950C6.8531 -3.7105 2.5109 -4.8166 0.7594 -4.0450z"/>
+</g>
+<g transform="translate(82.3210, 18.3718)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1170" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(82.2560, 16.8718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(17.6669, 18.3718)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -2.5450C2.1296 -3.8263 6.4373 -3.8263 7.9147 -2.5450L7.9147 -2.5450C6.4373 -3.7063 2.1296 -3.7063 0.6521 -2.5450z"/>
+</g>
+<g transform="translate(7.9000, 18.5618)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(7.9000, 19.3718)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(27.1837, 18.3718)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4997 0.4550C1.5465 -1.4066 6.5003 -3.2613 8.5123 -2.5450L8.5123 -2.5450C6.5423 -3.1490 1.5886 -1.2942 0.4997 0.4550z"/>
+</g>
+<g transform="translate(17.6669, 19.5618)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(17.6669, 20.3718)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(37.7006, 18.3718)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -3.0450C2.1296 -4.3263 6.4373 -4.3263 7.9147 -3.0450L7.9147 -3.0450C6.4373 -4.2063 2.1296 -4.2063 0.6521 -3.0450z"/>
+</g>
+<g transform="translate(27.1837, 22.0618)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.8900 8.1026 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(27.1837, 22.8718)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.8900 8.1026 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(48.5493, 18.3718)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -3.5450C1.6921 -3.8556 2.7332 -3.3937 3.0826 -2.5450L3.0826 -2.5450C2.6846 -3.2841 1.6434 -3.7459 0.8284 -3.5450z"/>
+</g>
+<g transform="translate(37.7006, 18.5618)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(37.7006, 19.3718)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(53.3077, 18.3718)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8755 -2.5450C1.8179 -2.7574 2.8721 -2.1261 3.1297 -1.1950L3.1297 -1.1950C2.8104 -2.0231 1.7562 -2.6545 0.8755 -2.5450z"/>
+</g>
+<g transform="translate(58.0661, 18.3718)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4758 1.2285C0.8252 2.1390 1.8663 2.6008 2.7300 2.2285L2.7300 2.2285C1.9150 2.4911 0.8739 2.0293 0.4758 1.2285z"/>
+</g>
+<g transform="translate(48.5493, 19.3718)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(48.5493, 20.1818)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(62.8245, 18.3718)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4987 2.1950C0.8879 3.0071 1.9244 3.3980 2.7529 3.0450L2.7529 3.0450C1.9667 3.2857 0.9303 2.8948 0.4987 2.1950z"/>
+</g>
+<g transform="translate(59.2403, 15.3718)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(59.2403, 16.1818)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(74.7433, 18.3718)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7372 -4.0450C2.4923 -5.0335 7.0090 -4.1317 8.2499 -2.5450L8.2499 -2.5450C6.9855 -4.0140 2.4688 -4.9158 0.7372 -4.0450z"/>
+</g>
+<g transform="translate(71.2041, 20.9049)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.7331 1.1250 -0.3331 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(67.5830, 23.3718)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="4.7462 -2.3900 4.7462 -1.9900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(72.2391, 15.8718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(72.8912, 15.1268)">
+<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
+</g>
+<g transform="translate(72.3041, 18.3718)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="5.1536" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(74.7433, 15.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(75.3954, 13.9109)">
+<path transform="scale(0.0040, -0.0040)" d="M128 508c2 7 9 12 17 12c10 0 18 -7 18 -17c0 -2 -1 -4 -1 -6l-145 -485c-2 -7 -9 -12 -17 -12s-15 5 -17 12l-145 485v6c0 10 7 17 17 17c8 0 15 -5 17 -12l88 -295l40 -164l40 164z" fill="currentColor"/>
+</g>
+<g transform="translate(74.8083, 18.3718)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8208" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(77.2476, 15.8718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(77.3126, 18.3718)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.5862" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(79.7518, 16.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(79.8168, 18.3718)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.3516" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(15.1626, 17.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(15.2276, 18.3718)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8051" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(17.6669, 16.8718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(17.7319, 18.3718)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(19.9211, 17.8718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(19.9861, 18.3718)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(22.4253, 17.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(22.4903, 18.3718)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(24.9945, 18.3718)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 15.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(0.8000, 17.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
+c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
+</g>
+<g transform="translate(4.3000, 17.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
+v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+</g>
+<g transform="translate(-1.1267, 15.2971)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>3</tspan>
 </text>
 </g>
-<g transform="translate(7.9650, 17.6175)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(10.1542, 15.6175)">
+<g transform="translate(24.9295, 16.8718)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(10.2192, 17.6175)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(7.9650, 18.3718)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8227" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(12.6584, 16.1175)">
+<g transform="translate(10.1542, 16.3718)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.7234, 17.6175)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(10.2192, 18.3718)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1276" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(40.2048, 15.1175)">
+<g transform="translate(12.6584, 16.8718)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(35.1963, 16.1175)">
+<g transform="translate(12.7234, 18.3718)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9664" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(42.7740, 18.3718)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(42.7090, 15.3718)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(35.2613, 17.6175)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.3261" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(37.7006, 15.6175)">
+<g transform="translate(35.1963, 16.8718)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(37.9429, 14.1008)">
+<g transform="translate(35.2613, 18.3718)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1374" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(27.1837, 19.8718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(37.7006, 16.3718)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(37.9429, 14.8552)">
 <path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
 c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
 </g>
-<g transform="translate(37.7656, 17.6175)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.5199" ry="0.0400" fill="currentColor"/>
+<g transform="translate(37.7656, 18.3718)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(40.2698, 17.6175)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.7137" ry="0.0400" fill="currentColor"/>
+<g transform="translate(40.2698, 18.3718)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.7090, 14.6175)">
+<g transform="translate(40.2048, 15.8718)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(42.7740, 17.6175)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.9075" ry="0.0400" fill="currentColor"/>
+<g transform="translate(27.2487, 18.3718)">
+<rect x="-0.0650" y="1.6861" width="0.1300" height="2.8004" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(44.9632, 15.6175)">
+<g transform="translate(29.9379, 18.3718)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(45.0282, 17.6175)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6318" ry="0.0400" fill="currentColor"/>
+<g transform="translate(30.0029, 18.3718)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="3.7288" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(32.7571, 17.6175)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="4.1324" ry="0.0400" fill="currentColor"/>
+<g transform="translate(45.0282, 18.3718)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(32.6921, 16.6175)">
+<g transform="translate(44.9632, 16.3718)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(27.2487, 17.6175)">
-<rect x="-0.0650" y="1.6861" width="0.1300" height="2.3059" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(27.1837, 19.1175)">
+<g transform="translate(32.6921, 17.3718)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(29.9379, 17.6175)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(30.0029, 17.6175)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="3.4692" ry="0.0400" fill="currentColor"/>
+<g transform="translate(32.7571, 18.3718)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="4.1571" ry="0.0400" fill="currentColor"/>
 </g>
 </svg>

--- a/scores/allemande/mm-10-12.svg
+++ b/scores/allemande/mm-10-12.svg
@@ -1,42 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="33.34mm" viewBox="-2.2535 -0.0000 104.6834 18.9732">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="32.82mm" viewBox="-2.2535 -0.0000 104.6834 18.6750">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
-<g transform="translate(0.0000, 1.5450)">
-<rect x="63.7331" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 0.5450)">
-<rect x="50.9313" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 1.5450)">
-<rect x="50.9313" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 1.5450)">
-<rect x="44.9659" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 1.5450)">
-<rect x="39.2506" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 1.5450)">
-<rect x="33.2853" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 1.5450)">
-<rect x="30.3026" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 1.5450)">
-<rect x="21.3546" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 1.5450)">
-<rect x="9.5750" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(102.2399, 4.5450)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(56.7359, 4.5450)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
 <g transform="translate(0.0000, 6.5450)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
@@ -52,378 +19,437 @@ tspan { white-space: pre; }
 <g transform="translate(0.0000, 2.5450)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(72.7571, 3.5450)">
+<g transform="translate(0.0000, 1.5450)">
+<rect x="63.1636" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 0.5450)">
+<rect x="50.1445" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="50.1445" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="44.0916" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="38.2887" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="32.2357" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="29.2092" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="20.1298" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.5450)">
+<rect x="8.1750" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(102.2399, 4.5450)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(56.0368, 4.5450)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(72.3841, 4.5450)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.3520" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(66.2661, 2.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(66.7918, 2.5450)">
+<g transform="translate(72.3191, 3.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(66.8568, 4.5450)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.3082" ry="0.0400" fill="currentColor"/>
+<g transform="translate(69.3576, 4.5450)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.5858" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(69.7744, 3.0450)">
+<g transform="translate(69.2926, 3.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(69.8394, 4.5450)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.9127" ry="0.0400" fill="currentColor"/>
+<g transform="translate(66.3311, 4.5450)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.8196" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(78.7874, 4.5450)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.6245" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(72.8221, 4.5450)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.5172" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(75.7398, 4.0450)">
+<g transform="translate(75.3455, 4.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(75.8048, 4.5450)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1216" ry="0.0400" fill="currentColor"/>
+<g transform="translate(75.4105, 4.5450)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1182" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(78.7224, 4.5450)">
+<g transform="translate(78.3720, 4.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(78.7224, 6.5450)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.7187 -0.0100 20.7187 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(78.4370, 4.5450)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8126" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(78.7224, 7.3550)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.7187 -0.0100 20.7187 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(53.3121, 4.5450)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.8103" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(53.9900, 3.0450)">
+<g transform="translate(90.4779, 6.7350)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.3000 8.9194 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(90.4779, 7.5450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.3000 8.9194 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(57.4835, 3.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(54.0550, 4.5450)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.3133" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(58.1662, 3.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(58.8183, 2.2450)">
+<g transform="translate(58.1356, 2.2450)">
 <path transform="scale(0.0040, -0.0040)" d="M-297 227c0 -15 8 -30 39 -30c10 0 46 2 103 28l5 24c-23 17 -50 29 -81 29c-51 0 -66 -31 -66 -51zM-26 104c0 -61 -47 -115 -98 -115c-39 0 -56 44 -56 91c0 14 1 28 4 41l15 76c-20 -8 -63 -25 -101 -25c-19 0 -60 6 -60 51c0 38 32 80 96 80c31 0 58 -10 82 -25
 l46 232c6 -3 13 -5 20 -5c22 0 48 16 68 35l-53 -266l64 36c26 14 51 20 74 20c29 0 53 -10 64 -28c18 20 44 30 69 30c36 0 69 -22 69 -69c0 -49 -31 -90 -65 -90c-25 0 -38 22 -38 48c0 50 37 64 60 64h3c-8 14 -23 20 -38 20c-24 0 -50 -16 -55 -43l-54 -270
 c-11 7 -24 11 -38 11s-29 -4 -43 -11l54 270v7c0 16 -12 26 -29 26c-7 0 -16 -3 -24 -7l-79 -44l-7 -31c27 -31 50 -67 50 -109zM-86 39c23 0 35 34 35 61c0 30 -14 55 -32 78l-5 -27c-4 -18 -13 -56 -13 -83c0 -17 4 -29 15 -29z" fill="currentColor"/>
 </g>
-<g transform="translate(59.9204, 3.0450)">
+<g transform="translate(59.2377, 3.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(58.2312, 4.5450)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.0062" ry="0.0400" fill="currentColor"/>
+<g transform="translate(57.5485, 4.5450)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.9893" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(64.0591, 1.0450)">
+<g transform="translate(63.4897, 1.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(64.1241, 4.5450)">
-<rect x="-0.0650" y="-3.3139" width="0.1300" height="5.7125" ry="0.0400" fill="currentColor"/>
+<g transform="translate(63.5547, 4.5450)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1385" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(96.6184, 2.5450)">
+<g transform="translate(96.5308, 2.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(96.6834, 4.5450)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.7883" ry="0.0400" fill="currentColor"/>
+<g transform="translate(96.5958, 4.5450)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="5.1553" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(99.3511, 5.0450)">
+<g transform="translate(99.3073, 5.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(99.4161, 4.5450)">
-<rect x="-0.0650" y="0.6861" width="0.1300" height="2.3133" ry="0.0400" fill="currentColor"/>
+<g transform="translate(99.3723, 4.5450)">
+<rect x="-0.0650" y="0.6861" width="0.1300" height="2.8103" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(9.7500, 8.2350)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.9687 -0.2000 20.9687 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(8.3500, 7.5450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.9900 8.9194 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(9.7500, 9.0450)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.9687 -0.2000 20.9687 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(8.3500, 8.3550)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.9900 8.9194 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(33.6113, 4.5450)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.4687 -0.0100 20.4687 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(20.4559, 4.5450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 -0.2000 9.1694 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(33.6113, 5.3550)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.4687 -0.0100 20.4687 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(20.4559, 5.3550)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 -0.2000 9.1694 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(64.0591, 6.1314)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="11.7707 0.2136 11.7707 0.6136 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(32.5618, 4.5450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 -0.2000 8.9194 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(58.1662, 6.7350)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.6636 0.4200 17.6636 0.8200 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(32.5618, 5.3550)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 -0.2000 8.9194 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(81.9551, 2.5450)">
+<g transform="translate(44.4177, 4.7350)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.3000 8.9194 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(44.4177, 5.5450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.3000 8.9194 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(62.4547, 4.8070)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.4620 1.1250 -0.0620 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(57.4835, 6.7350)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.0962 -1.5800 6.0962 -1.1800 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(66.2661, 5.7350)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 0.6100 9.1694 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(66.2661, 6.5450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 0.6100 9.1694 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(78.3720, 6.7350)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 -0.3900 9.1694 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(78.3720, 7.5450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 -0.3900 9.1694 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(81.6485, 2.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(82.0201, 4.5450)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.6541" ry="0.0400" fill="currentColor"/>
+<g transform="translate(81.7135, 4.5450)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.7450" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(84.9378, 3.0450)">
+<g transform="translate(84.6749, 3.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(85.0028, 4.5450)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1814" ry="0.0400" fill="currentColor"/>
+<g transform="translate(84.7399, 4.5450)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1825" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(87.6704, 4.0450)">
+<g transform="translate(87.4514, 4.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(87.7354, 4.5450)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.2064" ry="0.0400" fill="currentColor"/>
+<g transform="translate(87.5164, 4.5450)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1252" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(90.6531, 3.5450)">
+<g transform="translate(90.4779, 3.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(90.7181, 4.5450)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.7337" ry="0.0400" fill="currentColor"/>
+<g transform="translate(90.5429, 4.5450)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.8175" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(93.3858, 4.5450)">
+<g transform="translate(93.2544, 4.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(93.4508, 4.5450)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.7587" ry="0.0400" fill="currentColor"/>
+<g transform="translate(93.3194, 4.5450)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.9725" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(18.4480, 4.0450)">
+<g transform="translate(23.2324, 2.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.5130, 4.5450)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(21.6807, 1.5450)">
+<g transform="translate(17.1794, 4.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(21.7457, 4.5450)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="7.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(17.2444, 4.5450)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="5.3053" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.2803, 4.5450)">
-<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(24.4133, 2.5450)">
+<g transform="translate(20.4559, 1.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(24.4783, 4.5450)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="6.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(20.5209, 4.5450)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(27.4610, 4.5450)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(23.2974, 4.5450)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(30.6287, 1.0450)">
+<g transform="translate(26.2588, 2.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(9.7500, 1.5450)">
+<g transform="translate(26.3238, 4.5450)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(53.2471, 3.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g color="rgb(100.0000%, 100.0000%, 100.0000%)">
-<g transform="translate(0.0000, 4.5450)">
-<rect x="0.0000" y="-2.0812" width="3.7500" height="4.1625" ry="0.0000" fill="currentColor"/>
+<g transform="translate(29.5353, 1.0450)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
+<g transform="translate(29.6003, 4.5450)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(0.6000, 4.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<g transform="translate(8.3500, 1.5450)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(1.6500, 4.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(2.7000, 4.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(4.7500, 3.5450)">
+<g transform="translate(0.8000, 3.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(9.8150, 4.5450)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="7.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(8.3000, 1.5450)">
+<g transform="translate(4.3000, 3.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(27.3960, 2.0450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(8.4150, 4.5450)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="6.6325" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(6.9000, 1.5450)">
+<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
+v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
 <g transform="translate(-2.2535, 1.4703)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>10</tspan>
 </text>
 </g>
-<g transform="translate(12.4827, 4.0450)">
+<g transform="translate(11.1265, 4.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.5477, 4.5450)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(11.1915, 4.5450)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.5013" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.2153, 6.5450)">
+<g transform="translate(13.9030, 6.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(48.0896, 4.5450)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.7580" ry="0.0400" fill="currentColor"/>
+<g transform="translate(13.9680, 4.5450)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3701" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(39.5767, 1.0450)">
+<g transform="translate(41.3912, 2.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(39.6417, 4.5450)">
-<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1798" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(48.0246, 2.5450)">
+<g transform="translate(38.6147, 1.0450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(30.6937, 4.5450)">
-<rect x="-0.0650" y="-3.3139" width="0.1300" height="7.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(38.6797, 4.5450)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.3093, 2.0450)">
+<g transform="translate(47.2591, 4.5450)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.9725" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(47.1941, 2.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(42.3743, 4.5450)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.2051" ry="0.0400" fill="currentColor"/>
+<g transform="translate(41.4562, 4.5450)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(45.2920, 1.5450)">
+<g transform="translate(44.4177, 1.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(45.3570, 4.5450)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.7327" ry="0.0400" fill="currentColor"/>
+<g transform="translate(44.4827, 4.5450)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8175" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(51.2573, 0.5450)">
+<g transform="translate(32.6268, 4.5450)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(32.5618, 1.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(33.6113, 1.5450)">
+<g transform="translate(35.3382, 2.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(51.3223, 4.5450)">
-<rect x="-0.0650" y="-3.8139" width="0.1300" height="4.7880" ry="0.0400" fill="currentColor"/>
+<g transform="translate(35.4032, 4.5450)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(33.6763, 4.5450)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6245" ry="0.0400" fill="currentColor"/>
+<g transform="translate(50.5356, 4.5450)">
+<rect x="-0.0650" y="-3.8139" width="0.1300" height="5.1553" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(36.4090, 4.5450)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6498" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(36.3440, 2.5450)">
+<g transform="translate(50.4706, 0.5450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 17.9282)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
+<g transform="translate(0.0000, 16.2450)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0898" y2="0"/>
 </g>
-<g transform="translate(0.0000, 16.9282)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
+<g transform="translate(0.0000, 15.2450)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0898" y2="0"/>
 </g>
-<g transform="translate(0.0000, 15.9282)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
+<g transform="translate(0.0000, 14.2450)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0898" y2="0"/>
 </g>
-<g transform="translate(0.0000, 14.9282)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
+<g transform="translate(0.0000, 13.2450)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0898" y2="0"/>
 </g>
-<g transform="translate(0.0000, 13.9282)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
+<g transform="translate(0.0000, 12.2450)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0898" y2="0"/>
 </g>
-<g transform="translate(44.8609, 15.9282)">
+<g transform="translate(44.9498, 14.2450)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(32.3399, 17.4282)">
+<g transform="translate(37.1872, 16.2450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(33.5791, 15.9282)">
+<g transform="translate(32.4288, 15.7450)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(33.6680, 14.2450)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(34.8441, 16.9282)">
+<g transform="translate(34.9330, 15.2450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(36.0833, 15.9282)">
+<g transform="translate(36.1722, 14.2450)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(24.8272, 17.9282)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(26.1553, 14.2450)">
+<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(31.3249, 15.9282)">
+<g transform="translate(31.4138, 14.2450)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(30.0857, 16.4282)">
+<g transform="translate(30.1745, 14.7450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.8207, 15.9282)">
+<g transform="translate(28.9095, 14.2450)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(27.5814, 15.9282)">
+<g transform="translate(27.6703, 14.2450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(26.0664, 15.9282)">
+<g transform="translate(36.1072, 11.4350)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(36.1072, 12.2450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(26.0903, 11.4350)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(26.0903, 12.2450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(16.0735, 11.4350)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 0.6100 7.6026 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(16.0735, 12.2450)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 0.6100 7.6026 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(11.5212, 16.5809)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.5359 1.1250 -0.1359 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(7.9000, 18.4350)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="4.7462 -1.5800 4.7462 -1.1800 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(38.4264, 14.2450)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(26.0014, 13.1182)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.3695 -0.2000 17.3695 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(26.0014, 13.9282)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.3695 -0.2000 17.3695 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(9.0742, 11.9282)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="14.5130 -0.0100 14.5130 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(13.7304, 12.7989)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.8568 -0.0708 9.8568 0.3292 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(37.0983, 17.9282)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(43.3459, 15.9282)">
+<g transform="translate(43.4348, 14.2450)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.1067, 18.4282)">
+<g transform="translate(42.1956, 16.7450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(41.0917, 15.9282)">
+<g transform="translate(41.1806, 14.2450)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(39.8525, 15.9282)">
+<g transform="translate(39.9414, 14.2450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(38.3375, 15.9282)">
-<rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 16.9282)">
+<g transform="translate(7.9000, 15.2450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(14.8104, 15.9282)">
+<g transform="translate(14.8993, 14.2450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(13.7954, 15.9282)">
-<rect x="-0.0650" y="-3.9384" width="0.1300" height="2.2523" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(12.5562, 14.4282)">
+<g transform="translate(24.9161, 16.2450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(9.1392, 15.9282)">
-<rect x="-0.0650" y="-3.9992" width="0.1300" height="4.8130" ry="0.0400" fill="currentColor"/>
+<g transform="translate(12.6212, 14.2450)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1426" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(9.6542, 16.4282)">
+<g transform="translate(12.5562, 12.7450)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(7.9650, 14.2450)">
+<rect x="-0.0650" y="1.1861" width="0.1300" height="2.9852" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(9.6542, 14.7450)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(8.5521, 11.4450)">
+<g transform="translate(8.5521, 11.9450)">
 <path transform="scale(0.0040, -0.0040)" d="M-297 227c0 -15 8 -30 39 -30c10 0 46 2 103 28l5 24c-23 17 -50 29 -81 29c-51 0 -66 -31 -66 -51zM-26 104c0 -61 -47 -115 -98 -115c-39 0 -56 44 -56 91c0 14 1 28 4 41l15 76c-20 -8 -63 -25 -101 -25c-19 0 -60 6 -60 51c0 38 32 80 96 80c31 0 58 -10 82 -25
 l46 232c6 -3 13 -5 20 -5c22 0 48 16 68 35l-53 -266l64 36c26 14 51 20 74 20c29 0 53 -10 64 -28c18 20 44 30 69 30c36 0 69 -22 69 -69c0 -49 -31 -90 -65 -90c-25 0 -38 22 -38 48c0 50 37 64 60 64h3c-8 14 -23 20 -38 20c-24 0 -50 -16 -55 -43l-54 -270
 c-11 7 -24 11 -38 11s-29 -4 -43 -11l54 270v7c0 16 -12 26 -29 26c-7 0 -16 -3 -24 -7l-79 -44l-7 -31c27 -31 50 -67 50 -109zM-86 39c23 0 35 34 35 61c0 30 -14 55 -32 78l-5 -27c-4 -18 -13 -56 -13 -83c0 -17 4 -29 15 -29z" fill="currentColor"/>
 </g>
-<g transform="translate(-2.2535, 12.8782)">
+<g transform="translate(-2.2535, 11.1950)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>12</tspan>
 </text>
 </g>
-<g transform="translate(4.3000, 14.9282)">
+<g transform="translate(4.3000, 13.2450)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 14.9282)">
+<g transform="translate(0.8000, 13.2450)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(21.0580, 15.9282)">
-<rect x="-0.0650" y="-3.8435" width="0.1300" height="4.6574" ry="0.0400" fill="currentColor"/>
+<g transform="translate(21.1469, 14.2450)">
+<rect x="-0.0650" y="-2.2723" width="0.1300" height="3.0862" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(19.8188, 16.9282)">
+<g transform="translate(22.4119, 15.7450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(16.0496, 15.9282)">
-<rect x="-0.0650" y="-3.9089" width="0.1300" height="3.7228" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(22.3230, 17.4282)">
+<g transform="translate(19.9077, 15.2450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.5538, 15.9282)">
-<rect x="-0.0650" y="-3.8762" width="0.1300" height="4.1901" ry="0.0400" fill="currentColor"/>
+<g transform="translate(16.1385, 14.2450)">
+<rect x="-0.0650" y="-2.8031" width="0.1300" height="2.6170" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(17.3146, 16.4282)">
+<g transform="translate(23.6511, 14.2450)">
+<rect x="-0.0650" y="-2.0069" width="0.1300" height="3.3208" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(18.6427, 14.2450)">
+<rect x="-0.0650" y="-2.5377" width="0.1300" height="2.8516" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(17.4035, 14.7450)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(23.5622, 15.9282)">
-<rect x="-0.0650" y="-3.8108" width="0.1300" height="5.1247" ry="0.0400" fill="currentColor"/>
 </g>
 </svg>

--- a/scores/allemande/mm-4-6.svg
+++ b/scores/allemande/mm-4-6.svg
@@ -1,445 +1,471 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="34.96mm" viewBox="-1.1267 -0.0000 103.5567 19.8934">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="36.20mm" viewBox="-1.1267 -0.0000 103.5567 20.6003">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
-<g transform="translate(0.0000, 3.5584)">
-<rect x="86.8045" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 8.5597)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 3.5584)">
-<rect x="61.7338" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 7.5597)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 3.5584)">
-<rect x="42.0809" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 6.5597)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(54.4185, 6.5584)">
+<g transform="translate(0.0000, 5.5597)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+</g>
+<g transform="translate(0.0000, 4.5597)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+</g>
+<g transform="translate(0.0000, 3.5597)">
+<rect x="86.5067" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 3.5597)">
+<rect x="60.9248" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 3.5597)">
+<rect x="40.9208" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(53.4967, 6.5597)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(102.2399, 6.5584)">
+<g transform="translate(102.2399, 6.5597)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 8.5584)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
-</g>
-<g transform="translate(0.0000, 7.5584)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
-</g>
-<g transform="translate(0.0000, 6.5584)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
-</g>
-<g transform="translate(0.0000, 5.5584)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
-</g>
-<g transform="translate(0.0000, 4.5584)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
-</g>
-<g transform="translate(67.9340, 5.0584)">
+<g transform="translate(73.4873, 5.0597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(68.1593, 3.5279)">
+<g transform="translate(67.2441, 5.0597)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(70.4307, 6.5597)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.7501" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(70.3657, 5.5597)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(67.3091, 6.5597)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3126" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(67.4694, 3.5296)">
 <path transform="scale(0.0022, -0.0022)" d="M94 66c-60 0 -39 -66 -72 -66c-11 0 -22 7 -22 21c0 154 232 162 232 334c0 50 -17 102 -61 102c-33 0 -66 -14 -66 -44c0 -24 31 -37 31 -61c0 -34 -27 -61 -61 -61s-61 27 -61 61c0 84 72 148 157 148c98 0 190 -55 190 -145c0 -140 -131 -154 -225 -205
 c85 -2 113 -61 165 -61c45 0 28 41 57 41c11 0 22 -8 22 -21c0 -29 -48 -109 -144 -109c-92 0 -96 66 -142 66z" fill="currentColor"/>
 </g>
-<g transform="translate(67.9990, 6.5584)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(73.5523, 6.5597)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1877" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(70.9961, 5.5584)">
+<g transform="translate(76.6090, 4.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(71.0611, 6.5584)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(76.6740, 6.5597)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6252" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(74.0581, 5.0584)">
+<g transform="translate(80.5806, 6.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(74.1231, 6.5584)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(77.1202, 4.5584)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(77.1852, 6.5584)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(81.0323, 6.5584)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(81.6844, 4.2584)">
+<g transform="translate(81.2327, 4.2597)">
 <path transform="scale(0.0040, -0.0040)" d="M-297 227c0 -15 8 -30 39 -30c10 0 46 2 103 28l5 24c-23 17 -50 29 -81 29c-51 0 -66 -31 -66 -51zM-26 104c0 -61 -47 -115 -98 -115c-39 0 -56 44 -56 91c0 14 1 28 4 41l15 76c-20 -8 -63 -25 -101 -25c-19 0 -60 6 -60 51c0 38 32 80 96 80c31 0 58 -10 82 -25
 l46 232c6 -3 13 -5 20 -5c22 0 48 16 68 35l-53 -266l64 36c26 14 51 20 74 20c29 0 53 -10 64 -28c18 20 44 30 69 30c36 0 69 -22 69 -69c0 -49 -31 -90 -65 -90c-25 0 -38 22 -38 48c0 50 37 64 60 64h3c-8 14 -23 20 -38 20c-24 0 -50 -16 -55 -43l-54 -270
 c-11 7 -24 11 -38 11s-29 -4 -43 -11l54 270v7c0 16 -12 26 -29 26c-7 0 -16 -3 -24 -7l-79 -44l-7 -31c27 -31 50 -67 50 -109zM-86 39c23 0 35 34 35 61c0 30 -14 55 -32 78l-5 -27c-4 -18 -13 -56 -13 -83c0 -17 4 -29 15 -29z" fill="currentColor"/>
 </g>
-<g transform="translate(87.1305, 8.6857)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.3383 -0.3273 12.3383 0.0727 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(82.3348, 6.0597)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(81.0323, 9.5584)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="18.4365 -0.3900 18.4365 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(80.6456, 6.5597)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="3.2967" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(56.0007, 6.5584)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(55.0726, 6.5597)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(81.0973, 6.5584)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8132" ry="0.0400" fill="currentColor"/>
+<g transform="translate(89.9544, 6.7497)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 0.8000 9.4549 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(58.9977, 4.0584)">
+<g transform="translate(89.9544, 7.5597)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 0.8000 9.4549 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(58.1292, 4.0597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(59.0627, 6.5584)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(58.1942, 6.5597)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(62.0598, 3.5584)">
+<g transform="translate(61.2508, 3.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(62.1248, 6.5584)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(61.3158, 6.5597)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(64.8719, 4.5584)">
+<g transform="translate(64.1224, 4.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(64.9369, 6.5584)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(64.1874, 6.5597)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(99.3788, 5.5584)">
+<g transform="translate(99.3193, 5.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(99.4438, 6.5584)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6246" ry="0.0400" fill="currentColor"/>
+<g transform="translate(99.3843, 6.5597)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8070" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(96.3818, 6.5584)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1561" ry="0.0400" fill="currentColor"/>
+<g transform="translate(7.9000, 6.5597)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7951 -3.5450C1.7841 -3.9898 3.1679 -3.5079 3.6667 -2.5450L3.6667 -2.5450C3.1284 -3.3946 1.7446 -3.8765 0.7951 -3.5450z"/>
 </g>
-<g transform="translate(9.7500, 6.5584)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7978 -3.5450C1.7751 -3.9774 3.1249 -3.4974 3.6098 -2.5450L3.6098 -2.5450C3.0847 -3.3844 1.7349 -3.8644 0.7978 -3.5450z"/>
+<g transform="translate(13.8933, 6.5597)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8371 -2.5450C1.9020 -2.8946 3.2985 -2.2381 3.7087 -1.1950L3.7087 -1.1950C3.2474 -2.1295 1.8510 -2.7860 0.8371 -2.5450z"/>
 </g>
-<g transform="translate(15.6241, 6.5584)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8403 -2.5450C1.8938 -2.8819 3.2563 -2.2278 3.6523 -1.1950L3.6523 -1.1950C3.2044 -2.1196 1.8419 -2.7737 0.8403 -2.5450z"/>
+<g transform="translate(19.8865, 6.5597)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5091 1.1961C1.0079 2.1613 2.3917 2.6432 3.3808 2.1961L3.3808 2.1961C2.4312 2.5298 1.0474 2.0479 0.5091 1.1961z"/>
 </g>
-<g transform="translate(21.4983, 6.5584)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7978 -1.1988C1.7751 -1.6396 3.1249 -1.1596 3.6098 -0.1988L3.6098 -0.1988C3.0847 -1.0465 1.7349 -1.5265 0.7978 -1.1988z"/>
+<g transform="translate(7.9000, 7.5597)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9549 0.9900 8.9549 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(27.3725, 6.5584)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7978 -0.1988C1.7751 -0.6396 3.1249 -0.1596 3.6098 0.8012L3.6098 0.8012C3.0847 -0.0465 1.7349 -0.5265 0.7978 -0.1988z"/>
+<g transform="translate(7.9000, 8.3697)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9549 0.9900 8.9549 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(9.7500, 7.7484)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.5245 2.3000 20.5245 2.7000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(25.8798, 6.5597)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5287 2.1950C1.0657 3.1224 2.4451 3.5307 3.4003 3.0450L3.4003 3.0450C2.4791 3.4156 1.0998 3.0073 0.5287 2.1950z"/>
 </g>
-<g transform="translate(9.7500, 8.5584)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.5245 2.3000 20.5245 2.7000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(21.0607, 3.5597)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9549 0.8000 8.9549 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(42.4069, 6.5584)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7222 -4.0450C2.6441 -5.1725 8.4449 -4.2253 9.9084 -2.5450L9.9084 -2.5450C8.4256 -4.1069 2.6248 -5.0541 0.7222 -4.0450z"/>
+<g transform="translate(21.0607, 4.3697)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9549 0.8000 8.9549 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(55.9357, 6.5584)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5820 -3.0450C1.7077 -4.4295 5.1986 -4.9995 6.7062 -4.0450L6.7062 -4.0450C5.2179 -4.8810 1.7271 -4.3110 0.5820 -3.0450z"/>
+<g transform="translate(41.2468, 6.5597)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7209 -4.0450C2.6591 -5.1854 8.6006 -4.2337 10.0858 -2.5450L10.0858 -2.5450C8.5816 -4.1152 2.6402 -5.0669 0.7209 -4.0450z"/>
 </g>
-<g transform="translate(39.3448, 9.6906)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.3383 -1.3322 12.3383 -0.9322 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(37.0902, 8.9941)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.6344 1.1250 -0.2344 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(33.2466, 11.0584)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="18.4365 -1.8900 18.4365 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(31.8730, 11.7497)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.3422 -2.5800 6.3422 -2.1800 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(67.9340, 6.5584)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -2.5450C1.9745 -3.7217 5.4538 -3.7217 6.7763 -2.5450L6.7763 -2.5450C5.4538 -3.6017 1.9745 -3.6017 0.6521 -2.5450z"/>
+<g transform="translate(55.0076, 6.5597)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5833 -3.0450C1.7279 -4.4402 5.3035 -5.0129 6.8266 -4.0450L6.8266 -4.0450C5.3225 -4.8945 1.7469 -4.3217 0.5833 -3.0450z"/>
 </g>
-<g transform="translate(55.9357, 7.5584)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="21.2745 -0.2000 21.2745 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(41.2468, 6.7497)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 0.6100 9.4549 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(55.9357, 8.3684)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="21.2745 -0.2000 21.2745 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(41.2468, 7.5597)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 0.6100 9.4549 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(79.5823, 6.5584)">
+<g transform="translate(67.2441, 6.5597)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -2.5450C1.9916 -3.7338 5.5558 -3.7338 6.8954 -2.5450L6.8954 -2.5450C5.5558 -3.6138 1.9916 -3.6138 0.6521 -2.5450z"/>
+</g>
+<g transform="translate(55.0076, 6.7497)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.2049 -0.2000 9.2049 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(55.0076, 7.5597)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.2049 -0.2000 9.2049 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(67.2441, 7.7497)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 -0.3900 9.4549 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(67.2441, 8.5597)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 -0.3900 9.4549 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(85.7978, 7.8682)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.5085 1.1250 -0.1085 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(80.5806, 10.0597)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.3422 -1.8900 6.3422 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(79.1306, 6.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(87.1305, 3.5584)">
+<g transform="translate(86.8328, 3.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(87.3217, 2.5134)">
+<g transform="translate(87.0239, 2.5147)">
 <path transform="scale(0.0022, -0.0022)" d="M148 501c10 0 41 -15 72 -15c32 0 63 15 76 15c15 0 26 -11 26 -21c0 -4 -1 -7 -4 -10l-264 -291h134v4c0 60 50 41 75 85c7 11 8 24 14 36c3 7 10 10 17 10c11 0 24 -8 24 -25v-110h70c18 0 27 -14 27 -27s-9 -27 -27 -27h-70c2 -45 36 -82 80 -82c14 0 22 -10 22 -21
 s-8 -22 -22 -22c-49 0 -96 14 -145 14s-97 -14 -146 -14c-14 0 -21 11 -21 22s7 21 21 21c44 0 79 37 81 82h-134c-43 0 -57 25 -57 42c0 5 1 10 3 12c73 81 123 182 123 291c0 17 11 31 25 31z" fill="currentColor"/>
 </g>
-<g transform="translate(87.1955, 6.5584)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="5.7505" ry="0.0400" fill="currentColor"/>
+<g transform="translate(86.8978, 6.5597)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.6411" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(82.7865, 6.0584)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(90.1926, 4.0584)">
+<g transform="translate(89.9544, 4.0597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(90.2576, 6.5584)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="5.2190" ry="0.0400" fill="currentColor"/>
+<g transform="translate(90.0194, 6.5597)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3207" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(93.2547, 4.5584)">
+<g transform="translate(93.0760, 4.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(93.3197, 6.5584)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.6875" ry="0.0400" fill="currentColor"/>
+<g transform="translate(93.1410, 6.5597)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1495" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(96.3168, 5.0584)">
+<g transform="translate(96.1977, 5.0597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(24.3754, 6.5584)">
-<rect x="-0.0650" y="1.1861" width="0.1300" height="2.5919" ry="0.0400" fill="currentColor"/>
+<g transform="translate(96.2627, 6.5597)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9783" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(18.4362, 6.5584)">
+<g transform="translate(16.7649, 6.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.5012, 6.5584)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8778" ry="0.0400" fill="currentColor"/>
+<g transform="translate(16.8299, 6.5597)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8053" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(21.4983, 6.5584)">
+<g transform="translate(19.8865, 6.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(21.5633, 6.5584)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="3.2500" ry="0.0400" fill="currentColor"/>
+<g transform="translate(21.1257, 6.5597)">
+<rect x="-0.0650" y="-2.9928" width="0.1300" height="2.8067" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(24.3104, 7.5584)">
+<g transform="translate(22.7582, 7.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(27.3725, 7.5584)">
+<g transform="translate(23.9974, 6.5597)">
+<rect x="-0.0650" y="-2.6735" width="0.1300" height="3.4874" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(25.8798, 7.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(27.4375, 6.5584)">
-<rect x="-0.0650" y="1.1861" width="0.1300" height="2.9641" ry="0.0400" fill="currentColor"/>
+<g transform="translate(27.1190, 6.5597)">
+<rect x="-0.0650" y="-2.3265" width="0.1300" height="3.1404" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(30.1845, 8.5584)">
+<g transform="translate(28.7514, 8.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(30.2495, 6.5584)">
-<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3060" ry="0.0400" fill="currentColor"/>
+<g transform="translate(29.9906, 6.5597)">
+<rect x="-0.0650" y="-2.0072" width="0.1300" height="3.8211" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(9.7500, 4.0584)">
+<g transform="translate(7.9000, 4.0597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g color="rgb(100.0000%, 100.0000%, 100.0000%)">
-<g transform="translate(0.0000, 6.5584)">
-<rect x="0.0000" y="-2.0812" width="3.7500" height="4.1625" ry="0.0000" fill="currentColor"/>
-</g>
-</g>
-<g transform="translate(0.6000, 6.5584)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(1.6500, 6.5584)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(2.7000, 6.5584)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(4.7500, 5.5584)">
+<g transform="translate(0.8000, 5.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(9.8150, 6.5584)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.3218" ry="0.0400" fill="currentColor"/>
+<g transform="translate(4.3000, 5.5597)">
+<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
+v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 3.5084)">
+<g transform="translate(7.9650, 6.5597)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1325" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(-1.1267, 3.5097)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>4</tspan>
 </text>
 </g>
-<g transform="translate(12.5621, 5.0584)">
+<g transform="translate(10.7716, 5.0597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.6271, 6.5584)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.6637" ry="0.0400" fill="currentColor"/>
+<g transform="translate(10.8366, 6.5597)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.5124" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.6241, 5.0584)">
+<g transform="translate(13.8933, 5.0597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(15.6891, 6.5584)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.0359" ry="0.0400" fill="currentColor"/>
+<g transform="translate(13.9583, 6.5597)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.9254" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(48.5311, 4.5584)">
+<g transform="translate(47.5551, 6.5597)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.3520" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(41.2468, 3.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(42.4069, 3.5584)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(43.0590, 2.0800)">
+<g transform="translate(41.8990, 2.0800)">
 <path transform="scale(0.0040, -0.0040)" d="M128 508c2 7 9 12 17 12c10 0 18 -7 18 -17c0 -2 -1 -4 -1 -6l-145 -485c-2 -7 -9 -12 -17 -12s-15 5 -17 12l-145 485v6c0 10 7 17 17 17c8 0 15 -5 17 -12l88 -295l40 -164l40 164z" fill="currentColor"/>
 </g>
-<g transform="translate(42.4719, 6.5584)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="6.4701" ry="0.0400" fill="currentColor"/>
+<g transform="translate(41.3118, 6.5597)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8194" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(45.4690, 4.0584)">
+<g transform="translate(44.3685, 4.0597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(45.5340, 6.5584)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="5.6900" ry="0.0400" fill="currentColor"/>
+<g transform="translate(44.4335, 6.5597)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.5857" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(48.5961, 6.5584)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.9099" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(51.5932, 5.0584)">
+<g transform="translate(47.4901, 4.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(51.6582, 6.5584)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1298" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(55.9357, 4.5584)">
+<g transform="translate(50.6117, 5.0597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(56.1781, 2.8863)">
+<g transform="translate(50.6767, 6.5597)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1183" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(55.0076, 4.5597)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(55.2499, 2.8914)">
 <path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
 c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
 </g>
-<g transform="translate(33.3116, 6.5584)">
-<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3079" ry="0.0400" fill="currentColor"/>
+<g transform="translate(31.9380, 6.5597)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.9797" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(39.3448, 4.0584)">
+<g transform="translate(38.1252, 4.0597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(35.0008, 8.0584)">
+<g transform="translate(38.7773, 3.3147)">
+<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
+</g>
+<g transform="translate(38.1902, 6.5597)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="5.1481" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(33.6273, 8.0597)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(33.8987, 4.2584)">
+<g transform="translate(32.5252, 4.2597)">
 <path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
 </g>
-<g transform="translate(33.2466, 8.5584)">
+<g transform="translate(31.8730, 8.5597)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(39.4098, 6.5584)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.2502" ry="0.0400" fill="currentColor"/>
+<g transform="translate(0.0000, 18.3603)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
 </g>
-<g transform="translate(39.9970, 3.3134)">
-<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
+<g transform="translate(0.0000, 17.3603)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
 </g>
-<g transform="translate(0.0000, 19.3484)">
+<g transform="translate(0.0000, 16.3603)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
+</g>
+<g transform="translate(0.0000, 15.3603)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
+</g>
+<g transform="translate(0.0000, 14.3603)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
+</g>
+<g transform="translate(0.0000, 19.3603)">
 <rect x="26.6077" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 19.3484)">
+<g transform="translate(0.0000, 19.3603)">
 <rect x="24.1034" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 18.3484)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
-</g>
-<g transform="translate(0.0000, 17.3484)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
-</g>
-<g transform="translate(0.0000, 16.3484)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
-</g>
-<g transform="translate(0.0000, 15.3484)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
-</g>
-<g transform="translate(0.0000, 14.3484)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0009" y2="0"/>
-</g>
-<g transform="translate(44.8609, 16.3484)">
+<g transform="translate(44.5220, 16.3603)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(31.5899, 17.3484)">
+<g transform="translate(37.0094, 14.8603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(32.8291, 16.3484)">
-<rect x="-0.0650" y="-2.9853" width="0.1300" height="3.7992" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(34.3441, 15.8484)">
+<g transform="translate(31.5899, 17.3603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(35.5833, 16.3484)">
-<rect x="-0.0650" y="-3.4493" width="0.1300" height="2.7632" ry="0.0400" fill="currentColor"/>
+<g transform="translate(32.8291, 16.3603)">
+<rect x="-0.0650" y="-1.9838" width="0.1300" height="2.7977" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(28.1729, 16.3484)">
-<rect x="-0.0650" y="-2.2009" width="0.1300" height="5.0148" ry="0.0400" fill="currentColor"/>
+<g transform="translate(34.2552, 15.8603)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.6879, 18.8484)">
+<g transform="translate(34.3202, 16.3603)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1174" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(28.1729, 16.3603)">
+<rect x="-0.0650" y="-0.8262" width="0.1300" height="3.6401" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(28.6879, 18.8603)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(26.9337, 19.3484)">
+<g transform="translate(26.9337, 19.3603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(25.6687, 16.3484)">
-<rect x="-0.0650" y="-1.8193" width="0.1300" height="4.6332" ry="0.0400" fill="currentColor"/>
+<g transform="translate(25.6687, 16.3603)">
+<rect x="-0.0650" y="-1.0091" width="0.1300" height="3.8230" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(24.4295, 19.3484)">
+<g transform="translate(24.4295, 19.3603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.1079, 14.1584)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="15.5130 -2.8200 15.5130 -2.4200 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(34.2552, 18.3603)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.0100 8.1026 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(32.7641, 14.1840)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="10.8568 -2.0356 10.8568 -1.6356 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(34.2552, 19.1703)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.0100 8.1026 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(9.0742, 12.1584)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="16.6195 2.1800 16.6195 2.5800 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(28.1079, 15.5503)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="4.7462 -1.3900 4.7462 -0.9900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(9.0742, 12.9684)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="16.6195 2.1800 16.6195 2.5800 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(31.7291, 15.4600)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.4897 1.1250 -0.0897 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(37.0983, 14.8484)">
+<g transform="translate(18.5911, 14.3603)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(18.5911, 15.1703)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(7.9000, 18.3603)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(7.9000, 19.1703)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(37.0744, 16.3603)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.8434" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(42.3328, 16.3603)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.8204" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(42.2678, 14.3603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(43.5959, 16.3484)">
-<rect x="-0.0650" y="-4.7991" width="0.1300" height="2.6129" ry="0.0400" fill="currentColor"/>
+<g transform="translate(39.5786, 16.3603)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.0943" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.3567, 14.3484)">
+<g transform="translate(39.5136, 15.3603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(40.8417, 16.3484)">
-<rect x="-0.0650" y="-4.3351" width="0.1300" height="3.1490" ry="0.0400" fill="currentColor"/>
+<g transform="translate(12.7234, 16.3603)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.9275" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(39.6025, 15.3484)">
+<g transform="translate(10.2192, 16.3603)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.5103" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(10.1542, 15.8603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(38.3375, 16.3484)">
-<rect x="-0.0650" y="-3.9132" width="0.1300" height="2.2271" ry="0.0400" fill="currentColor"/>
+<g transform="translate(7.9650, 16.3603)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1347" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 14.8484)">
+<g transform="translate(7.9000, 14.8603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(13.8976, 16.3484)">
-<rect x="-0.0650" y="-3.5009" width="0.1300" height="2.8148" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(12.6584, 15.8484)">
+<g transform="translate(12.6584, 15.8603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(11.3934, 16.3484)">
-<rect x="-0.0650" y="-3.8587" width="0.1300" height="3.1726" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(10.1542, 15.8484)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(9.1392, 16.3484)">
-<rect x="-0.0650" y="-4.1807" width="0.1300" height="2.4946" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(23.4145, 16.3484)">
-<rect x="-0.0650" y="-2.1413" width="0.1300" height="3.9552" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(-1.1267, 13.2737)">
+<g transform="translate(-1.1267, 13.2856)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>6</tspan>
 </text>
 </g>
-<g transform="translate(4.3000, 15.3484)">
+<g transform="translate(4.3000, 15.3603)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 15.3484)">
+<g transform="translate(0.8000, 15.3603)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(22.1753, 18.3484)">
+<g transform="translate(18.6561, 16.3603)">
+<rect x="-0.0650" y="-1.9909" width="0.1300" height="2.8048" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(23.4145, 16.3603)">
+<rect x="-0.0650" y="-1.3247" width="0.1300" height="3.1386" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(22.1753, 18.3603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(20.9103, 16.3484)">
-<rect x="-0.0650" y="-2.4991" width="0.1300" height="4.3130" ry="0.0400" fill="currentColor"/>
+<g transform="translate(20.9103, 16.3603)">
+<rect x="-0.0650" y="-1.6753" width="0.1300" height="3.4892" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(19.6711, 18.3484)">
+<g transform="translate(19.6711, 18.3603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.6561, 16.3484)">
-<rect x="-0.0650" y="-2.8211" width="0.1300" height="3.6350" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(17.4169, 17.3484)">
+<g transform="translate(17.4169, 17.3603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(16.1519, 16.3484)">
-<rect x="-0.0650" y="-3.1789" width="0.1300" height="3.9928" ry="0.0400" fill="currentColor"/>
+<g transform="translate(14.9776, 16.3603)">
+<rect x="-0.0650" y="1.1861" width="0.1300" height="2.8031" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(14.9126, 17.3484)">
+<g transform="translate(14.9126, 17.3603)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 </svg>

--- a/scores/allemande/mm-6-8.svg
+++ b/scores/allemande/mm-6-8.svg
@@ -1,410 +1,436 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="29.03mm" viewBox="-1.1267 -0.0000 103.5567 16.5206">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="28.73mm" viewBox="-1.1267 0.0000 103.5567 16.3506">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
-<g transform="translate(0.0000, 2.0500)">
-<rect x="82.0397" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 6.5000)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 2.0500)">
-<rect x="70.4130" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 5.5000)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 8.0500)">
-<rect x="31.9793" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 4.5000)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 8.0500)">
-<rect x="29.0349" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+<g transform="translate(0.0000, 3.5000)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(102.2399, 5.0500)">
+<g transform="translate(0.0000, 2.5000)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+</g>
+<g transform="translate(0.0000, 1.5000)">
+<rect x="81.5602" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.5000)">
+<rect x="69.6597" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 7.5000)">
+<rect x="30.6772" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 7.5000)">
+<rect x="27.6643" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(102.2399, 4.5000)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(53.5715, 5.0500)">
+<g transform="translate(52.4500, 4.5000)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 7.0500)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
+<g transform="translate(72.6626, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.2540" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 6.0500)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
-</g>
-<g transform="translate(0.0000, 5.0500)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
-</g>
-<g transform="translate(0.0000, 4.0500)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
-</g>
-<g transform="translate(0.0000, 3.0500)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
-</g>
-<g transform="translate(73.2825, 3.5500)">
+<g transform="translate(72.5976, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(66.7936, 3.5500)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(66.8586, 5.0500)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(70.5880, 2.0500)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(70.6530, 5.0500)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(69.1380, 2.0500)">
+<g transform="translate(68.3847, 1.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(79.2363, 5.0500)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(69.8997, 4.5000)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.7003" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(73.3475, 5.0500)">
+<g transform="translate(69.8347, 1.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(75.6105, 3.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(75.6755, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8126" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(78.6234, 3.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(78.6884, 4.5000)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(76.2269, 4.0500)">
+<g transform="translate(90.6750, 7.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.8787 -0.2000 8.8787 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(90.6750, 8.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.8787 -0.2000 8.8787 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(56.9330, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(76.2919, 5.0500)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(56.9980, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.6877" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(79.1713, 3.5500)">
+<g transform="translate(66.0368, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1252" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(59.9460, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(58.0254, 5.0500)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(60.0110, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.2501" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(79.1713, 8.0500)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.4509 -0.2000 20.4509 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(79.1713, 8.8600)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.4509 -0.2000 20.4509 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(55.0809, 5.0500)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(57.9604, 4.0500)">
+<g transform="translate(62.9589, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(60.9048, 4.5500)">
+<g transform="translate(63.0239, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8125" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(65.9718, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(60.9698, 5.0500)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(63.8492, 4.0500)">
+<g transform="translate(96.2008, 6.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(63.9142, 5.0500)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(96.3378, 6.5500)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(96.4028, 5.0500)">
+<g transform="translate(96.2658, 4.5000)">
 <rect x="-0.0650" y="1.6861" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(99.5322, 3.5500)">
+<g transform="translate(99.4637, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(99.5972, 5.0500)">
+<g transform="translate(99.5287, 4.5000)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(10.9242, 0.5500)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="19.7009 2.3000 19.7009 2.7000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(7.9000, 6.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.9900 8.6287 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(10.9242, 1.3600)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="19.7009 2.3000 19.7009 2.7000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(7.9000, 7.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.9900 8.6287 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(33.4795, 2.8600)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="18.4118 -2.8200 18.4118 -2.4200 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(20.6258, 2.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.8000 8.6287 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(39.2736, 2.8473)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.6177 -1.9973 12.6177 -1.5973 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(20.6258, 3.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.8000 8.6287 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(55.0159, 6.2400)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="21.3009 -0.2000 21.3009 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(32.1775, 3.6900)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.0611 -1.3900 6.0611 -0.9900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(55.0159, 7.0500)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="21.3009 -0.2000 21.3009 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(37.1136, 3.5372)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.4272 1.1250 -0.0272 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(82.3657, 2.0500)">
+<g transform="translate(40.1484, 6.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.6287 -1.0100 9.6287 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(40.1484, 7.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.6287 -1.0100 9.6287 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(53.9201, 5.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1287 -0.0100 9.1287 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(53.9201, 6.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1287 -0.0100 9.1287 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(65.9718, 5.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.7287 -0.0100 9.7287 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(65.9718, 6.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.7287 -0.0100 9.7287 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(78.6234, 5.6900)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1287 -0.2000 9.1287 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(78.6234, 6.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1287 -0.2000 9.1287 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(81.8863, 1.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(82.4307, 5.0500)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="6.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(81.9513, 4.5000)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(85.0601, 4.5500)">
+<g transform="translate(84.6492, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(85.1251, 5.0500)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(84.7142, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(88.0045, 4.0500)">
+<g transform="translate(87.6621, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(88.0695, 5.0500)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(87.7271, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(90.9490, 3.5500)">
+<g transform="translate(90.6750, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(91.0140, 5.0500)">
+<g transform="translate(90.7400, 4.5000)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(93.6434, 4.5500)">
+<g transform="translate(93.4379, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(93.7084, 5.0500)">
+<g transform="translate(93.5029, 4.5000)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(18.0832, 6.0500)">
+<g transform="translate(23.4537, 4.5000)">
+<rect x="-0.0650" y="-1.6738" width="0.1300" height="3.4877" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(16.4387, 5.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(19.3225, 5.0500)">
-<rect x="-0.0650" y="-3.4364" width="0.1300" height="4.2503" ry="0.0400" fill="currentColor"/>
+<g transform="translate(16.5037, 4.5000)">
+<rect x="-0.0650" y="1.1861" width="0.1300" height="2.8050" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(21.0277, 6.0500)">
+<g transform="translate(19.4516, 5.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(22.2669, 5.0500)">
-<rect x="-0.0650" y="-3.0636" width="0.1300" height="3.8775" ry="0.0400" fill="currentColor"/>
+<g transform="translate(20.6908, 4.5000)">
+<rect x="-0.0650" y="-1.9925" width="0.1300" height="2.8064" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(23.7221, 7.0500)">
+<g transform="translate(22.2145, 6.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(24.9613, 5.0500)">
-<rect x="-0.0650" y="-2.7223" width="0.1300" height="4.5362" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(26.6665, 7.0500)">
+<g transform="translate(25.2274, 6.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(29.3609, 8.0500)">
+<g transform="translate(26.4667, 4.5000)">
+<rect x="-0.0650" y="-1.3262" width="0.1300" height="3.1401" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(27.9903, 7.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(30.6001, 5.0500)">
-<rect x="-0.0650" y="-2.0082" width="0.1300" height="4.8221" ry="0.0400" fill="currentColor"/>
+<g transform="translate(29.2296, 4.5000)">
+<rect x="-0.0650" y="-1.0075" width="0.1300" height="3.8214" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(9.7500, 3.5500)">
+<g transform="translate(7.9000, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g color="rgb(100.0000%, 100.0000%, 100.0000%)">
-<g transform="translate(0.0000, 5.0500)">
-<rect x="0.0000" y="-2.0812" width="3.7500" height="4.1625" ry="0.0000" fill="currentColor"/>
-</g>
-</g>
-<g transform="translate(0.6000, 5.0500)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(1.6500, 5.0500)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(2.7000, 5.0500)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(4.7500, 4.0500)">
+<g transform="translate(0.8000, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(10.9892, 5.0500)">
-<rect x="-0.0650" y="-4.4918" width="0.1300" height="2.8057" ry="0.0400" fill="currentColor"/>
+<g transform="translate(4.3000, 3.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
+v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(27.9057, 5.0500)">
-<rect x="-0.0650" y="-2.3495" width="0.1300" height="4.1633" ry="0.0400" fill="currentColor"/>
+<g transform="translate(7.9650, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1328" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 1.9753)">
+<g transform="translate(-1.1267, 1.4253)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>6</tspan>
 </text>
 </g>
-<g transform="translate(12.4444, 4.5500)">
+<g transform="translate(53.9851, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1252" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(10.6629, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(13.6836, 5.0500)">
-<rect x="-0.0650" y="-4.1505" width="0.1300" height="3.4644" ry="0.0400" fill="currentColor"/>
+<g transform="translate(10.7279, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.5121" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.3888, 4.5500)">
+<g transform="translate(13.6758, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(16.6280, 5.0500)">
-<rect x="-0.0650" y="-3.7777" width="0.1300" height="3.0916" ry="0.0400" fill="currentColor"/>
+<g transform="translate(13.7408, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.9257" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(47.4327, 4.0500)">
+<g transform="translate(40.2134, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1184" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(43.4113, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(41.2938, 4.5500)">
+<g transform="translate(43.4763, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.8451" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(46.4242, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(42.5330, 5.0500)">
-<rect x="-0.0650" y="-3.4755" width="0.1300" height="2.7894" ry="0.0400" fill="currentColor"/>
+<g transform="translate(46.4892, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.0927" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(44.4882, 3.5500)">
+<g transform="translate(49.6871, 2.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(45.7275, 5.0500)">
-<rect x="-0.0650" y="-3.9291" width="0.1300" height="2.2430" ry="0.0400" fill="currentColor"/>
+<g transform="translate(49.7521, 4.5000)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.8193" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(48.6719, 5.0500)">
-<rect x="-0.0650" y="-4.3472" width="0.1300" height="3.1611" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(50.6271, 3.0500)">
+<g transform="translate(53.9201, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(51.8663, 5.0500)">
-<rect x="-0.0650" y="-4.8008" width="0.1300" height="2.6147" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(55.0159, 3.5500)">
+<g transform="translate(40.1484, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(32.3053, 8.0500)">
+<g transform="translate(32.2425, 4.5000)">
+<rect x="-0.0650" y="-0.8227" width="0.1300" height="3.6366" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(36.9744, 5.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(34.0595, 7.5500)">
+<g transform="translate(38.2136, 4.5000)">
+<rect x="-0.0650" y="-1.9873" width="0.1300" height="2.8012" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(32.7575, 7.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(33.5445, 5.0500)">
-<rect x="-0.0650" y="-2.1992" width="0.1300" height="5.0131" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(38.0994, 6.0500)">
+<g transform="translate(31.0033, 7.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(39.3386, 5.0500)">
-<rect x="-0.0650" y="-3.0219" width="0.1300" height="3.8358" ry="0.0400" fill="currentColor"/>
+<g transform="translate(0.0000, 15.1106)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 10.4706)">
+<g transform="translate(0.0000, 14.1106)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
+</g>
+<g transform="translate(0.0000, 13.1106)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
+</g>
+<g transform="translate(0.0000, 12.1106)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
+</g>
+<g transform="translate(0.0000, 11.1106)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
+</g>
+<g transform="translate(0.0000, 10.1106)">
 <rect x="40.8287" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 15.4706)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8032" y2="0"/>
-</g>
-<g transform="translate(0.0000, 14.4706)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8032" y2="0"/>
-</g>
-<g transform="translate(0.0000, 13.4706)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8032" y2="0"/>
-</g>
-<g transform="translate(0.0000, 12.4706)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8032" y2="0"/>
-</g>
-<g transform="translate(0.0000, 11.4706)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8032" y2="0"/>
-</g>
-<g transform="translate(45.6632, 13.4706)">
+<g transform="translate(45.6765, 13.1106)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(33.6421, 11.9706)">
+<g transform="translate(33.6421, 11.6106)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(33.7071, 13.4706)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(33.7071, 13.1106)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1255" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(36.1463, 11.4706)">
+<g transform="translate(36.1463, 11.1106)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(36.2113, 13.4706)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(36.2113, 13.1106)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(31.2029, 13.4706)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(31.2029, 13.1106)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6878" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(31.1379, 12.4706)">
+<g transform="translate(31.1379, 12.1106)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.4487, 13.4706)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(28.4487, 13.1106)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.7562" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(28.3837, 13.4706)">
+<g transform="translate(28.3837, 13.1106)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(26.1945, 13.4706)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(26.1945, 13.1106)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.8123" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(26.1295, 12.4706)">
+<g transform="translate(26.1295, 12.1106)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(26.1295, 15.4706)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.3695 -0.2000 17.3695 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(36.1463, 13.3006)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(26.1295, 16.2806)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.3695 -0.2000 17.3695 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(36.1463, 14.1106)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(11.3542, 15.4706)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="12.3611 -0.2000 12.3611 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(26.1295, 15.3006)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.3900 7.6026 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(7.9000, 16.2806)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="15.8153 -0.2000 15.8153 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(26.1295, 16.1106)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.3900 7.6026 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(43.4740, 13.4706)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(16.3626, 15.1106)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(43.4090, 11.4706)">
+<g transform="translate(16.3626, 15.9206)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(11.3542, 15.1106)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="2.5942 -0.2000 2.5942 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(7.9000, 15.9206)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.0484 -0.2000 6.0484 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(38.6506, 10.6106)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(41.2198, 13.4706)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="5.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(43.4740, 13.1106)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(41.1548, 10.4706)">
+<g transform="translate(43.4090, 11.1106)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(38.7156, 13.4706)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(41.2198, 13.1106)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(38.6506, 10.9706)">
+<g transform="translate(41.1548, 10.1106)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(7.9650, 13.4706)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(38.7156, 13.1106)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(13.8584, 12.9706)">
+<g transform="translate(16.3626, 12.1106)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(11.4192, 13.4706)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(11.3542, 13.4706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(13.9234, 13.4706)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 12.4706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(-1.1267, 10.3959)">
+<g transform="translate(-1.1267, 10.0359)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>8</tspan>
 </text>
 </g>
-<g transform="translate(4.3000, 12.4706)">
+<g transform="translate(13.9234, 13.1106)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(13.8584, 12.6106)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(4.3000, 12.1106)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 12.4706)">
-<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
-c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
-</g>
-<g transform="translate(23.6903, 13.4706)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(23.6253, 12.9706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(21.4361, 13.4706)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(21.3711, 11.9706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(18.6819, 13.4706)">
+<g transform="translate(11.4192, 13.1106)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(18.6169, 13.4706)">
+<g transform="translate(11.3542, 13.1106)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(16.3626, 12.4706)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(16.4276, 13.4706)">
+<g transform="translate(7.9650, 13.1106)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 12.1106)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(16.4276, 13.1106)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(23.6903, 13.1106)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(23.6253, 12.6106)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(21.4361, 13.1106)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(21.3711, 11.6106)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(18.6819, 13.1106)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(18.6169, 13.1106)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(0.8000, 12.1106)">
+<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
+c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
 </svg>

--- a/scores/allemande/mm-8-10.svg
+++ b/scores/allemande/mm-8-10.svg
@@ -1,24 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="32.55mm" viewBox="-2.2535 -0.0000 104.6834 18.5250">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="33.64mm" viewBox="-2.2535 -0.0000 104.6834 19.1450">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
-<g transform="translate(0.0000, 1.5000)">
-<rect x="96.5720" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 1.5000)">
-<rect x="93.8022" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 1.5000)">
-<rect x="48.5125" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(54.1804, 4.5000)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(102.2399, 4.5000)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
 <g transform="translate(0.0000, 6.5000)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
@@ -34,182 +19,208 @@ tspan { white-space: pre; }
 <g transform="translate(0.0000, 2.5000)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(70.0748, 4.5000)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="5.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(102.2399, 4.5000)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(70.0098, 3.0000)">
+<g transform="translate(53.2338, 4.5000)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.5000)">
+<rect x="96.4251" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.5000)">
+<rect x="93.5996" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 1.5000)">
+<rect x="47.4414" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
+</g>
+<g transform="translate(66.6357, 2.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(67.4039, 4.5000)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(66.7007, 4.5000)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3200" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(67.3389, 2.0000)">
+<g transform="translate(69.3622, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(64.2330, 4.5000)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="4.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(69.4272, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.5781" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(72.9308, 2.5000)">
+<g transform="translate(72.3388, 2.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(72.9958, 4.5000)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="6.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(72.4038, 4.5000)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.3597" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(75.6017, 3.5000)">
+<g transform="translate(75.0653, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(75.6667, 4.5000)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="5.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(75.1303, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.6177" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(78.5226, 3.0000)">
+<g transform="translate(78.0419, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(78.5876, 4.5000)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(78.1069, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3125" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(78.5226, 5.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="21.1364 -0.2000 21.1364 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(57.5210, 4.5000)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="3.9408" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(78.5226, 6.3100)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="21.1364 -0.2000 21.1364 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(89.9480, 4.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.6196 -0.2000 9.6196 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(55.7203, 4.5000)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(89.9480, 5.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.6196 -0.2000 9.6196 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(58.3262, 4.5000)">
+<g transform="translate(54.7945, 4.5000)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.1313" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(57.4560, 4.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(58.3912, 4.5000)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="4.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(60.9971, 6.5000)">
+<g transform="translate(60.1826, 6.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(61.0621, 4.5000)">
-<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(60.2476, 4.5000)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.2503" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(64.1680, 4.5000)">
+<g transform="translate(63.4091, 4.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(92.5272, 1.5000)">
+<g transform="translate(63.4741, 4.5000)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="4.6165" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(96.7511, 1.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(96.8161, 4.5000)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(99.4777, 2.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(99.5427, 4.5000)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(92.3246, 1.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(96.8981, 1.0000)">
+<g transform="translate(12.2989, 6.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="3.0665 -0.2000 3.0665 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(7.9000, 7.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.4654 -0.2000 7.4654 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(18.2520, 6.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 -0.2000 8.7696 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(18.2520, 7.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 -0.2000 8.7696 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(29.9082, 6.6900)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0196 -0.3900 9.0196 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(29.9082, 7.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0196 -0.3900 9.0196 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(41.8143, 4.6900)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 -0.2000 8.7696 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(41.8143, 5.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 -0.2000 8.7696 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(54.7295, 7.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 0.8000 8.7696 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(54.7295, 8.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 0.8000 8.7696 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(66.6357, 4.6900)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.5196 0.6100 8.5196 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(66.6357, 5.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.5196 0.6100 8.5196 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(78.0419, 5.6900)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0196 -0.3900 9.0196 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(78.0419, 6.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0196 -0.3900 9.0196 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(80.7684, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(96.9631, 4.5000)">
-<rect x="-0.0650" y="-3.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(80.8334, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.2553" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(99.5690, 2.0000)">
+<g transform="translate(83.9949, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(99.6340, 4.5000)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(84.0599, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1877" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(14.0376, 6.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="14.4446 -0.2000 14.4446 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(9.7500, 7.3100)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="18.7322 -0.2000 18.7322 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(31.3131, 6.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.2864 -0.2000 20.2864 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(31.3131, 7.3100)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.2864 -0.2000 20.2864 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(55.6553, 8.1900)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.0364 -0.2000 20.0364 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(55.6553, 9.0000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="20.0364 -0.2000 20.0364 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(81.1935, 4.0000)">
+<g transform="translate(86.9715, 2.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(81.2585, 4.5000)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(87.0365, 4.5000)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6253" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(84.3644, 3.0000)">
+<g transform="translate(89.9480, 2.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(84.4294, 4.5000)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(90.0130, 4.5000)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(87.2853, 2.5000)">
+<g transform="translate(93.7746, 1.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(87.3503, 4.5000)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(93.8396, 4.5000)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(90.2063, 2.0000)">
+<g transform="translate(18.2520, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(90.2713, 4.5000)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(93.9772, 1.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(94.0422, 4.5000)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(25.7863, 4.5000)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(19.8794, 3.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(19.9444, 4.5000)">
+<g transform="translate(18.3170, 4.5000)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(22.5504, 4.5000)">
+<g transform="translate(20.9785, 4.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(22.6154, 4.5000)">
+<g transform="translate(21.0435, 4.5000)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(25.7213, 3.0000)">
+<g transform="translate(24.2051, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.3922, 4.0000)">
+<g transform="translate(24.2701, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(26.9316, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.4572, 4.5000)">
+<g transform="translate(26.9966, 4.5000)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(55.6553, 2.0000)">
+<g transform="translate(29.9082, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(31.3131, 3.5000)">
+<g transform="translate(29.9732, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.8125" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(31.3781, 4.5000)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(9.7500, 3.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g color="rgb(100.0000%, 100.0000%, 100.0000%)">
-<g transform="translate(0.0000, 4.5000)">
-<rect x="0.0000" y="-2.0812" width="3.7500" height="4.1625" ry="0.0000" fill="currentColor"/>
-</g>
-</g>
-<g transform="translate(0.6000, 4.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(1.6500, 4.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(2.7000, 4.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(4.7500, 3.5000)">
+<g transform="translate(0.8000, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(9.8150, 4.5000)">
+<g transform="translate(4.3000, 3.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
+v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+</g>
+<g transform="translate(7.9650, 4.5000)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(-1.1267, 1.4253)">
@@ -217,225 +228,240 @@ c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22
 <tspan>8</tspan>
 </text>
 </g>
-<g transform="translate(14.0376, 4.5000)">
+<g transform="translate(12.2989, 4.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(14.1026, 4.5000)">
+<g transform="translate(12.3639, 4.5000)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(16.9585, 4.0000)">
+<g transform="translate(15.2754, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(17.0235, 4.5000)">
+<g transform="translate(15.3404, 4.5000)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.9968, 2.5000)">
+<g transform="translate(41.8143, 2.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(40.0759, 3.0000)">
+<g transform="translate(41.8793, 4.5000)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(44.7909, 2.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(40.1409, 4.5000)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(44.8559, 4.5000)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(48.9036, 4.5000)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="5.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(48.8386, 1.5000)">
+<g transform="translate(47.7674, 1.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(43.0618, 4.5000)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(47.8324, 4.5000)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(45.9177, 2.0000)">
+<g transform="translate(50.4940, 2.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(45.9827, 4.5000)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(50.5590, 4.5000)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(33.9840, 4.5000)">
+<g transform="translate(54.7295, 2.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(34.0490, 4.5000)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(35.9262, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6877" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(51.5095, 2.5000)">
+<g transform="translate(35.8612, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(51.5745, 4.5000)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(32.6997, 4.5000)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.7553" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(37.2199, 4.5000)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(37.1549, 3.5000)">
+<g transform="translate(38.8378, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 9.7850)">
+<g transform="translate(32.6347, 4.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(38.9028, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1253" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 16.0950)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
+</g>
+<g transform="translate(0.0000, 15.0950)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
+</g>
+<g transform="translate(0.0000, 14.0950)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
+</g>
+<g transform="translate(0.0000, 13.0950)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
+</g>
+<g transform="translate(0.0000, 12.0950)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
+</g>
+<g transform="translate(0.0000, 10.0950)">
 <rect x="42.8329" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 10.7850)">
+<g transform="translate(0.0000, 11.0950)">
 <rect x="42.8329" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 10.7850)">
+<g transform="translate(0.0000, 11.0950)">
 <rect x="37.8245" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 10.7850)">
+<g transform="translate(0.0000, 11.0950)">
 <rect x="33.0661" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 10.7850)">
+<g transform="translate(0.0000, 11.0950)">
 <rect x="28.0577" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 10.7850)">
+<g transform="translate(0.0000, 11.0950)">
 <rect x="25.5534" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 10.7850)">
+<g transform="translate(0.0000, 11.0950)">
 <rect x="18.0408" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 10.7850)">
+<g transform="translate(0.0000, 11.0950)">
 <rect x="8.1750" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 15.7850)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
-</g>
-<g transform="translate(0.0000, 14.7850)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
-</g>
-<g transform="translate(0.0000, 13.7850)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
-</g>
-<g transform="translate(0.0000, 12.7850)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
-</g>
-<g transform="translate(0.0000, 11.7850)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
-</g>
-<g transform="translate(47.6807, 13.7850)">
+<g transform="translate(47.6807, 14.0950)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(33.3921, 10.2850)">
+<g transform="translate(33.3921, 10.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(33.4571, 13.7850)">
-<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1801" ry="0.0400" fill="currentColor"/>
+<g transform="translate(33.4571, 14.0950)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(35.6463, 11.2850)">
+<g transform="translate(35.6463, 11.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(35.7113, 13.7850)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.2050" ry="0.0400" fill="currentColor"/>
+<g transform="translate(35.7113, 14.0950)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(38.1506, 10.7850)">
+<g transform="translate(38.1506, 11.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(38.2156, 13.7850)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.7328" ry="0.0400" fill="currentColor"/>
+<g transform="translate(38.2156, 14.0950)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8183" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(25.8795, 10.2850)">
+<g transform="translate(25.9445, 14.0950)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(38.1506, 14.2850)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.3000 7.3526 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(38.1506, 15.0950)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.3000 7.3526 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(28.3837, 11.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.3837, 13.7850)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.1195 -0.0100 17.1195 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(28.4487, 14.0950)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(28.3837, 14.5950)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.1195 -0.0100 17.1195 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(25.9445, 13.7850)">
-<rect x="-0.0650" y="-3.3139" width="0.1300" height="7.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(28.3837, 10.7850)">
+<g transform="translate(30.6379, 12.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.4487, 13.7850)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6246" ry="0.0400" fill="currentColor"/>
+<g transform="translate(30.7029, 14.0950)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(30.6379, 11.7850)">
+<g transform="translate(8.3500, 17.0950)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(8.3500, 17.9050)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(18.3669, 14.0950)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(18.3669, 14.9050)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(28.3837, 14.0950)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(28.3837, 14.9050)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(45.4782, 14.0950)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.8095" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(45.4132, 12.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(30.7029, 13.7850)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6496" ry="0.0400" fill="currentColor"/>
+<g transform="translate(43.2240, 14.0950)">
+<rect x="-0.0650" y="-3.8139" width="0.1300" height="5.1570" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(45.4782, 13.7850)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.3132" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(8.3500, 17.4750)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.6195 -0.2000 17.6195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(8.3500, 18.2850)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="17.6195 -0.2000 17.6195 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(45.4132, 12.2850)">
+<g transform="translate(43.1590, 10.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(43.2240, 13.7850)">
-<rect x="-0.0650" y="-3.8139" width="0.1300" height="4.7882" ry="0.0400" fill="currentColor"/>
+<g transform="translate(40.4698, 14.0950)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.9708" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(43.1590, 9.7850)">
+<g transform="translate(40.4048, 12.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(40.4698, 13.7850)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.7577" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(40.4048, 11.7850)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(6.9000, 10.7850)">
+<g transform="translate(6.9000, 11.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(10.6042, 13.2850)">
+<g transform="translate(10.6042, 13.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(10.6692, 13.7850)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(10.6692, 14.0950)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.4376" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(8.4150, 13.7850)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="7.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(8.4150, 14.0950)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="6.6327" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(12.8584, 15.7850)">
+<g transform="translate(12.8584, 16.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.9234, 13.7850)">
-<rect x="-0.0650" y="2.1861" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(8.3500, 10.7850)">
+<g transform="translate(25.8795, 10.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(-2.2535, 10.7103)">
+<g transform="translate(0.8000, 13.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
+c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
+</g>
+<g transform="translate(4.3000, 13.0950)">
+<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
+v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+</g>
+<g transform="translate(-2.2535, 11.0203)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>10</tspan>
 </text>
 </g>
-<g transform="translate(4.3000, 12.7850)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+<g transform="translate(12.9234, 14.0950)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.2425" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 12.7850)">
-<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
-c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
-</g>
-<g transform="translate(20.6211, 11.7850)">
+<g transform="translate(8.3500, 11.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(20.6861, 13.7850)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="6.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(23.1253, 11.2850)">
+<g transform="translate(18.3669, 11.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(23.1903, 13.7850)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(20.6861, 14.0950)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.6126, 13.2850)">
+<g transform="translate(20.6211, 12.0950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.3669, 10.7850)">
+<g transform="translate(23.1253, 11.5950)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(15.6776, 13.7850)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(18.4319, 14.0950)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(18.4319, 13.7850)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="7.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(23.1903, 14.0950)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(15.6776, 14.0950)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="5.1151" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(15.6126, 13.5950)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 </svg>

--- a/tools/scores/README.md
+++ b/tools/scores/README.md
@@ -7,7 +7,8 @@ Renders the per-loop SVG scores in `scores/` from LilyPond sources in this direc
   the community LilyPond typeset at
   [babysnakes/Bach---Cello-Suites](https://github.com/babysnakes/Bach---Cello-Suites)
   (Bärenreiter-based), with editorial slurs, bow markings and trills added
-  by hand to follow the Peters/Becker edition.
+  by hand to follow the Peters/Becker edition. Written in **absolute octaves**
+  (not `\relative`) so each measure is self-contained.
 
 ## Build
 Requires LilyPond on `$PATH`. Run `tools/scores/setup.sh` to install it if
@@ -26,10 +27,11 @@ its `label` (e.g. `"mm 4-6"`), extracts those measures from the matching
 LilyPond source, and writes the cropped SVG to the path in the loop's
 `score` field.
 
-For ranges that don't start at m. 1, the earlier measures are emitted inside
-`\set Score.skipTypesetting = ##t` so LilyPond parses them silently —
-necessary because the source uses `\relative` notation and slicing measures
-out of context shifts later pitches by an octave or more.
+The source is in **absolute octaves**, so every measure renders on its own —
+ranges that don't start at m. 1 simply set `Score.currentBarNumber`, with no
+need to parse earlier measures for pitch context. (This replaced an older
+`\relative` + `skipTypesetting` scheme whose octave context drifted whenever a
+measure used polyphony.)
 
 ### One measure per line (important)
 The splitter treats **each line of the music as one measure**. Keep one measure

--- a/tools/scores/allemande.ly
+++ b/tools/scores/allemande.ly
@@ -1,59 +1,60 @@
-\version "2.18.2"
+\version "2.24.0"
 
-allemande = \context Staff \relative c {
+%% Bach Cello Suite No. 1, Allemande (BWV 1007). Absolute-octave source so
+%% each measure is self-contained (no \relative drift when slicing per loop).
+allemande = \absolute {
 
   \time 2/2
   \key g \major
   \set Staff.midiInstrument = "cello"
 
-  %% Next two lines helps spliting the beam to quarters (after
-  %% changing the time to 2/2, can be removed if time is back to 4/4)
+  %% Beam sixteenths in groups of four (2/2 would otherwise beam them in eights).
   \set Timing.baseMoment = #(ly:make-moment 1/16)
   \set Timing.beatStructure = #'(4 4 4 4)
 
   \repeat volta 2 {
-    \partial 16 b'16 |
-    <b d, g,>4\f~ b16 a-4( g fis) g( d e fis) g( a b c) |
-    d( b g fis) g( e d c) b( c d e) fis( g a-1 b) |
-    c( a g fis) g( e fis g) a,( d fis g) a-1( b c a) |
-    b( g) g( d) d( b) b( g) g8.\downbow b'16\downbow c\upbow( b a g) |
+    \partial 16 b16\f |
+    <b d g,>4 << { b16\repeatTie a16-4( g16 fis16) } \\ { d16\repeatTie s8. } >> g16 d16( e16 fis16 g16 a16 b16 c'16) |
+    d'16( b16 g16 fis16 g16 e16 d16 c16) \stemUp b,16( c16 d16 e16 \stemNeutral fis16 g16 a16-1 b16) |
+    c'16( a16 g16 fis16) g16( e16 fis16 g16) a,16( d16 fis16 g16) a16-1( b16 c'16 a16) |
+    b16( g16) g16( d16) d16( b,16) b,16( g,16) g,8.\downbow b16\downbow c'16\upbow( b16 a16 g16) |
     \barNumberCheck #5
-    a-1( b c) a g-2( fis g) a dis,8.\trill c'16-4 b a g fis |
-    g e e b b g g e e8. b'16 e g fis a |
-    g fis e fis g cis g fis g cis e, fis g e a, g' |
-    fis8 d16 e fis d g e fis d fis g a b c a |
-    b d, g, d' b' g a fis g e g a b cis d b |
+    a16-1( b16 c'16) a16 g16-2( fis16 g16) a16 dis8.\trill c'16-4 b16 a16 g16 fis16 |
+    g16 e16 e16 b,16 b,16 g,16 g,16 e,16 e,8. b,16 e16 g16 fis16 a16 |
+    g16 fis16 e16 fis16 g16 cis'16 g16 fis16 g16 cis'16 e16 fis16 g16 e16 a,16 g16 |
+    fis8 d16 e16 fis16 d16 g16 e16 fis16 d16 fis16 g16 a16 b16 c'16 a16 |
+    b16 d16 g,16 d16 b16 g16 a16 fis16 g16 e16 g16 a16 b16 cis'16 d'16 b16 |
     \barNumberCheck #10
-    cis e, g, e' cis' a b d cis a d b cis a e' g, |
-    fis8.\trill d'16 a g fis e d a' g e fis d a' c, |
-    b8.\trill g'16 d c b a g d' c a b g d' fis, |
-    e g a b cis d e fis g a cis d e a, g'8 |
-    d,16 g' fis e fis d a d d, fis a c b8.\trill a16 |
+    cis'16 e16 g,16 e16 cis'16 a16 b16 d'16 cis'16 a16 d'16 b16 cis'16 a16 e'16 g16 |
+    fis8.\trill d'16 a16 g16 fis16 e16 d16 a16 g16 e16 fis16 d16 a16 c16 |
+    b,8.\trill g16 d16 c16 b,16 a,16 g,16 d16 c16 a,16 b,16 g,16 d16 fis,16 |
+    e,16 g,16 a,16 b,16 cis16 d16 e16 fis16 g16 a16 cis'16 d'16 e'16 a16 g'8 |
+    d16 g'16 fis'16 e'16 fis'16 d'16 a16 d'16 d16 fis16 a16 c'16 b8.\trill a16 |
     \barNumberCheck #15
-    <g, d' b'>8. a'16 g fis e d' cis e a, g fis d a cis |
-    d,8. a'16 d fis a cis d a fis d d,8.
+    <g, d b>8. a16 g16 fis16 e16 d'16 cis'16 e'16 a16 g16 fis16 d16 a,16 cis16 |
+    d,8. a,16 d16 fis16 a16 cis'16 d'16 a16 fis16 d16 d,8.
   }
 
   \repeat volta 2 {
-    a''16 |
-    <d, a'>4~ <d a'>16 fis g a d, e fis g a fis d c |
-    b d g fis g a b c d b a g f e f d' |
-    e,8\trill \appoggiatura d8 c c'16 a,b c d, c'' b c d b c a |
+    a16 |
+    <d a>4 ~ <d a>16 fis16 g16 a16 d16 e16 fis16 g16 a16 fis16 d16 c16 |
+    b,16 d16 g16 fis16 g16 a16 b16 c'16 d'16 b16 a16 g16 f16 e16 f16 d'16 |
+    e8\trill \appoggiatura d8 c8 c'16 a,16 b,16 c16 d,16 c'16 b16 c'16 d'16 b16 c'16 a16 |
     \barNumberCheck #20
-    gis8\trill e b'16 d, c b c e fis gis a c b a |
-    d8 b,16 c d e f a, gis8.\trill e'16 b'd c b |
-    <a, e' c'>8. b'16 a g f e f d bes' a bes c d a |
-    gis a b e, f d c b c e a b <e, b'>8. a16 |
-    <a, e' a>8. b'16 c b c g fis g a e d c b a |
+    gis8\trill e8 b16 d16 c16 b,16 c16 e16 fis16 gis16 a16 c'16 b16 a16 |
+    d'8 b,16 c16 d16 e16 f16 a,16 gis,8.\trill e16 b16 d'16 c'16 b16 |
+    <a, e c'>8. b16 a16 g16 f16 e16 f16 d16 bes16 a16 bes16 c'16 d'16 a16 |
+    gis16 a16 b16 e16 f16 d16 c16 b,16 c16 e16 a16 b16 <e b>8. a16 |
+    <a, e a>8. b16 c'16 b16 c'16 g16 fis16 g16 a16 e16 d16 c16 b,16 a,16 |
     \barNumberCheck #25
-    g d' fis c' b a g a b c d e d e f d |
-    e8 g, c,16 d' c b a b c e d8. c16 |
-    d8 a b,16 c' b a g fis e g b d c b |
-    c8 g a,16 e' fis g fis a b c d, c b a |
-    g d' fis a c a fis d <g, d' b'>8. d'16 e g a cis |
+    g,16 d16 fis16 c'16 b16 a16 g16 a16 b16 c'16 d'16 e'16 d'16 e'16 f'16 d'16 |
+    e'8 g8 c16 d'16 c'16 b16 a16 b16 c'16 e'16 d'8. c'16 |
+    d'8 a8 b,16 c'16 b16 a16 g16 fis16 e16 g16 b16 d'16 c'16 b16 |
+    c'8 g8 a,16 e16 fis16 g16 fis16 a16 b16 c'16 d16 c16 b,16 a,16 |
+    g,16 d16 fis16 a16 c'16 a16 fis16 d16 <g, d b>8. d16 e16 g16 a16 cis'16 |
     \barNumberCheck #30
-    d a fis e d f g b c g e d c e a c |
-    fis, a c e d8. c,16 b g' a, g d a' g' fis |
-    g g, b d g b d fis g d b g g,8. s16
+    d'16 a16 fis16 e16 d16 f16 g16 b16 c'16 g16 e16 d16 c16 e16 a16 c'16 |
+    fis16 a16 c'16 e'16 d'8. c16 b,16 g16 a,16 g,16 d,16 a,16 g16 fis16 |
+    g16 g,16 b,16 d16 g16 b16 d'16 fis'16 g'16 d'16 b16 g16 g,8. s16
   }
 }

--- a/tools/scores/build_scores.py
+++ b/tools/scores/build_scores.py
@@ -30,16 +30,13 @@ def parse_range(label):
     return int(nums[0]), int(nums[1])
 
 def make_ly(start, end):
+    # The source is in absolute octaves, so each measure stands alone — no
+    # \relative context and no skipTypesetting of earlier measures needed.
     visible = '\n'.join('    ' + m for m in measures[start-1:end])
     if start == 1:
         body = f'    {pickup}\n{visible}'
     else:
-        hidden = '\n'.join('    ' + m for m in measures[:start-1])
-        body = (f'    \\set Score.skipTypesetting = ##t\n'
-                f'    {pickup}\n{hidden}\n'
-                f'    \\set Score.skipTypesetting = ##f\n'
-                f'    \\set Score.currentBarNumber = #{start}\n'
-                f'    \\bar ""\n{visible}')
+        body = f'    \\set Score.currentBarNumber = #{start}\n{visible}'
     return f'''\\version "2.24.0"
 \\paper {{
   indent = 0
@@ -50,10 +47,12 @@ def make_ly(start, end):
 }}
 \\header {{ tagline = "" }}
 \\score {{
-  \\new Staff \\with {{ \\remove "Time_signature_engraver" }} \\relative c {{
+  \\new Staff \\with {{ \\remove "Time_signature_engraver" }} {{
     \\clef "bass"
     \\key g \\major
     \\time 2/2
+    \\set Timing.baseMoment = #(ly:make-moment 1/16)
+    \\set Timing.beatStructure = #'(4 4 4 4)
 {body}
   }}
   \\layout {{ }}


### PR DESCRIPTION
## Summary
- Rewrite `tools/scores/allemande.ly` in **absolute octaves** so each measure is self-contained. This fixes an octave drift where a polyphonic voice in m. 1 shifted every later note down an octave under the old `\relative` source.
- Simplify `build_scores.py`: no `\relative` wrapper and no `skipTypesetting` of earlier measures (ranges that don't start at m. 1 just set `currentBarNumber`). The render template now sets the sixteenth-note `beatStructure`, so beams group in fours.
- Apply the m. 1 engraving (pickup `f`, down-stem tied d via a sub-voice + `\repeatTie`) and m. 2's eight-note slurs with the b-c-d-e beam from above.
- Rebuild all five loop SVGs; update README and the score-workflow skill to document the absolute-octave convention.

## Test plan
- [x] `python3 tools/scores/build_scores.py` builds clean (no warnings) and changes only the five intended SVGs
- [x] Rendered mm. 1-6 and mm. 9-12 and verified correct octaves, fingerings, and groups-of-4 beaming

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_