### PR TITLE
Allemande m.4 bowing fix + Claude workflow notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# Project notes for Claude
+
+## Git / PR workflow
+
+PRs in this repo are **squash-merged** (see #60–64). A squash merge puts the
+branch's combined diff onto `main` as a single new commit with a *new* SHA and
+**no ancestry link** to the branch's commits.
+
+**After every merge, realign the working branch to `main` before doing more work:**
+
+```
+git fetch origin main
+git reset --hard origin/main        # branch == main; nothing lost, work is already merged
+git push --force-with-lease origin <branch>   # only if the remote branch still has the old commits
+```
+
+Why this matters: if you keep committing on the same branch *without* realigning,
+the next PR's merge-base is the pre-squash commit. Git then sees both `main` (via
+the squash) and the branch (via its original commits) as having changed the same
+files, producing a **phantom merge conflict** even when the content agrees. The
+fix is to realign — not to repeatedly rebase/`reset --soft` at merge time.
+
+Equivalent alternatives: cut a fresh branch from `main` for each batch, or switch
+to regular merge commits (preserves history but clutters `main`).
+
+## Scores
+
+Engraved sheet music lives in `tools/scores/*.ly` (absolute octaves) and builds to
+`scores/<piece>/*.svg` via `tools/scores/build_scores.py`. See the `score-workflow`
+skill in `.claude/skills/` for the full process.

--- a/scores/allemande/mm-1-4.svg
+++ b/scores/allemande/mm-1-4.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="41.49mm" viewBox="-1.1267 -0.0000 103.5567 23.6118">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="39.36mm" viewBox="-1.1267 -0.0000 103.5567 22.3959">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
@@ -314,318 +314,315 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(36.2261, 6.0928)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 20.3718)">
+<g transform="translate(0.0000, 19.1559)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6635" y2="0"/>
 </g>
-<g transform="translate(0.0000, 19.3718)">
+<g transform="translate(0.0000, 18.1559)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6635" y2="0"/>
 </g>
-<g transform="translate(0.0000, 18.3718)">
+<g transform="translate(0.0000, 17.1559)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6635" y2="0"/>
 </g>
-<g transform="translate(0.0000, 17.3718)">
+<g transform="translate(0.0000, 16.1559)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6635" y2="0"/>
 </g>
-<g transform="translate(0.0000, 16.3718)">
+<g transform="translate(0.0000, 15.1559)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6635" y2="0"/>
 </g>
-<g transform="translate(84.5235, 18.3718)">
+<g transform="translate(84.5235, 17.1559)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(47.2307, 18.3718)">
+<g transform="translate(47.2307, 17.1559)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 15.3718)">
+<g transform="translate(0.0000, 14.1559)">
 <rect x="74.4173" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 15.3718)">
+<g transform="translate(0.0000, 14.1559)">
 <rect x="42.3829" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 15.3718)">
+<g transform="translate(0.0000, 14.1559)">
 <rect x="7.5740" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(67.6480, 18.3718)">
-<rect x="-0.0650" y="2.1861" width="0.1300" height="2.7842" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(61.5595, 18.3718)">
+<g transform="translate(61.5595, 17.1559)">
 <rect x="-0.0650" y="-2.6753" width="0.1300" height="3.4892" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(60.3203, 19.3718)">
