### PR TITLE
Allemande m.3 bowing: 8 slurred, a, separate, 7 slurred

### DIFF
--- a/scores/allemande/mm-1-4.svg
+++ b/scores/allemande/mm-1-4.svg
@@ -329,12 +329,6 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(0.0000, 15.1559)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="84.6635" y2="0"/>
 </g>
-<g transform="translate(84.5235, 17.1559)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(47.2307, 17.1559)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
 <g transform="translate(0.0000, 14.1559)">
 <rect x="74.4173" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
@@ -344,19 +338,28 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(0.0000, 14.1559)">
 <rect x="7.5740" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
+<g transform="translate(47.2307, 17.1559)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(84.5235, 17.1559)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(55.6269, 17.1559)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8031" ry="0.0400" fill="currentColor"/>
+</g>
 <g transform="translate(61.5595, 17.1559)">
 <rect x="-0.0650" y="-2.6753" width="0.1300" height="3.4892" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(60.3203, 18.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(69.3372, 18.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
 <g transform="translate(59.3053, 17.1559)">
 <rect x="-0.0650" y="-2.9909" width="0.1300" height="2.8048" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(58.0661, 17.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(67.5830, 19.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(62.8245, 18.1559)">
@@ -371,12 +374,6 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(66.3180, 17.1559)">
 <rect x="-0.0650" y="-2.0091" width="0.1300" height="3.8230" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(67.5830, 19.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(68.2351, 14.8559)">
-<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
-</g>
 <g transform="translate(74.7433, 17.3459)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 0.6100 7.6026 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
@@ -389,8 +386,8 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(48.6143, 17.1559)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1347" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(55.6269, 17.1559)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8031" ry="0.0400" fill="currentColor"/>
+<g transform="translate(55.5619, 17.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(50.8035, 15.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -404,20 +401,14 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(53.3727, 17.1559)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.9275" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(55.5619, 17.1559)">
+<g transform="translate(82.2560, 15.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 17.1559)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7594 -4.0450C2.5406 -4.9329 6.8827 -3.8268 8.0221 -2.1950L8.0221 -2.1950C6.8531 -3.7105 2.5109 -4.8166 0.7594 -4.0450z"/>
 </g>
 <g transform="translate(82.3210, 17.1559)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1170" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(82.2560, 15.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(17.6669, 17.1559)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -2.5450C2.1296 -3.8263 6.4373 -3.8263 7.9147 -2.5450L7.9147 -2.5450C6.4373 -3.7063 2.1296 -3.7063 0.6521 -2.5450z"/>
+<g transform="translate(7.9000, 17.1559)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6903 -4.0450C3.1481 -5.5264 15.5587 -4.4332 17.7197 -2.5450L17.7197 -2.5450C15.5482 -4.3137 3.1376 -5.4069 0.6903 -4.0450z"/>
 </g>
 <g transform="translate(7.9000, 17.3459)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
@@ -425,17 +416,14 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(7.9000, 18.1559)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(27.1837, 17.1559)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4997 0.4550C1.5465 -1.4066 6.5003 -3.2613 8.5123 -2.5450L8.5123 -2.5450C6.5423 -3.1490 1.5886 -1.2942 0.4997 0.4550z"/>
-</g>
 <g transform="translate(17.6669, 18.3459)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
 <g transform="translate(17.6669, 19.1559)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(37.7006, 17.1559)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -3.0450C2.1296 -4.3263 6.4373 -4.3263 7.9147 -3.0450L7.9147 -3.0450C6.4373 -4.2063 2.1296 -4.2063 0.6521 -3.0450z"/>
+<g transform="translate(29.9379, 17.1559)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5849 -1.1950C2.5071 -3.1642 13.1785 -4.8333 15.6102 -3.5450L15.6102 -3.5450C13.1971 -4.7147 2.5257 -3.0457 0.5849 -1.1950z"/>
 </g>
 <g transform="translate(27.1837, 20.8459)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.8900 8.1026 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
@@ -482,6 +470,15 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(67.5830, 22.1559)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="4.7462 -2.3900 4.7462 -1.9900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
+<g transform="translate(74.8083, 17.1559)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8208" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(69.3372, 18.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(67.6480, 17.1559)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.7842" ry="0.0400" fill="currentColor"/>
+</g>
 <g transform="translate(72.2391, 14.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
@@ -494,11 +491,8 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(74.7433, 14.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(74.8083, 17.1559)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8208" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(67.6480, 17.1559)">
-<rect x="-0.0650" y="2.1861" width="0.1300" height="2.7842" ry="0.0400" fill="currentColor"/>
+<g transform="translate(68.2351, 14.8559)">
+<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
 </g>
 <g transform="translate(77.2476, 14.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -512,48 +506,6 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(79.8168, 17.1559)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.3516" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(19.9861, 17.1559)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9650, 17.1559)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8227" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(22.4253, 16.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(22.4903, 17.1559)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(19.9211, 16.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(24.9295, 15.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(24.9945, 17.1559)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 14.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(27.1837, 18.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(27.2487, 17.1559)">
-<rect x="-0.0650" y="1.6861" width="0.1300" height="2.8004" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(10.1542, 15.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(12.6584, 15.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(12.7234, 17.1559)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9664" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(10.2192, 17.1559)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1276" ry="0.0400" fill="currentColor"/>
-</g>
 <g transform="translate(15.1626, 16.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
@@ -566,50 +518,57 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(17.7319, 17.1559)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(37.7656, 17.1559)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(19.9211, 16.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(19.9861, 17.1559)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(22.4253, 16.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(22.4903, 17.1559)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(24.9295, 15.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(24.9945, 17.1559)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 14.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(0.8000, 16.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(40.2048, 14.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(40.2698, 17.1559)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(37.9429, 13.6393)">
-<path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
-c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
-</g>
-<g transform="translate(42.7090, 14.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(42.7740, 17.1559)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(44.9632, 15.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(45.0282, 17.1559)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
-</g>
 <g transform="translate(4.3000, 16.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(29.9379, 17.1559)">
+<g transform="translate(-1.1267, 14.0812)">
+<text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
+<tspan>3</tspan>
+</text>
+</g>
+<g transform="translate(7.9650, 17.1559)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8227" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(10.1542, 15.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(30.0029, 17.1559)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="3.7288" ry="0.0400" fill="currentColor"/>
+<g transform="translate(10.2192, 17.1559)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1276" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(32.6921, 16.1559)">
+<g transform="translate(12.6584, 15.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(32.7571, 17.1559)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="4.1571" ry="0.0400" fill="currentColor"/>
+<g transform="translate(12.7234, 17.1559)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9664" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(42.7090, 14.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(35.1963, 15.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -617,12 +576,47 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(35.2613, 17.1559)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1374" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 14.0812)">
-<text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
-<tspan>3</tspan>
-</text>
+<g transform="translate(42.7740, 17.1559)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(37.7006, 15.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(40.2698, 17.1559)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(40.2048, 14.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(37.9429, 13.2771)">
+<path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
+c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
+</g>
+<g transform="translate(37.7656, 17.1559)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(30.0029, 17.1559)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="3.7288" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(27.1837, 18.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(27.2487, 17.1559)">
+<rect x="-0.0650" y="1.6861" width="0.1300" height="2.8004" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(45.0282, 17.1559)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(29.9379, 17.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(32.7571, 17.1559)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="4.1571" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(44.9632, 15.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(32.6921, 16.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 </svg>

--- a/tools/scores/allemande.ly
+++ b/tools/scores/allemande.ly
@@ -16,7 +16,7 @@ allemande = \absolute {
     \partial 16 b16\f |
     <b d g,>4 << { b16\repeatTie a16-4( g16 fis16) } \\ { d16\repeatTie s8. } >> g16 d16( e16 fis16 g16 a16 b16 c'16) |
     d'16( b16 g16 fis16 g16 e16 d16 c16) \stemUp b,16( c16 d16 e16 \stemNeutral fis16 g16 a16-1 b16) |
-    c'16( a16 g16 fis16) g16( e16 fis16 g16) a,16( d16 fis16 g16) a16-1( b16 c'16 a16) |
+    c'16( a16 g16 fis16 g16 e16 fis16 g16) a,16 d16( fis16 g16 a16-1 b16 c'16 a16) |
     b16( g16) g16( d16) d16( b,16) b,16( g,16) g,8.\downbow b16\upbow c'16( b16 a16) g16 |
     \barNumberCheck #5
     a16-1( b16 c'16) a16 g16-2( fis16 g16) a16 dis8.\trill c'16-4 b16 a16 g16 fis16 |


### PR DESCRIPTION
## Summary
- Allemande m.3: slur the first 8 notes together, bow the `a,` (9th note) separately, and slur the final 7 notes.

## Test plan
- [x] `build_scores.py` clean; only `mm-1-4.svg` changed.
- [x] Rendered mm. 2-4 to confirm the 8 / 1 / 7 phrasing.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_