+<g transform="translate(60.3203, 18.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(59.3053, 18.3718)">
-<rect x="-0.0650" y="-2.9909" width="0.1300" height="2.8048" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(58.0661, 18.3718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(62.8245, 19.3718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(64.0638, 18.3718)">
-<rect x="-0.0650" y="-2.3247" width="0.1300" height="3.1386" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(65.0788, 20.3718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(66.3180, 18.3718)">
-<rect x="-0.0650" y="-2.0091" width="0.1300" height="3.8230" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(67.5830, 20.3718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(68.2351, 16.0718)">
-<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
-</g>
-<g transform="translate(69.3372, 19.8718)">
+<g transform="translate(69.3372, 18.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(48.5493, 15.8718)">
+<g transform="translate(59.3053, 17.1559)">
+<rect x="-0.0650" y="-2.9909" width="0.1300" height="2.8048" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(58.0661, 17.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(74.7433, 18.5618)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 0.6100 7.6026 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(74.7433, 19.3718)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 0.6100 7.6026 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(48.6143, 18.3718)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1347" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(50.8035, 16.8718)">
+<g transform="translate(62.8245, 18.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(50.8685, 18.3718)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.5103" ry="0.0400" fill="currentColor"/>
+<g transform="translate(64.0638, 17.1559)">
+<rect x="-0.0650" y="-2.3247" width="0.1300" height="3.1386" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(53.3077, 16.8718)">
+<g transform="translate(65.0788, 19.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(53.3727, 18.3718)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.9275" ry="0.0400" fill="currentColor"/>
+<g transform="translate(66.3180, 17.1559)">
+<rect x="-0.0650" y="-2.0091" width="0.1300" height="3.8230" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(55.5619, 18.3718)">
+<g transform="translate(67.5830, 19.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(55.6269, 18.3718)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8031" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 18.3718)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7594 -4.0450C2.5406 -4.9329 6.8827 -3.8268 8.0221 -2.1950L8.0221 -2.1950C6.8531 -3.7105 2.5109 -4.8166 0.7594 -4.0450z"/>
-</g>
-<g transform="translate(82.3210, 18.3718)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1170" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(82.2560, 16.8718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(17.6669, 18.3718)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -2.5450C2.1296 -3.8263 6.4373 -3.8263 7.9147 -2.5450L7.9147 -2.5450C6.4373 -3.7063 2.1296 -3.7063 0.6521 -2.5450z"/>
-</g>
-<g transform="translate(7.9000, 18.5618)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(7.9000, 19.3718)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(27.1837, 18.3718)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4997 0.4550C1.5465 -1.4066 6.5003 -3.2613 8.5123 -2.5450L8.5123 -2.5450C6.5423 -3.1490 1.5886 -1.2942 0.4997 0.4550z"/>
-</g>
-<g transform="translate(17.6669, 19.5618)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(17.6669, 20.3718)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(37.7006, 18.3718)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -3.0450C2.1296 -4.3263 6.4373 -4.3263 7.9147 -3.0450L7.9147 -3.0450C6.4373 -4.2063 2.1296 -4.2063 0.6521 -3.0450z"/>
-</g>
-<g transform="translate(27.1837, 22.0618)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.8900 8.1026 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(27.1837, 22.8718)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.8900 8.1026 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(48.5493, 18.3718)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -3.5450C1.6921 -3.8556 2.7332 -3.3937 3.0826 -2.5450L3.0826 -2.5450C2.6846 -3.2841 1.6434 -3.7459 0.8284 -3.5450z"/>
-</g>
-<g transform="translate(37.7006, 18.5618)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(37.7006, 19.3718)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(53.3077, 18.3718)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8755 -2.5450C1.8179 -2.7574 2.8721 -2.1261 3.1297 -1.1950L3.1297 -1.1950C2.8104 -2.0231 1.7562 -2.6545 0.8755 -2.5450z"/>
-</g>
-<g transform="translate(58.0661, 18.3718)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4758 1.2285C0.8252 2.1390 1.8663 2.6008 2.7300 2.2285L2.7300 2.2285C1.9150 2.4911 0.8739 2.0293 0.4758 1.2285z"/>
-</g>
-<g transform="translate(48.5493, 19.3718)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(48.5493, 20.1818)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(62.8245, 18.3718)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4987 2.1950C0.8879 3.0071 1.9244 3.3980 2.7529 3.0450L2.7529 3.0450C1.9667 3.2857 0.9303 2.8948 0.4987 2.1950z"/>
-</g>
-<g transform="translate(59.2403, 15.3718)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(59.2403, 16.1818)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(74.7433, 18.3718)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7372 -4.0450C2.4923 -5.0335 7.0090 -4.1317 8.2499 -2.5450L8.2499 -2.5450C6.9855 -4.0140 2.4688 -4.9158 0.7372 -4.0450z"/>
-</g>
-<g transform="translate(71.2041, 20.9049)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.7331 1.1250 -0.3331 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(67.5830, 23.3718)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="4.7462 -2.3900 4.7462 -1.9900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(72.2391, 15.8718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(72.8912, 15.1268)">
+<g transform="translate(68.2351, 14.8559)">
 <path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
 </g>
-<g transform="translate(72.3041, 18.3718)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="5.1536" ry="0.0400" fill="currentColor"/>
+<g transform="translate(74.7433, 17.3459)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 0.6100 7.6026 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(74.7433, 15.3718)">
+<g transform="translate(74.7433, 18.1559)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 0.6100 7.6026 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(48.5493, 14.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(75.3954, 13.9109)">
+<g transform="translate(48.6143, 17.1559)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1347" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(55.6269, 17.1559)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8031" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(50.8035, 15.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(50.8685, 17.1559)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.5103" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(53.3077, 15.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(53.3727, 17.1559)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.9275" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(55.5619, 17.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 17.1559)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7594 -4.0450C2.5406 -4.9329 6.8827 -3.8268 8.0221 -2.1950L8.0221 -2.1950C6.8531 -3.7105 2.5109 -4.8166 0.7594 -4.0450z"/>
+</g>
+<g transform="translate(82.3210, 17.1559)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1170" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(82.2560, 15.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(17.6669, 17.1559)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -2.5450C2.1296 -3.8263 6.4373 -3.8263 7.9147 -2.5450L7.9147 -2.5450C6.4373 -3.7063 2.1296 -3.7063 0.6521 -2.5450z"/>
+</g>
+<g transform="translate(7.9000, 17.3459)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(7.9000, 18.1559)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(27.1837, 17.1559)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4997 0.4550C1.5465 -1.4066 6.5003 -3.2613 8.5123 -2.5450L8.5123 -2.5450C6.5423 -3.1490 1.5886 -1.2942 0.4997 0.4550z"/>
+</g>
+<g transform="translate(17.6669, 18.3459)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(17.6669, 19.1559)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(37.7006, 17.1559)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -3.0450C2.1296 -4.3263 6.4373 -4.3263 7.9147 -3.0450L7.9147 -3.0450C6.4373 -4.2063 2.1296 -4.2063 0.6521 -3.0450z"/>
+</g>
+<g transform="translate(27.1837, 20.8459)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.8900 8.1026 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(27.1837, 21.6559)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.8900 8.1026 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(48.5493, 17.1559)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -3.5450C1.6921 -3.8556 2.7332 -3.3937 3.0826 -2.5450L3.0826 -2.5450C2.6846 -3.2841 1.6434 -3.7459 0.8284 -3.5450z"/>
+</g>
+<g transform="translate(37.7006, 17.3459)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(37.7006, 18.1559)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(53.3077, 17.1559)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8755 -2.5450C1.8179 -2.7574 2.8721 -2.1261 3.1297 -1.1950L3.1297 -1.1950C2.8104 -2.0231 1.7562 -2.6545 0.8755 -2.5450z"/>
+</g>
+<g transform="translate(58.0661, 17.1559)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4758 1.2285C0.8252 2.1390 1.8663 2.6008 2.7300 2.2285L2.7300 2.2285C1.9150 2.4911 0.8739 2.0293 0.4758 1.2285z"/>
+</g>
+<g transform="translate(48.5493, 18.1559)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(48.5493, 18.9659)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(62.8245, 17.1559)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4987 2.1950C0.8879 3.0071 1.9244 3.3980 2.7529 3.0450L2.7529 3.0450C1.9667 3.2857 0.9303 2.8948 0.4987 2.1950z"/>
+</g>
+<g transform="translate(59.2403, 14.1559)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(59.2403, 14.9659)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(74.7433, 17.1559)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7372 -4.0450C2.0894 -4.8578 4.8092 -4.3147 5.7457 -3.0450L5.7457 -3.0450C4.7857 -4.1970 2.0659 -4.7401 0.7372 -4.0450z"/>
+</g>
+<g transform="translate(71.2041, 19.6890)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.7331 1.1250 -0.3331 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(67.5830, 22.1559)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="4.7462 -2.3900 4.7462 -1.9900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(72.2391, 14.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(72.8912, 13.9109)">
 <path transform="scale(0.0040, -0.0040)" d="M128 508c2 7 9 12 17 12c10 0 18 -7 18 -17c0 -2 -1 -4 -1 -6l-145 -485c-2 -7 -9 -12 -17 -12s-15 5 -17 12l-145 485v6c0 10 7 17 17 17c8 0 15 -5 17 -12l88 -295l40 -164l40 164z" fill="currentColor"/>
 </g>
-<g transform="translate(74.8083, 18.3718)">
+<g transform="translate(72.3041, 17.1559)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="5.1536" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(74.7433, 14.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(74.8083, 17.1559)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8208" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(77.2476, 15.8718)">
+<g transform="translate(67.6480, 17.1559)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.7842" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(77.2476, 14.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(77.3126, 18.3718)">
+<g transform="translate(77.3126, 17.1559)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.5862" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(79.7518, 16.3718)">
+<g transform="translate(79.7518, 15.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(79.8168, 18.3718)">
+<g transform="translate(79.8168, 17.1559)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.3516" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.1626, 17.3718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(15.2276, 18.3718)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8051" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(17.6669, 16.8718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(17.7319, 18.3718)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(19.9211, 17.8718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(19.9861, 18.3718)">
+<g transform="translate(19.9861, 17.1559)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(22.4253, 17.3718)">
+<g transform="translate(7.9650, 17.1559)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8227" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(22.4253, 16.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(22.4903, 18.3718)">
+<g transform="translate(22.4903, 17.1559)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(24.9945, 18.3718)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 15.3718)">
+<g transform="translate(19.9211, 16.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 17.3718)">
+<g transform="translate(24.9295, 15.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(24.9945, 17.1559)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 14.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(27.1837, 18.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(27.2487, 17.1559)">
+<rect x="-0.0650" y="1.6861" width="0.1300" height="2.8004" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(10.1542, 15.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(12.6584, 15.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(12.7234, 17.1559)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9664" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(10.2192, 17.1559)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1276" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(15.1626, 16.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(15.2276, 17.1559)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8051" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(17.6669, 15.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(17.7319, 17.1559)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(37.7656, 17.1559)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(0.8000, 16.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 17.3718)">
+<g transform="translate(40.2048, 14.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(40.2698, 17.1559)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(37.9429, 13.6393)">
+<path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
+c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
+</g>
+<g transform="translate(42.7090, 14.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(42.7740, 17.1559)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(44.9632, 15.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(45.0282, 17.1559)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(4.3000, 16.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 15.2971)">
+<g transform="translate(29.9379, 17.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(30.0029, 17.1559)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="3.7288" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(32.6921, 16.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(32.7571, 17.1559)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="4.1571" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(35.1963, 15.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(35.2613, 17.1559)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1374" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(-1.1267, 14.0812)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>3</tspan>
 </text>
 </g>
-<g transform="translate(24.9295, 16.8718)">
+<g transform="translate(37.7006, 15.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(7.9650, 18.3718)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8227" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(10.1542, 16.3718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(10.2192, 18.3718)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1276" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(12.6584, 16.8718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(12.7234, 18.3718)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9664" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(42.7740, 18.3718)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(42.7090, 15.3718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(35.1963, 16.8718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(35.2613, 18.3718)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1374" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(27.1837, 19.8718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(37.7006, 16.3718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(37.9429, 14.8552)">
-<path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
-c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
-</g>
-<g transform="translate(37.7656, 18.3718)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(40.2698, 18.3718)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(40.2048, 15.8718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(27.2487, 18.3718)">
-<rect x="-0.0650" y="1.6861" width="0.1300" height="2.8004" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(29.9379, 18.3718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(30.0029, 18.3718)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="3.7288" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(45.0282, 18.3718)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(44.9632, 16.3718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(32.6921, 17.3718)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(32.7571, 18.3718)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="4.1571" ry="0.0400" fill="currentColor"/>
 </g>
 </svg>

--- a/scores/allemande/mm-4-6.svg
+++ b/scores/allemande/mm-4-6.svg
@@ -1,471 +1,468 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="36.20mm" viewBox="-1.1267 -0.0000 103.5567 20.6003">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="34.03mm" viewBox="-1.1267 -0.0000 103.5567 19.3656">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
-<g transform="translate(0.0000, 8.5597)">
+<g transform="translate(0.0000, 7.3250)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 7.5597)">
+<g transform="translate(0.0000, 6.3250)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 6.5597)">
+<g transform="translate(0.0000, 5.3250)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 5.5597)">
+<g transform="translate(0.0000, 4.3250)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 4.5597)">
+<g transform="translate(0.0000, 3.3250)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 3.5597)">
+<g transform="translate(0.0000, 2.3250)">
 <rect x="86.5067" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 3.5597)">
+<g transform="translate(0.0000, 2.3250)">
 <rect x="60.9248" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 3.5597)">
+<g transform="translate(0.0000, 2.3250)">
 <rect x="40.9208" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(53.4967, 6.5597)">
+<g transform="translate(53.4967, 5.3250)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(102.2399, 6.5597)">
+<g transform="translate(102.2399, 5.3250)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(73.4873, 5.0597)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(73.5523, 5.3250)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1877" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(67.2441, 5.0597)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(70.4307, 6.5597)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.7501" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(70.3657, 5.5597)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(67.3091, 6.5597)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3126" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(67.4694, 3.5296)">
+<g transform="translate(67.4694, 2.2949)">
 <path transform="scale(0.0022, -0.0022)" d="M94 66c-60 0 -39 -66 -72 -66c-11 0 -22 7 -22 21c0 154 232 162 232 334c0 50 -17 102 -61 102c-33 0 -66 -14 -66 -44c0 -24 31 -37 31 -61c0 -34 -27 -61 -61 -61s-61 27 -61 61c0 84 72 148 157 148c98 0 190 -55 190 -145c0 -140 -131 -154 -225 -205
 c85 -2 113 -61 165 -61c45 0 28 41 57 41c11 0 22 -8 22 -21c0 -29 -48 -109 -144 -109c-92 0 -96 66 -142 66z" fill="currentColor"/>
 </g>
-<g transform="translate(73.5523, 6.5597)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1877" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(76.6090, 4.5597)">
+<g transform="translate(73.4873, 3.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(76.6740, 6.5597)">
+<g transform="translate(70.4307, 5.3250)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.7501" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(70.3657, 4.3250)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(67.3091, 5.3250)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3126" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(76.6090, 3.3250)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(76.6740, 5.3250)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6252" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(80.5806, 6.5597)">
+<g transform="translate(80.5806, 5.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(81.2327, 4.2597)">
+<g transform="translate(81.2327, 3.0250)">
 <path transform="scale(0.0040, -0.0040)" d="M-297 227c0 -15 8 -30 39 -30c10 0 46 2 103 28l5 24c-23 17 -50 29 -81 29c-51 0 -66 -31 -66 -51zM-26 104c0 -61 -47 -115 -98 -115c-39 0 -56 44 -56 91c0 14 1 28 4 41l15 76c-20 -8 -63 -25 -101 -25c-19 0 -60 6 -60 51c0 38 32 80 96 80c31 0 58 -10 82 -25
 l46 232c6 -3 13 -5 20 -5c22 0 48 16 68 35l-53 -266l64 36c26 14 51 20 74 20c29 0 53 -10 64 -28c18 20 44 30 69 30c36 0 69 -22 69 -69c0 -49 -31 -90 -65 -90c-25 0 -38 22 -38 48c0 50 37 64 60 64h3c-8 14 -23 20 -38 20c-24 0 -50 -16 -55 -43l-54 -270
 c-11 7 -24 11 -38 11s-29 -4 -43 -11l54 270v7c0 16 -12 26 -29 26c-7 0 -16 -3 -24 -7l-79 -44l-7 -31c27 -31 50 -67 50 -109zM-86 39c23 0 35 34 35 61c0 30 -14 55 -32 78l-5 -27c-4 -18 -13 -56 -13 -83c0 -17 4 -29 15 -29z" fill="currentColor"/>
 </g>
-<g transform="translate(82.3348, 6.0597)">
+<g transform="translate(82.3348, 4.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(80.6456, 6.5597)">
+<g transform="translate(80.6456, 5.3250)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="3.2967" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(55.0726, 6.5597)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(89.9544, 6.7497)">
+<g transform="translate(89.9544, 5.5150)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 0.8000 9.4549 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(89.9544, 7.5597)">
+<g transform="translate(89.9544, 6.3250)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 0.8000 9.4549 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(58.1292, 4.0597)">
+<g transform="translate(58.1292, 2.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(58.1942, 6.5597)">
+<g transform="translate(58.1942, 5.3250)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(61.2508, 3.5597)">
+<g transform="translate(67.2441, 3.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(61.3158, 6.5597)">
+<g transform="translate(61.2508, 2.3250)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(61.3158, 5.3250)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(64.1224, 4.5597)">
+<g transform="translate(64.1224, 3.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(64.1874, 6.5597)">
+<g transform="translate(64.1874, 5.3250)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(99.3193, 5.5597)">
+<g transform="translate(99.3193, 4.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(99.3843, 6.5597)">
+<g transform="translate(99.3843, 5.3250)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8070" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 6.5597)">
+<g transform="translate(7.9000, 5.3250)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7951 -3.5450C1.7841 -3.9898 3.1679 -3.5079 3.6667 -2.5450L3.6667 -2.5450C3.1284 -3.3946 1.7446 -3.8765 0.7951 -3.5450z"/>
 </g>
-<g transform="translate(13.8933, 6.5597)">
+<g transform="translate(13.8933, 5.3250)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8371 -2.5450C1.9020 -2.8946 3.2985 -2.2381 3.7087 -1.1950L3.7087 -1.1950C3.2474 -2.1295 1.8510 -2.7860 0.8371 -2.5450z"/>
 </g>
-<g transform="translate(19.8865, 6.5597)">
+<g transform="translate(19.8865, 5.3250)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5091 1.1961C1.0079 2.1613 2.3917 2.6432 3.3808 2.1961L3.3808 2.1961C2.4312 2.5298 1.0474 2.0479 0.5091 1.1961z"/>
 </g>
-<g transform="translate(7.9000, 7.5597)">
+<g transform="translate(7.9000, 6.3250)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9549 0.9900 8.9549 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(7.9000, 8.3697)">
+<g transform="translate(7.9000, 7.1350)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9549 0.9900 8.9549 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(25.8798, 6.5597)">
+<g transform="translate(25.8798, 5.3250)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5287 2.1950C1.0657 3.1224 2.4451 3.5307 3.4003 3.0450L3.4003 3.0450C2.4791 3.4156 1.0998 3.0073 0.5287 2.1950z"/>
 </g>
-<g transform="translate(21.0607, 3.5597)">
+<g transform="translate(21.0607, 2.3250)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9549 0.8000 8.9549 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(21.0607, 4.3697)">
+<g transform="translate(21.0607, 3.1350)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9549 0.8000 8.9549 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(41.2468, 6.5597)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7209 -4.0450C2.6591 -5.1854 8.6006 -4.2337 10.0858 -2.5450L10.0858 -2.5450C8.5816 -4.1152 2.6402 -5.0669 0.7209 -4.0450z"/>
+<g transform="translate(41.2468, 5.3250)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7209 -4.0450C2.2439 -5.0129 5.8196 -4.4402 6.9641 -3.0450L6.9641 -3.0450C5.8006 -4.3217 2.2250 -4.8945 0.7209 -4.0450z"/>
 </g>
-<g transform="translate(37.0902, 8.9941)">
+<g transform="translate(37.0902, 7.7594)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.6344 1.1250 -0.2344 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(31.8730, 11.7497)">
+<g transform="translate(31.8730, 10.5150)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.3422 -2.5800 6.3422 -2.1800 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(55.0076, 6.5597)">
+<g transform="translate(55.0076, 5.3250)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5833 -3.0450C1.7279 -4.4402 5.3035 -5.0129 6.8266 -4.0450L6.8266 -4.0450C5.3225 -4.8945 1.7469 -4.3217 0.5833 -3.0450z"/>
 </g>
-<g transform="translate(41.2468, 6.7497)">
+<g transform="translate(41.2468, 5.5150)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 0.6100 9.4549 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(41.2468, 7.5597)">
+<g transform="translate(41.2468, 6.3250)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 0.6100 9.4549 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(67.2441, 6.5597)">
+<g transform="translate(67.2441, 5.3250)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -2.5450C1.9916 -3.7338 5.5558 -3.7338 6.8954 -2.5450L6.8954 -2.5450C5.5558 -3.6138 1.9916 -3.6138 0.6521 -2.5450z"/>
 </g>
-<g transform="translate(55.0076, 6.7497)">
+<g transform="translate(55.0076, 5.5150)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.2049 -0.2000 9.2049 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(55.0076, 7.5597)">
+<g transform="translate(55.0076, 6.3250)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.2049 -0.2000 9.2049 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(67.2441, 7.7497)">
+<g transform="translate(67.2441, 6.5150)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 -0.3900 9.4549 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(67.2441, 8.5597)">
+<g transform="translate(67.2441, 7.3250)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 -0.3900 9.4549 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(85.7978, 7.8682)">
+<g transform="translate(85.7978, 6.6335)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.5085 1.1250 -0.1085 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(80.5806, 10.0597)">
+<g transform="translate(80.5806, 8.8250)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.3422 -1.8900 6.3422 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(79.1306, 6.5597)">
+<g transform="translate(79.1306, 5.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(86.8328, 3.5597)">
+<g transform="translate(86.8328, 2.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(87.0239, 2.5147)">
+<g transform="translate(87.0239, 1.2800)">
 <path transform="scale(0.0022, -0.0022)" d="M148 501c10 0 41 -15 72 -15c32 0 63 15 76 15c15 0 26 -11 26 -21c0 -4 -1 -7 -4 -10l-264 -291h134v4c0 60 50 41 75 85c7 11 8 24 14 36c3 7 10 10 17 10c11 0 24 -8 24 -25v-110h70c18 0 27 -14 27 -27s-9 -27 -27 -27h-70c2 -45 36 -82 80 -82c14 0 22 -10 22 -21
 s-8 -22 -22 -22c-49 0 -96 14 -145 14s-97 -14 -146 -14c-14 0 -21 11 -21 22s7 21 21 21c44 0 79 37 81 82h-134c-43 0 -57 25 -57 42c0 5 1 10 3 12c73 81 123 182 123 291c0 17 11 31 25 31z" fill="currentColor"/>
 </g>
-<g transform="translate(86.8978, 6.5597)">
+<g transform="translate(86.8978, 5.3250)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="4.6411" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(89.9544, 4.0597)">
+<g transform="translate(89.9544, 2.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(90.0194, 6.5597)">
+<g transform="translate(90.0194, 5.3250)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3207" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(93.0760, 4.5597)">
+<g transform="translate(93.0760, 3.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(93.1410, 6.5597)">
+<g transform="translate(93.1410, 5.3250)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1495" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(96.1977, 5.0597)">
+<g transform="translate(96.1977, 3.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(96.2627, 6.5597)">
+<g transform="translate(96.2627, 5.3250)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9783" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(16.7649, 6.5597)">
+<g transform="translate(16.7649, 5.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(16.8299, 6.5597)">
+<g transform="translate(16.8299, 5.3250)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.8053" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(19.8865, 6.5597)">
+<g transform="translate(19.8865, 5.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(21.1257, 6.5597)">
+<g transform="translate(21.1257, 5.3250)">
 <rect x="-0.0650" y="-2.9928" width="0.1300" height="2.8067" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(22.7582, 7.5597)">
+<g transform="translate(22.7582, 6.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(23.9974, 6.5597)">
+<g transform="translate(23.9974, 5.3250)">
 <rect x="-0.0650" y="-2.6735" width="0.1300" height="3.4874" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(25.8798, 7.5597)">
+<g transform="translate(25.8798, 6.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(27.1190, 6.5597)">
+<g transform="translate(27.1190, 5.3250)">
 <rect x="-0.0650" y="-2.3265" width="0.1300" height="3.1404" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(28.7514, 8.5597)">
+<g transform="translate(55.0726, 5.3250)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(28.7514, 7.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(29.9906, 6.5597)">
+<g transform="translate(29.9906, 5.3250)">
 <rect x="-0.0650" y="-2.0072" width="0.1300" height="3.8211" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 4.0597)">
+<g transform="translate(7.9000, 2.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 5.5597)">
+<g transform="translate(0.8000, 4.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 5.5597)">
+<g transform="translate(4.3000, 4.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(7.9650, 6.5597)">
+<g transform="translate(7.9650, 5.3250)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1325" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 3.5097)">
+<g transform="translate(-1.1267, 2.2750)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>4</tspan>
 </text>
 </g>
-<g transform="translate(10.7716, 5.0597)">
+<g transform="translate(10.7716, 3.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(10.8366, 6.5597)">
+<g transform="translate(10.8366, 5.3250)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.5124" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(13.8933, 5.0597)">
+<g transform="translate(13.8933, 3.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(13.9583, 6.5597)">
+<g transform="translate(13.9583, 5.3250)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.9254" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(47.5551, 6.5597)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.3520" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(41.2468, 3.5597)">
+<g transform="translate(41.2468, 2.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(41.8990, 2.0800)">
-<path transform="scale(0.0040, -0.0040)" d="M128 508c2 7 9 12 17 12c10 0 18 -7 18 -17c0 -2 -1 -4 -1 -6l-145 -485c-2 -7 -9 -12 -17 -12s-15 5 -17 12l-145 485v6c0 10 7 17 17 17c8 0 15 -5 17 -12l88 -295l40 -164l40 164z" fill="currentColor"/>
-</g>
-<g transform="translate(41.3118, 6.5597)">
+<g transform="translate(41.3118, 5.3250)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8194" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(44.3685, 4.0597)">
+<g transform="translate(44.3685, 2.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(44.4335, 6.5597)">
+<g transform="translate(44.4335, 5.3250)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.5857" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(47.4901, 4.5597)">
+<g transform="translate(47.4901, 3.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(50.6117, 5.0597)">
+<g transform="translate(47.5551, 5.3250)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.3520" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(50.6117, 3.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(50.6767, 6.5597)">
+<g transform="translate(50.6767, 5.3250)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1183" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(55.0076, 4.5597)">
+<g transform="translate(55.0076, 3.3250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(55.2499, 2.8914)">
+<g transform="translate(55.2499, 1.6567)">
 <path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
 c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
 </g>
-<g transform="translate(31.9380, 6.5597)">
+<g transform="translate(31.9380, 5.3250)">
 <rect x="-0.0650" y="2.1861" width="0.1300" height="2.9797" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(38.1252, 4.0597)">
+<g transform="translate(38.1252, 2.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(38.7773, 3.3147)">
-<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
+<g transform="translate(38.7773, 2.0800)">
+<path transform="scale(0.0040, -0.0040)" d="M128 508c2 7 9 12 17 12c10 0 18 -7 18 -17c0 -2 -1 -4 -1 -6l-145 -485c-2 -7 -9 -12 -17 -12s-15 5 -17 12l-145 485v6c0 10 7 17 17 17c8 0 15 -5 17 -12l88 -295l40 -164l40 164z" fill="currentColor"/>
 </g>
-<g transform="translate(38.1902, 6.5597)">
+<g transform="translate(38.1902, 5.3250)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="5.1481" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(33.6273, 8.0597)">
+<g transform="translate(31.8730, 7.3250)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(33.6273, 6.8250)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(32.5252, 4.2597)">
+<g transform="translate(32.5252, 3.0250)">
 <path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
 </g>
-<g transform="translate(31.8730, 8.5597)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 18.3603)">
+<g transform="translate(0.0000, 17.1256)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
 </g>
-<g transform="translate(0.0000, 17.3603)">
+<g transform="translate(0.0000, 16.1256)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
 </g>
-<g transform="translate(0.0000, 16.3603)">
+<g transform="translate(0.0000, 15.1256)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
 </g>
-<g transform="translate(0.0000, 15.3603)">
+<g transform="translate(0.0000, 14.1256)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
 </g>
-<g transform="translate(0.0000, 14.3603)">
+<g transform="translate(0.0000, 13.1256)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
 </g>
-<g transform="translate(0.0000, 19.3603)">
+<g transform="translate(0.0000, 18.1256)">
 <rect x="26.6077" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 19.3603)">
+<g transform="translate(0.0000, 18.1256)">
 <rect x="24.1034" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(44.5220, 16.3603)">
+<g transform="translate(44.5220, 15.1256)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(37.0094, 14.8603)">
+<g transform="translate(37.0094, 13.6256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(31.5899, 17.3603)">
+<g transform="translate(31.5899, 16.1256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(32.8291, 16.3603)">
+<g transform="translate(32.8291, 15.1256)">
 <rect x="-0.0650" y="-1.9838" width="0.1300" height="2.7977" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(34.2552, 15.8603)">
+<g transform="translate(34.2552, 14.6256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(34.3202, 16.3603)">
+<g transform="translate(34.3202, 15.1256)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1174" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(28.1729, 16.3603)">
+<g transform="translate(28.1729, 15.1256)">
 <rect x="-0.0650" y="-0.8262" width="0.1300" height="3.6401" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(28.6879, 18.8603)">
+<g transform="translate(28.6879, 17.6256)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(26.9337, 19.3603)">
+<g transform="translate(26.9337, 18.1256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(25.6687, 16.3603)">
+<g transform="translate(25.6687, 15.1256)">
 <rect x="-0.0650" y="-1.0091" width="0.1300" height="3.8230" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(24.4295, 19.3603)">
+<g transform="translate(24.4295, 18.1256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(34.2552, 18.3603)">
+<g transform="translate(34.2552, 17.1256)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.0100 8.1026 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(34.2552, 19.1703)">
+<g transform="translate(34.2552, 17.9356)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.0100 8.1026 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(28.1079, 15.5503)">
+<g transform="translate(28.1079, 14.3156)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="4.7462 -1.3900 4.7462 -0.9900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(31.7291, 15.4600)">
+<g transform="translate(31.7291, 14.2253)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.4897 1.1250 -0.0897 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(18.5911, 14.3603)">
+<g transform="translate(18.5911, 13.1256)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(18.5911, 15.1703)">
+<g transform="translate(18.5911, 13.9356)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(7.9000, 18.3603)">
+<g transform="translate(7.9000, 17.1256)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(7.9000, 19.1703)">
+<g transform="translate(7.9000, 17.9356)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(37.0744, 16.3603)">
+<g transform="translate(37.0744, 15.1256)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.8434" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.3328, 16.3603)">
+<g transform="translate(42.3328, 15.1256)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.8204" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.2678, 14.3603)">
+<g transform="translate(42.2678, 13.1256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(39.5786, 16.3603)">
+<g transform="translate(39.5786, 15.1256)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.0943" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(39.5136, 15.3603)">
+<g transform="translate(39.5136, 14.1256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.7234, 16.3603)">
+<g transform="translate(12.7234, 15.1256)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.9275" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(10.2192, 16.3603)">
+<g transform="translate(10.2192, 15.1256)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.5103" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(10.1542, 15.8603)">
+<g transform="translate(10.1542, 14.6256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(7.9650, 16.3603)">
+<g transform="translate(7.9650, 15.1256)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1347" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 14.8603)">
+<g transform="translate(7.9000, 13.6256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.6584, 15.8603)">
+<g transform="translate(12.6584, 14.6256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 13.2856)">
+<g transform="translate(-1.1267, 12.0509)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>6</tspan>
 </text>
 </g>
-<g transform="translate(4.3000, 15.3603)">
+<g transform="translate(4.3000, 14.1256)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 15.3603)">
+<g transform="translate(0.8000, 14.1256)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(18.6561, 16.3603)">
+<g transform="translate(18.6561, 15.1256)">
 <rect x="-0.0650" y="-1.9909" width="0.1300" height="2.8048" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(23.4145, 16.3603)">
+<g transform="translate(23.4145, 15.1256)">
 <rect x="-0.0650" y="-1.3247" width="0.1300" height="3.1386" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(22.1753, 18.3603)">
+<g transform="translate(22.1753, 17.1256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(20.9103, 16.3603)">
+<g transform="translate(20.9103, 15.1256)">
 <rect x="-0.0650" y="-1.6753" width="0.1300" height="3.4892" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(19.6711, 18.3603)">
+<g transform="translate(19.6711, 17.1256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(17.4169, 17.3603)">
+<g transform="translate(17.4169, 16.1256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(14.9776, 16.3603)">
+<g transform="translate(14.9776, 15.1256)">
 <rect x="-0.0650" y="1.1861" width="0.1300" height="2.8031" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(14.9126, 17.3603)">
+<g transform="translate(14.9126, 16.1256)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 </svg>

--- a/tools/scores/allemande.ly
+++ b/tools/scores/allemande.ly
@@ -17,7 +17,7 @@ allemande = \absolute {
     <b d g,>4 << { b16\repeatTie a16-4( g16 fis16) } \\ { d16\repeatTie s8. } >> g16 d16( e16 fis16 g16 a16 b16 c'16) |
     d'16( b16 g16 fis16 g16 e16 d16 c16) \stemUp b,16( c16 d16 e16 \stemNeutral fis16 g16 a16-1 b16) |
     c'16( a16 g16 fis16) g16( e16 fis16 g16) a,16( d16 fis16 g16) a16-1( b16 c'16 a16) |
-    b16( g16) g16( d16) d16( b,16) b,16( g,16) g,8.\downbow b16\downbow c'16\upbow( b16 a16 g16) |
+    b16( g16) g16( d16) d16( b,16) b,16( g,16) g,8.\downbow b16\upbow c'16( b16 a16) g16 |
     \barNumberCheck #5
     a16-1( b16 c'16) a16 g16-2( fis16 g16) a16 dis8.\trill c'16-4 b16 a16 g16 fis16 |
     g16 e16 e16 b,16 b,16 g,16 g,16 e,16 e,8. b,16 e16 g16 fis16 a16 |


### PR DESCRIPTION
## Summary
- Allemande m.4: replace the double down-bow with a down-up pattern (up-bow on the 10th note), slur the closing c-b-a run, and bow the final g separately.
- Add `CLAUDE.md` notes on the squash-merge realign workflow.

## Test plan
- [x] `build_scores.py` runs clean; only `mm-1-4.svg` and `mm-4-6.svg` changed (both contain m.4).
- [x] Rendered mm. 4-6 to confirm down-bow then up-bow, c-b-a slur, separate g.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_