### PR TITLE
Allemande mm.4-6: mp, slurs, down-bow, spelled-out crescendo

### DIFF
--- a/scores/allemande/mm-1-4.svg
+++ b/scores/allemande/mm-1-4.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="39.36mm" viewBox="-1.1267 -0.0000 103.5567 22.3959">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="40.10mm" viewBox="-1.1267 -0.0000 103.5567 22.8219">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
@@ -344,9 +344,6 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(84.5235, 17.1559)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(55.6269, 17.1559)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8031" ry="0.0400" fill="currentColor"/>
-</g>
 <g transform="translate(61.5595, 17.1559)">
 <rect x="-0.0650" y="-2.6753" width="0.1300" height="3.4892" ry="0.0400" fill="currentColor"/>
 </g>
@@ -359,8 +356,8 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(58.0661, 17.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(67.5830, 19.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(69.3372, 18.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
 <g transform="translate(62.8245, 18.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -374,6 +371,12 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(66.3180, 17.1559)">
 <rect x="-0.0650" y="-2.0091" width="0.1300" height="3.8230" ry="0.0400" fill="currentColor"/>
 </g>
+<g transform="translate(67.5830, 19.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(68.2351, 14.8559)">
+<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
+</g>
 <g transform="translate(74.7433, 17.3459)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 0.6100 7.6026 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
@@ -386,8 +389,8 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(48.6143, 17.1559)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1347" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(55.5619, 17.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(55.6269, 17.1559)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.8031" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(50.8035, 15.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -400,6 +403,9 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 </g>
 <g transform="translate(53.3727, 17.1559)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.9275" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(55.5619, 17.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(82.2560, 15.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -470,17 +476,18 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(67.5830, 22.1559)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="4.7462 -2.3900 4.7462 -1.9900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(74.8083, 17.1559)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8208" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(69.3372, 18.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(67.6480, 17.1559)">
-<rect x="-0.0650" y="2.1861" width="0.1300" height="2.7842" ry="0.0400" fill="currentColor"/>
-</g>
 <g transform="translate(72.2391, 14.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(71.1670, 22.2379)">
+<g>
+<path transform="scale(0.0040, -0.0040)" d="M-43 140c0 14 58 159 151 159c22 0 36 -20 41 -45c22 26 51 45 81 45c23 0 38 -21 44 -46c22 27 51 46 80 46c33 0 59 -35 59 -69c0 -5 -1 -10 -2 -15l-35 -149c0 -2 -1 -4 -1 -5c0 -5 2 -8 7 -8c21 0 48 37 61 37c6 0 11 -4 11 -10c0 -11 -77 -87 -138 -87
+c-20 0 -32 13 -32 32c0 4 0 7 1 11l39 165c1 5 2 9 2 14c0 10 -4 18 -14 18c-16 0 -33 -16 -39 -32l-53 -183c-3 -10 -12 -18 -22 -18h-41c-10 0 -16 8 -13 18l52 183c2 6 3 11 3 16c0 9 -4 16 -13 16c-15 0 -34 -14 -41 -33l-62 -182c-3 -10 -14 -18 -24 -18h-41
+c-10 0 -15 8 -12 18l63 183c2 5 2 10 2 15c0 10 -3 17 -13 17c-29 0 -54 -53 -66 -87c-4 -11 -15 -17 -23 -17c-7 0 -12 4 -12 11z" fill="currentColor"/>
+
+<path transform="translate(1.9803, 0.0000) scale(0.0040, -0.0040)" d="M161 32c78 0 97 176 97 178c0 18 -7 33 -25 33c-61 0 -102 -124 -102 -173c0 -22 8 -38 30 -38zM-53 141c0 2 51 151 134 151c35 0 59 -21 66 -52c29 31 67 52 103 52c69 0 107 -49 107 -114c0 -118 -105 -186 -159 -186c-53 0 -70 20 -84 20c-7 0 -14 -3 -16 -9l-29 -86
+c-1 -2 -1 -5 -1 -7c0 -37 57 -18 57 -42c0 -7 -4 -14 -13 -14c-3 0 -50 5 -116 5s-112 -5 -115 -5c-9 0 -14 7 -14 14c0 31 87 -1 102 41l102 300c2 7 4 14 4 20c0 8 -2 14 -11 14c-33 0 -63 -60 -79 -97c-5 -12 -15 -17 -24 -17c-8 0 -14 4 -14 12z" fill="currentColor"/>
+</g>
 </g>
 <g transform="translate(72.8912, 13.9109)">
 <path transform="scale(0.0040, -0.0040)" d="M128 508c2 7 9 12 17 12c10 0 18 -7 18 -17c0 -2 -1 -4 -1 -6l-145 -485c-2 -7 -9 -12 -17 -12s-15 5 -17 12l-145 485v6c0 10 7 17 17 17c8 0 15 -5 17 -12l88 -295l40 -164l40 164z" fill="currentColor"/>
@@ -491,8 +498,11 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(74.7433, 14.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(68.2351, 14.8559)">
-<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
+<g transform="translate(74.8083, 17.1559)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8208" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(67.6480, 17.1559)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.7842" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(77.2476, 14.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -506,29 +516,20 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(79.8168, 17.1559)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.3516" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.1626, 16.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(15.2276, 17.1559)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8051" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(17.6669, 15.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(17.7319, 17.1559)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(19.9211, 16.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
 <g transform="translate(19.9861, 17.1559)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(7.9650, 17.1559)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8227" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(22.4253, 16.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(22.4903, 17.1559)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(19.9211, 16.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(24.9295, 15.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -539,9 +540,79 @@ c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-
 <g transform="translate(7.9000, 14.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
+<g transform="translate(27.1837, 18.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(27.2487, 17.1559)">
+<rect x="-0.0650" y="1.6861" width="0.1300" height="2.8004" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(15.2276, 17.1559)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8051" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(12.6584, 15.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(12.7234, 17.1559)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9664" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(10.2192, 17.1559)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1276" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(15.1626, 16.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(10.1542, 15.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(17.6669, 15.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(17.7319, 17.1559)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(37.9429, 13.2771)">
+<path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
+c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
+</g>
 <g transform="translate(0.8000, 16.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
+</g>
+<g transform="translate(40.2048, 14.6559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(40.2698, 17.1559)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(37.7656, 17.1559)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(42.7090, 14.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(42.7740, 17.1559)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(44.9632, 15.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(45.0282, 17.1559)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(29.9379, 17.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(30.0029, 17.1559)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="3.7288" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(32.6921, 16.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(32.7571, 17.1559)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="4.1571" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(37.7006, 15.1559)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(4.3000, 16.1559)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
@@ -552,71 +623,10 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <tspan>3</tspan>
 </text>
 </g>
-<g transform="translate(7.9650, 17.1559)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8227" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(10.1542, 15.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(10.2192, 17.1559)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1276" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(12.6584, 15.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(12.7234, 17.1559)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9664" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(42.7090, 14.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(35.1963, 15.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
 <g transform="translate(35.2613, 17.1559)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1374" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.7740, 17.1559)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(37.7006, 15.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(40.2698, 17.1559)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(40.2048, 14.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(37.9429, 13.2771)">
-<path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
-c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
-</g>
-<g transform="translate(37.7656, 17.1559)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(30.0029, 17.1559)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="3.7288" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(27.1837, 18.6559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(27.2487, 17.1559)">
-<rect x="-0.0650" y="1.6861" width="0.1300" height="2.8004" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(45.0282, 17.1559)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(29.9379, 17.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(32.7571, 17.1559)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="4.1571" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(44.9632, 15.1559)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(32.6921, 16.1559)">
+<g transform="translate(35.1963, 15.6559)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 </svg>

--- a/scores/allemande/mm-4-6.svg
+++ b/scores/allemande/mm-4-6.svg
@@ -1,468 +1,534 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="34.03mm" viewBox="-1.1267 -0.0000 103.5567 19.3656">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="37.40mm" viewBox="-1.1267 -0.0000 103.5567 21.2813">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
-<g transform="translate(0.0000, 7.3250)">
+<g transform="translate(0.0000, 7.5380)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 6.3250)">
+<g transform="translate(0.0000, 6.5380)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 5.3250)">
+<g transform="translate(0.0000, 5.5380)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 4.3250)">
+<g transform="translate(0.0000, 4.5380)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 3.3250)">
+<g transform="translate(0.0000, 3.5380)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 2.3250)">
+<g transform="translate(102.2399, 5.5380)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(53.4967, 5.5380)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 2.5380)">
 <rect x="86.5067" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 2.3250)">
+<g transform="translate(0.0000, 2.5380)">
 <rect x="60.9248" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 2.3250)">
+<g transform="translate(0.0000, 2.5380)">
 <rect x="40.9208" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(53.4967, 5.3250)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(102.2399, 5.3250)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(73.5523, 5.3250)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1877" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(67.4694, 2.2949)">
-<path transform="scale(0.0022, -0.0022)" d="M94 66c-60 0 -39 -66 -72 -66c-11 0 -22 7 -22 21c0 154 232 162 232 334c0 50 -17 102 -61 102c-33 0 -66 -14 -66 -44c0 -24 31 -37 31 -61c0 -34 -27 -61 -61 -61s-61 27 -61 61c0 84 72 148 157 148c98 0 190 -55 190 -145c0 -140 -131 -154 -225 -205
-c85 -2 113 -61 165 -61c45 0 28 41 57 41c11 0 22 -8 22 -21c0 -29 -48 -109 -144 -109c-92 0 -96 66 -142 66z" fill="currentColor"/>
-</g>
-<g transform="translate(73.4873, 3.8250)">
+<g transform="translate(70.3657, 4.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(70.4307, 5.3250)">
+<g transform="translate(70.4307, 5.5380)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="2.7501" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(70.3657, 4.3250)">
+<g transform="translate(73.4873, 4.0380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(67.3091, 5.3250)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3126" ry="0.0400" fill="currentColor"/>
+<g transform="translate(73.5523, 5.5380)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1877" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(76.6090, 3.3250)">
+<g transform="translate(76.6090, 3.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(76.6740, 5.3250)">
+<g transform="translate(76.6740, 5.5380)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6252" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(80.5806, 5.3250)">
+<g transform="translate(80.5806, 5.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(81.2327, 3.0250)">
+<g transform="translate(81.2327, 3.2380)">
 <path transform="scale(0.0040, -0.0040)" d="M-297 227c0 -15 8 -30 39 -30c10 0 46 2 103 28l5 24c-23 17 -50 29 -81 29c-51 0 -66 -31 -66 -51zM-26 104c0 -61 -47 -115 -98 -115c-39 0 -56 44 -56 91c0 14 1 28 4 41l15 76c-20 -8 -63 -25 -101 -25c-19 0 -60 6 -60 51c0 38 32 80 96 80c31 0 58 -10 82 -25
 l46 232c6 -3 13 -5 20 -5c22 0 48 16 68 35l-53 -266l64 36c26 14 51 20 74 20c29 0 53 -10 64 -28c18 20 44 30 69 30c36 0 69 -22 69 -69c0 -49 -31 -90 -65 -90c-25 0 -38 22 -38 48c0 50 37 64 60 64h3c-8 14 -23 20 -38 20c-24 0 -50 -16 -55 -43l-54 -270
 c-11 7 -24 11 -38 11s-29 -4 -43 -11l54 270v7c0 16 -12 26 -29 26c-7 0 -16 -3 -24 -7l-79 -44l-7 -31c27 -31 50 -67 50 -109zM-86 39c23 0 35 34 35 61c0 30 -14 55 -32 78l-5 -27c-4 -18 -13 -56 -13 -83c0 -17 4 -29 15 -29z" fill="currentColor"/>
 </g>
-<g transform="translate(82.3348, 4.8250)">
+<g transform="translate(82.3348, 5.0380)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(80.6456, 5.3250)">
+<g transform="translate(80.6456, 5.5380)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="3.2967" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(89.9544, 5.5150)">
+<g transform="translate(89.9544, 5.7280)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 0.8000 9.4549 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(89.9544, 6.3250)">
+<g transform="translate(89.9544, 6.5380)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 0.8000 9.4549 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(58.1292, 2.8250)">
+<g transform="translate(58.1292, 3.0380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(58.1942, 5.3250)">
+<g transform="translate(58.1942, 5.5380)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(67.2441, 3.8250)">
+<g transform="translate(67.3091, 5.5380)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3126" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(61.2508, 2.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(61.2508, 2.3250)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(61.3158, 5.3250)">
+<g transform="translate(61.3158, 5.5380)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(64.1224, 3.3250)">
+<g transform="translate(64.1224, 3.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(64.1874, 5.3250)">
+<g transform="translate(64.1874, 5.5380)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(99.3193, 4.3250)">
+<g transform="translate(67.2441, 4.0380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(99.3843, 5.3250)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8070" ry="0.0400" fill="currentColor"/>
+<g transform="translate(67.4694, 2.5079)">
+<path transform="scale(0.0022, -0.0022)" d="M94 66c-60 0 -39 -66 -72 -66c-11 0 -22 7 -22 21c0 154 232 162 232 334c0 50 -17 102 -61 102c-33 0 -66 -14 -66 -44c0 -24 31 -37 31 -61c0 -34 -27 -61 -61 -61s-61 27 -61 61c0 84 72 148 157 148c98 0 190 -55 190 -145c0 -140 -131 -154 -225 -205
+c85 -2 113 -61 165 -61c45 0 28 41 57 41c11 0 22 -8 22 -21c0 -29 -48 -109 -144 -109c-92 0 -96 66 -142 66z" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 5.3250)">
+<g transform="translate(7.9000, 5.5380)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7951 -3.5450C1.7841 -3.9898 3.1679 -3.5079 3.6667 -2.5450L3.6667 -2.5450C3.1284 -3.3946 1.7446 -3.8765 0.7951 -3.5450z"/>
 </g>
-<g transform="translate(13.8933, 5.3250)">
+<g transform="translate(99.3843, 5.5380)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8070" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(101.3193, 8.8933)">
+<text font-family="serif" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>–</tspan>
+</text>
+</g>
+<g transform="translate(13.8933, 5.5380)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8371 -2.5450C1.9020 -2.8946 3.2985 -2.2381 3.7087 -1.1950L3.7087 -1.1950C3.2474 -2.1295 1.8510 -2.7860 0.8371 -2.5450z"/>
 </g>
-<g transform="translate(19.8865, 5.3250)">
+<g transform="translate(19.8865, 5.5380)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5091 1.1961C1.0079 2.1613 2.3917 2.6432 3.3808 2.1961L3.3808 2.1961C2.4312 2.5298 1.0474 2.0479 0.5091 1.1961z"/>
 </g>
-<g transform="translate(7.9000, 6.3250)">
+<g transform="translate(7.9000, 6.5380)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9549 0.9900 8.9549 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(7.9000, 7.1350)">
+<g transform="translate(7.9000, 7.3480)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9549 0.9900 8.9549 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(25.8798, 5.3250)">
+<g transform="translate(25.8798, 5.5380)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5287 2.1950C1.0657 3.1224 2.4451 3.5307 3.4003 3.0450L3.4003 3.0450C2.4791 3.4156 1.0998 3.0073 0.5287 2.1950z"/>
 </g>
-<g transform="translate(21.0607, 2.3250)">
+<g transform="translate(21.0607, 2.5380)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9549 0.8000 8.9549 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(21.0607, 3.1350)">
+<g transform="translate(21.0607, 3.3480)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9549 0.8000 8.9549 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(41.2468, 5.3250)">
+<g transform="translate(41.2468, 5.5380)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7209 -4.0450C2.2439 -5.0129 5.8196 -4.4402 6.9641 -3.0450L6.9641 -3.0450C5.8006 -4.3217 2.2250 -4.8945 0.7209 -4.0450z"/>
 </g>
-<g transform="translate(37.0902, 7.7594)">
+<g transform="translate(37.0902, 7.9724)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.6344 1.1250 -0.2344 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(31.8730, 10.5150)">
+<g transform="translate(31.8730, 10.7280)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.3422 -2.5800 6.3422 -2.1800 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(55.0076, 5.3250)">
+<g transform="translate(55.0076, 5.5380)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5833 -3.0450C1.7279 -4.4402 5.3035 -5.0129 6.8266 -4.0450L6.8266 -4.0450C5.3225 -4.8945 1.7469 -4.3217 0.5833 -3.0450z"/>
 </g>
-<g transform="translate(41.2468, 5.5150)">
+<g transform="translate(41.2468, 5.7280)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 0.6100 9.4549 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(41.2468, 6.3250)">
+<g transform="translate(41.2468, 6.5380)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 0.6100 9.4549 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(67.2441, 5.3250)">
+<g transform="translate(67.2441, 5.5380)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -2.5450C1.9916 -3.7338 5.5558 -3.7338 6.8954 -2.5450L6.8954 -2.5450C5.5558 -3.6138 1.9916 -3.6138 0.6521 -2.5450z"/>
 </g>
-<g transform="translate(55.0076, 5.5150)">
+<g transform="translate(55.0076, 5.7280)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.2049 -0.2000 9.2049 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(55.0076, 6.3250)">
+<g transform="translate(55.0076, 6.5380)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.2049 -0.2000 9.2049 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(67.2441, 6.5150)">
+<g transform="translate(67.2441, 6.7280)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 -0.3900 9.4549 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(67.2441, 7.3250)">
+<g transform="translate(67.2441, 7.5380)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.4549 -0.3900 9.4549 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(85.7978, 6.6335)">
+<g transform="translate(86.8328, 5.5380)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7158 -4.0450C2.9422 -5.3040 11.4367 -4.0455 13.2023 -2.1950L13.2023 -2.1950C11.4191 -3.9268 2.9246 -5.1853 0.7158 -4.0450z"/>
+</g>
+<g transform="translate(85.7978, 6.8465)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.5085 1.1250 -0.1085 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(80.5806, 8.8250)">
+<g transform="translate(80.5806, 9.0380)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.3422 -1.8900 6.3422 -1.4900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(79.1306, 5.3250)">
+<g transform="translate(79.1306, 5.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(86.8328, 2.3250)">
+<g transform="translate(86.8328, 2.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(87.0239, 1.2800)">
+<g transform="translate(87.0239, 1.1248)">
 <path transform="scale(0.0022, -0.0022)" d="M148 501c10 0 41 -15 72 -15c32 0 63 15 76 15c15 0 26 -11 26 -21c0 -4 -1 -7 -4 -10l-264 -291h134v4c0 60 50 41 75 85c7 11 8 24 14 36c3 7 10 10 17 10c11 0 24 -8 24 -25v-110h70c18 0 27 -14 27 -27s-9 -27 -27 -27h-70c2 -45 36 -82 80 -82c14 0 22 -10 22 -21
 s-8 -22 -22 -22c-49 0 -96 14 -145 14s-97 -14 -146 -14c-14 0 -21 11 -21 22s7 21 21 21c44 0 79 37 81 82h-134c-43 0 -57 25 -57 42c0 5 1 10 3 12c73 81 123 182 123 291c0 17 11 31 25 31z" fill="currentColor"/>
 </g>
-<g transform="translate(86.8978, 5.3250)">
+<g transform="translate(86.8978, 5.5380)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="4.6411" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(89.9544, 2.8250)">
+<g transform="translate(89.9544, 3.0380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(90.0194, 5.3250)">
+<g transform="translate(90.0194, 5.5380)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3207" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(93.0760, 3.3250)">
+<g transform="translate(93.0760, 3.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(93.1410, 5.3250)">
+<g transform="translate(93.3760, 9.4941)">
+<text font-family="serif" font-style="italic" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>cre</tspan>
+</text>
+</g>
+<g transform="translate(93.1410, 5.5380)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.1495" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(96.1977, 3.8250)">
+<g transform="translate(96.1977, 4.0380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(96.2627, 5.3250)">
+<g transform="translate(96.2627, 5.5380)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="2.9783" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(16.7649, 5.3250)">
+<g transform="translate(99.3193, 4.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(16.8299, 5.3250)">
+<g transform="translate(16.7649, 5.5380)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(16.8299, 5.5380)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.8053" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(19.8865, 5.3250)">
+<g transform="translate(19.8865, 5.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(21.1257, 5.3250)">
+<g transform="translate(21.1257, 5.5380)">
 <rect x="-0.0650" y="-2.9928" width="0.1300" height="2.8067" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(22.7582, 6.3250)">
+<g transform="translate(22.7582, 6.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(23.9974, 5.3250)">
+<g transform="translate(23.9974, 5.5380)">
 <rect x="-0.0650" y="-2.6735" width="0.1300" height="3.4874" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(25.8798, 6.3250)">
+<g transform="translate(25.8798, 6.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(27.1190, 5.3250)">
+<g transform="translate(27.1190, 5.5380)">
 <rect x="-0.0650" y="-2.3265" width="0.1300" height="3.1404" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(55.0726, 5.3250)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(28.7514, 7.3250)">
+<g transform="translate(28.7514, 7.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(29.9906, 5.3250)">
+<g transform="translate(29.9906, 5.5380)">
 <rect x="-0.0650" y="-2.0072" width="0.1300" height="3.8211" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 2.8250)">
+<g transform="translate(7.9000, 3.0380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 4.3250)">
+<g transform="translate(0.8000, 4.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 4.3250)">
+<g transform="translate(4.3000, 4.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(7.9650, 5.3250)">
+<g transform="translate(7.9650, 5.5380)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="4.1325" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 2.2750)">
+<g transform="translate(-1.1267, 2.4880)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>4</tspan>
 </text>
 </g>
-<g transform="translate(10.7716, 3.8250)">
+<g transform="translate(55.0726, 5.5380)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(10.7716, 4.0380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(10.8366, 5.3250)">
+<g transform="translate(10.8366, 5.5380)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.5124" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(13.8933, 3.8250)">
+<g transform="translate(13.8933, 4.0380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(13.9583, 5.3250)">
+<g transform="translate(13.9583, 5.5380)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.9254" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(41.2468, 2.3250)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(41.3118, 5.3250)">
+<g transform="translate(41.3118, 5.5380)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8194" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(44.3685, 2.8250)">
+<g transform="translate(31.8730, 7.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(44.4335, 5.3250)">
+<g transform="translate(44.4335, 5.5380)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.5857" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(47.4901, 3.3250)">
+<g transform="translate(47.4901, 3.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(47.5551, 5.3250)">
+<g transform="translate(47.5551, 5.5380)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.3520" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(50.6117, 3.8250)">
+<g transform="translate(44.3685, 3.0380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(50.6767, 5.3250)">
+<g transform="translate(50.6117, 4.0380)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(50.6767, 5.5380)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1183" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(55.0076, 3.3250)">
+<g transform="translate(55.0076, 3.5380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(55.2499, 1.6567)">
+<g transform="translate(55.2499, 1.8697)">
 <path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
 c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
 </g>
-<g transform="translate(31.9380, 5.3250)">
-<rect x="-0.0650" y="2.1861" width="0.1300" height="2.9797" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(38.1252, 2.8250)">
+<g transform="translate(38.1252, 3.0380)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(38.7773, 2.0800)">
+<g transform="translate(37.0531, 10.5335)">
+<g>
+<path transform="scale(0.0040, -0.0040)" d="M-43 140c0 14 58 159 151 159c22 0 36 -20 41 -45c22 26 51 45 81 45c23 0 38 -21 44 -46c22 27 51 46 80 46c33 0 59 -35 59 -69c0 -5 -1 -10 -2 -15l-35 -149c0 -2 -1 -4 -1 -5c0 -5 2 -8 7 -8c21 0 48 37 61 37c6 0 11 -4 11 -10c0 -11 -77 -87 -138 -87
+c-20 0 -32 13 -32 32c0 4 0 7 1 11l39 165c1 5 2 9 2 14c0 10 -4 18 -14 18c-16 0 -33 -16 -39 -32l-53 -183c-3 -10 -12 -18 -22 -18h-41c-10 0 -16 8 -13 18l52 183c2 6 3 11 3 16c0 9 -4 16 -13 16c-15 0 -34 -14 -41 -33l-62 -182c-3 -10 -14 -18 -24 -18h-41
+c-10 0 -15 8 -12 18l63 183c2 5 2 10 2 15c0 10 -3 17 -13 17c-29 0 -54 -53 -66 -87c-4 -11 -15 -17 -23 -17c-7 0 -12 4 -12 11z" fill="currentColor"/>
+
+<path transform="translate(1.9803, 0.0000) scale(0.0040, -0.0040)" d="M161 32c78 0 97 176 97 178c0 18 -7 33 -25 33c-61 0 -102 -124 -102 -173c0 -22 8 -38 30 -38zM-53 141c0 2 51 151 134 151c35 0 59 -21 66 -52c29 31 67 52 103 52c69 0 107 -49 107 -114c0 -118 -105 -186 -159 -186c-53 0 -70 20 -84 20c-7 0 -14 -3 -16 -9l-29 -86
+c-1 -2 -1 -5 -1 -7c0 -37 57 -18 57 -42c0 -7 -4 -14 -13 -14c-3 0 -50 5 -116 5s-112 -5 -115 -5c-9 0 -14 7 -14 14c0 31 87 -1 102 41l102 300c2 7 4 14 4 20c0 8 -2 14 -11 14c-33 0 -63 -60 -79 -97c-5 -12 -15 -17 -24 -17c-8 0 -14 4 -14 12z" fill="currentColor"/>
+</g>
+</g>
+<g transform="translate(38.7773, 2.2930)">
 <path transform="scale(0.0040, -0.0040)" d="M128 508c2 7 9 12 17 12c10 0 18 -7 18 -17c0 -2 -1 -4 -1 -6l-145 -485c-2 -7 -9 -12 -17 -12s-15 5 -17 12l-145 485v6c0 10 7 17 17 17c8 0 15 -5 17 -12l88 -295l40 -164l40 164z" fill="currentColor"/>
 </g>
-<g transform="translate(38.1902, 5.3250)">
+<g transform="translate(38.1902, 5.5380)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="5.1481" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(31.8730, 7.3250)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(33.6273, 6.8250)">
+<g transform="translate(33.6273, 7.0380)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(32.5252, 3.0250)">
+<g transform="translate(41.2468, 2.5380)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(32.5252, 3.2380)">
 <path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 17.1256)">
+<g transform="translate(31.9380, 5.5380)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.9797" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 17.4881)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
 </g>
-<g transform="translate(0.0000, 16.1256)">
+<g transform="translate(0.0000, 16.4881)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
 </g>
-<g transform="translate(0.0000, 15.1256)">
+<g transform="translate(0.0000, 15.4881)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
 </g>
-<g transform="translate(0.0000, 14.1256)">
+<g transform="translate(0.0000, 14.4881)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
 </g>
-<g transform="translate(0.0000, 13.1256)">
+<g transform="translate(0.0000, 13.4881)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="44.6620" y2="0"/>
 </g>
-<g transform="translate(0.0000, 18.1256)">
+<g transform="translate(0.0000, 18.4881)">
 <rect x="26.6077" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 18.1256)">
+<g transform="translate(0.0000, 18.4881)">
 <rect x="24.1034" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(44.5220, 15.1256)">
+<g transform="translate(44.5220, 15.4881)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(37.0094, 13.6256)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(31.5899, 16.1256)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(32.8291, 15.1256)">
+<g transform="translate(32.8291, 15.4881)">
 <rect x="-0.0650" y="-1.9838" width="0.1300" height="2.7977" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(34.2552, 14.6256)">
+<g transform="translate(34.2552, 14.9881)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(34.3202, 15.1256)">
+<g transform="translate(34.2552, 19.6534)">
+<text font-family="serif" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>–</tspan>
+</text>
+</g>
+<g transform="translate(34.3202, 15.4881)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1174" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(28.1729, 15.1256)">
-<rect x="-0.0650" y="-0.8262" width="0.1300" height="3.6401" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(28.6879, 17.6256)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(26.9337, 18.1256)">
+<g transform="translate(37.0094, 13.9881)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(25.6687, 15.1256)">
-<rect x="-0.0650" y="-1.0091" width="0.1300" height="3.8230" ry="0.0400" fill="currentColor"/>
+<g transform="translate(38.0094, 20.7318)">
+<text font-family="serif" font-style="italic" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>do</tspan>
+</text>
 </g>
-<g transform="translate(24.4295, 18.1256)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(34.2552, 17.1256)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.0100 8.1026 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(34.2552, 17.9356)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.0100 8.1026 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(28.1079, 14.3156)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="4.7462 -1.3900 4.7462 -0.9900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(31.7291, 14.2253)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.4897 1.1250 -0.0897 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(18.5911, 13.1256)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(18.5911, 13.9356)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(7.9000, 17.1256)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(7.9000, 17.9356)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(37.0744, 15.1256)">
+<g transform="translate(37.0744, 15.4881)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.8434" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.3328, 15.1256)">
+<g transform="translate(24.4295, 18.4881)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(28.6879, 17.9881)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(34.2552, 17.4881)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.0100 8.1026 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(34.2552, 18.2981)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.1026 -1.0100 8.1026 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(25.6295, 19.1855)">
+<text font-family="serif" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>–</tspan>
+</text>
+</g>
+<g transform="translate(25.6687, 15.4881)">
+<rect x="-0.0650" y="-1.0091" width="0.1300" height="3.8230" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(26.9337, 18.4881)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(32.2420, 13.0642)">
+<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
+</g>
+<g transform="translate(28.1729, 15.4881)">
+<rect x="-0.0650" y="-0.8262" width="0.1300" height="3.6401" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(31.5899, 16.4881)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 15.4881)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -2.5450C1.6921 -2.8556 2.7332 -2.3937 3.0826 -1.5450L3.0826 -1.5450C2.6846 -2.2841 1.6434 -2.7459 0.8284 -2.5450z"/>
+</g>
+<g transform="translate(12.6584, 15.4881)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8755 -1.5450C1.8179 -1.7574 2.8721 -1.1261 3.1297 -0.1950L3.1297 -0.1950C2.8104 -1.0231 1.7562 -1.6545 0.8755 -1.5450z"/>
+</g>
+<g transform="translate(17.4169, 15.4881)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4987 2.1950C0.8879 3.0071 1.9244 3.3980 2.7529 3.0450L2.7529 3.0450C1.9667 3.2857 0.9303 2.8948 0.4987 2.1950z"/>
+</g>
+<g transform="translate(7.9000, 17.4881)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(7.9000, 18.2981)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.9900 7.1026 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(22.1753, 15.4881)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4758 3.0450C0.8252 3.8937 1.8663 4.3556 2.7300 4.0450L2.7300 4.0450C1.9150 4.2459 0.8739 3.7841 0.4758 3.0450z"/>
+</g>
+<g transform="translate(18.5911, 13.4881)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(18.5911, 14.2981)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.1026 0.8000 7.1026 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(34.2552, 15.4881)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5721 -1.5450C1.8834 -3.1629 6.7770 -4.0790 8.5847 -3.0450L8.5847 -3.0450C6.7991 -3.9611 1.9055 -3.0450 0.5721 -1.5450z"/>
+</g>
+<g transform="translate(28.1079, 14.6781)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="4.7462 -1.3900 4.7462 -0.9900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(31.7291, 14.5877)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.4897 1.1250 -0.0897 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(42.3328, 15.4881)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.8204" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.2678, 13.1256)">
+<g transform="translate(42.2678, 13.4881)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(39.5786, 15.1256)">
+<g transform="translate(39.5786, 15.4881)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.0943" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(39.5136, 14.1256)">
+<g transform="translate(39.5136, 14.4881)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.7234, 15.1256)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.9275" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(10.2192, 15.1256)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.5103" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(10.1542, 14.6256)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(7.9650, 15.1256)">
+<g transform="translate(7.9650, 15.4881)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1347" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 13.6256)">
+<g transform="translate(10.1542, 14.9881)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.6584, 14.6256)">
+<g transform="translate(10.2192, 15.4881)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.5103" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 19.8539)">
+<text font-family="serif" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>–</tspan>
+</text>
+</g>
+<g transform="translate(12.6584, 14.9881)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 12.0509)">
+<g transform="translate(12.7234, 15.4881)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.9275" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(0.8000, 14.4881)">
+<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
+c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
+</g>
+<g transform="translate(4.3000, 14.4881)">
+<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
+v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+</g>
+<g transform="translate(-1.1267, 12.4134)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>6</tspan>
 </text>
 </g>
-<g transform="translate(4.3000, 14.1256)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(0.8000, 14.1256)">
-<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
-c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
-</g>
-<g transform="translate(18.6561, 15.1256)">
-<rect x="-0.0650" y="-1.9909" width="0.1300" height="2.8048" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(23.4145, 15.1256)">
-<rect x="-0.0650" y="-1.3247" width="0.1300" height="3.1386" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(22.1753, 17.1256)">
+<g transform="translate(7.9000, 13.9881)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(20.9103, 15.1256)">
+<g transform="translate(22.1753, 17.4881)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(20.9103, 15.4881)">
 <rect x="-0.0650" y="-1.6753" width="0.1300" height="3.4892" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(19.6711, 17.1256)">
+<g transform="translate(19.6711, 17.4881)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(17.4169, 16.1256)">
+<g transform="translate(18.6561, 15.4881)">
+<rect x="-0.0650" y="-1.9909" width="0.1300" height="2.8048" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(17.4169, 16.4881)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(14.9776, 15.1256)">
+<g transform="translate(23.4145, 15.4881)">
+<rect x="-0.0650" y="-1.3247" width="0.1300" height="3.1386" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(14.9776, 15.4881)">
 <rect x="-0.0650" y="1.1861" width="0.1300" height="2.8031" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(14.9126, 16.1256)">
+<g transform="translate(14.4126, 21.2502)">
+<text font-family="serif" font-style="italic" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>scen</tspan>
+</text>
+</g>
+<g transform="translate(14.9126, 16.4881)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 </svg>

--- a/scores/allemande/mm-6-8.svg
+++ b/scores/allemande/mm-6-8.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="28.73mm" viewBox="-1.1267 0.0000 103.5567 16.3506">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="31.46mm" viewBox="-1.1267 0.0000 103.5567 17.9039">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
@@ -31,10 +31,10 @@ tspan { white-space: pre; }
 <g transform="translate(0.0000, 7.5000)">
 <rect x="27.6643" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(102.2399, 4.5000)">
+<g transform="translate(52.4500, 4.5000)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(52.4500, 4.5000)">
+<g transform="translate(102.2399, 4.5000)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
 <g transform="translate(72.6626, 4.5000)">
@@ -51,6 +51,9 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="4.7003" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(69.8347, 1.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(81.8863, 1.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(75.6105, 3.5000)">
@@ -95,17 +98,20 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(65.9718, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(96.2008, 6.0000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(96.2658, 4.5000)">
-<rect x="-0.0650" y="1.6861" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
-</g>
 <g transform="translate(99.4637, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(99.5287, 4.5000)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8001 -2.5450C1.7678 -2.9671 3.0896 -2.4887 3.5630 -1.5450L3.5630 -1.5450C3.0488 -2.3759 1.7269 -2.8543 0.8001 -2.5450z"/>
+</g>
+<g transform="translate(13.6758, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8430 -1.5450C1.8871 -1.8714 3.2217 -1.2193 3.6059 -0.1950L3.6059 -0.1950C3.1690 -1.1115 1.8344 -1.7636 0.8430 -1.5450z"/>
+</g>
+<g transform="translate(19.4516, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5243 2.1950C1.0361 3.1030 2.3535 3.5082 3.2872 3.0450L3.2872 3.0450C2.3888 3.3935 1.0714 2.9883 0.5243 2.1950z"/>
 </g>
 <g transform="translate(7.9000, 6.5000)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.9900 8.6287 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
@@ -113,11 +119,17 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(7.9000, 7.3100)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.9900 8.6287 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
+<g transform="translate(25.2274, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5042 3.0450C0.9775 3.9887 2.2994 4.4671 3.2671 4.0450L3.2671 4.0450C2.3402 4.3543 1.0183 3.8759 0.5042 3.0450z"/>
+</g>
 <g transform="translate(20.6258, 2.5000)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.8000 8.6287 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
 <g transform="translate(20.6258, 3.3100)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.8000 8.6287 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(40.1484, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5846 -1.5450C2.0905 -3.2416 8.1694 -4.1975 10.1233 -3.0450L10.1233 -3.0450C8.1880 -4.0789 2.1091 -3.1230 0.5846 -1.5450z"/>
 </g>
 <g transform="translate(32.1775, 3.6900)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.0611 -1.3900 6.0611 -0.9900 0.0400 0.2000 0.0400 -0.2000"/>
@@ -149,12 +161,6 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(78.6234, 6.5000)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1287 -0.2000 9.1287 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(81.8863, 1.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(81.9513, 4.5000)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
-</g>
 <g transform="translate(84.6492, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
@@ -166,6 +172,9 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 </g>
 <g transform="translate(87.7271, 4.5000)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(81.9513, 4.5000)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(90.6750, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -179,11 +188,22 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(93.5029, 4.5000)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
+<g transform="translate(96.2008, 6.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(96.2658, 4.5000)">
+<rect x="-0.0650" y="1.6861" width="0.1300" height="2.1239" ry="0.0400" fill="currentColor"/>
+</g>
 <g transform="translate(23.4537, 4.5000)">
 <rect x="-0.0650" y="-1.6738" width="0.1300" height="3.4877" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(16.4387, 5.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(15.9387, 10.2621)">
+<text font-family="serif" font-style="italic" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>scen</tspan>
+</text>
 </g>
 <g transform="translate(16.5037, 4.5000)">
 <rect x="-0.0650" y="1.1861" width="0.1300" height="2.8050" ry="0.0400" fill="currentColor"/>
@@ -203,14 +223,27 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(26.4667, 4.5000)">
 <rect x="-0.0650" y="-1.3262" width="0.1300" height="3.1401" ry="0.0400" fill="currentColor"/>
 </g>
+<g transform="translate(53.9851, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1252" ry="0.0400" fill="currentColor"/>
+</g>
 <g transform="translate(27.9903, 7.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(29.1903, 8.2471)">
+<text font-family="serif" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>–</tspan>
+</text>
 </g>
 <g transform="translate(29.2296, 4.5000)">
 <rect x="-0.0650" y="-1.0075" width="0.1300" height="3.8214" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(7.9000, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(7.9000, 8.8305)">
+<text font-family="serif" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>–</tspan>
+</text>
 </g>
 <g transform="translate(0.8000, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
@@ -228,9 +261,6 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <tspan>6</tspan>
 </text>
 </g>
-<g transform="translate(53.9851, 4.5000)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1252" ry="0.0400" fill="currentColor"/>
-</g>
 <g transform="translate(10.6629, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
@@ -243,193 +273,206 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(13.7408, 4.5000)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.9257" ry="0.0400" fill="currentColor"/>
 </g>
+<g transform="translate(40.1484, 4.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(49.7521, 4.5000)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.8193" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(49.6871, 2.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(40.1484, 8.6653)">
+<text font-family="serif" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>–</tspan>
+</text>
+</g>
 <g transform="translate(40.2134, 4.5000)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1184" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(43.4113, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
+<g transform="translate(44.4113, 9.7626)">
+<text font-family="serif" font-style="italic" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>do</tspan>
+</text>
+</g>
 <g transform="translate(43.4763, 4.5000)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.8451" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(46.4242, 3.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(46.4892, 4.5000)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.0927" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(49.6871, 2.5000)">
+<g transform="translate(46.4242, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(49.7521, 4.5000)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.8193" ry="0.0400" fill="currentColor"/>
+<g transform="translate(31.0033, 7.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(32.7575, 7.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
 <g transform="translate(53.9201, 3.0000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(40.1484, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(32.2425, 4.5000)">
 <rect x="-0.0650" y="-0.8227" width="0.1300" height="3.6366" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(36.9744, 5.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
 <g transform="translate(38.2136, 4.5000)">
 <rect x="-0.0650" y="-1.9873" width="0.1300" height="2.8012" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(32.7575, 7.0000)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<g transform="translate(37.6265, 2.0727)">
+<path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
 </g>
-<g transform="translate(31.0033, 7.5000)">
+<g transform="translate(36.9744, 5.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 15.1106)">
+<g transform="translate(0.0000, 16.6639)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 14.1106)">
+<g transform="translate(0.0000, 15.6639)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 13.1106)">
+<g transform="translate(0.0000, 14.6639)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 12.1106)">
+<g transform="translate(0.0000, 13.6639)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 11.1106)">
+<g transform="translate(0.0000, 12.6639)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 10.1106)">
+<g transform="translate(0.0000, 11.6639)">
 <rect x="40.8287" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(45.6765, 13.1106)">
+<g transform="translate(45.6765, 14.6639)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(33.6421, 11.6106)">
+<g transform="translate(33.6421, 13.1639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(33.7071, 13.1106)">
+<g transform="translate(33.7071, 14.6639)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1255" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(36.1463, 11.1106)">
+<g transform="translate(36.1463, 12.6639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(36.2113, 13.1106)">
+<g transform="translate(36.2113, 14.6639)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(31.2029, 13.1106)">
+<g transform="translate(31.2029, 14.6639)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6878" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(31.1379, 12.1106)">
+<g transform="translate(31.1379, 13.6639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.4487, 13.1106)">
+<g transform="translate(28.4487, 14.6639)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.7562" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(28.3837, 13.1106)">
+<g transform="translate(28.3837, 14.6639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(26.1945, 13.1106)">
+<g transform="translate(26.1945, 14.6639)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.8123" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(26.1295, 12.1106)">
+<g transform="translate(26.1295, 13.6639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(36.1463, 13.3006)">
+<g transform="translate(36.1463, 14.8539)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(36.1463, 14.1106)">
+<g transform="translate(36.1463, 15.6639)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(26.1295, 15.3006)">
+<g transform="translate(26.1295, 16.8539)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.3900 7.6026 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(26.1295, 16.1106)">
+<g transform="translate(26.1295, 17.6639)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.3900 7.6026 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(16.3626, 15.1106)">
+<g transform="translate(16.3626, 16.6639)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(16.3626, 15.9206)">
+<g transform="translate(16.3626, 17.4739)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(11.3542, 15.1106)">
+<g transform="translate(11.3542, 16.6639)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="2.5942 -0.2000 2.5942 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(7.9000, 15.9206)">
+<g transform="translate(7.9000, 17.4739)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.0484 -0.2000 6.0484 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(38.6506, 10.6106)">
+<g transform="translate(38.6506, 12.1639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(43.4740, 13.1106)">
+<g transform="translate(43.4740, 14.6639)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(43.4090, 11.1106)">
+<g transform="translate(43.4090, 12.6639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(41.2198, 13.1106)">
+<g transform="translate(41.2198, 14.6639)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(41.1548, 10.1106)">
+<g transform="translate(41.1548, 11.6639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(38.7156, 13.1106)">
+<g transform="translate(38.7156, 14.6639)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(16.3626, 12.1106)">
+<g transform="translate(16.3626, 13.6639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 10.0359)">
+<g transform="translate(-1.1267, 11.5892)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>8</tspan>
 </text>
 </g>
-<g transform="translate(13.9234, 13.1106)">
+<g transform="translate(13.9234, 14.6639)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(13.8584, 12.6106)">
+<g transform="translate(13.8584, 14.1639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 12.1106)">
+<g transform="translate(4.3000, 13.6639)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(11.4192, 13.1106)">
+<g transform="translate(11.4192, 14.6639)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(11.3542, 13.1106)">
+<g transform="translate(11.3542, 14.6639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(7.9650, 13.1106)">
+<g transform="translate(7.9650, 14.6639)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 12.1106)">
+<g transform="translate(7.9000, 13.6639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(16.4276, 13.1106)">
+<g transform="translate(16.4276, 14.6639)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(23.6903, 13.1106)">
+<g transform="translate(23.6903, 14.6639)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(23.6253, 12.6106)">
+<g transform="translate(23.6253, 14.1639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(21.4361, 13.1106)">
+<g transform="translate(21.4361, 14.6639)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(21.3711, 11.6106)">
+<g transform="translate(21.3711, 13.1639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.6819, 13.1106)">
+<g transform="translate(18.6819, 14.6639)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(18.6169, 13.1106)">
+<g transform="translate(18.6169, 14.6639)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 12.1106)">
+<g transform="translate(0.8000, 13.6639)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>

--- a/tools/scores/allemande.ly
+++ b/tools/scores/allemande.ly
@@ -17,10 +17,10 @@ allemande = \absolute {
     <b d g,>4 << { b16\repeatTie a16-4( g16 fis16) } \\ { d16\repeatTie s8. } >> g16 d16( e16 fis16 g16 a16 b16 c'16) |
     d'16( b16 g16 fis16 g16 e16 d16 c16) \stemUp b,16( c16 d16 e16 \stemNeutral fis16 g16 a16-1 b16) |
     c'16( a16 g16 fis16 g16 e16 fis16 g16) a,16 d16( fis16 g16 a16-1 b16 c'16 a16) |
-    b16( g16) g16( d16) d16( b,16) b,16( g,16) g,8.\downbow b16\upbow c'16( b16 a16) g16 |
+    b16( g16) g16( d16) d16( b,16) b,16( g,16) g,8.\downbow b16\upbow\mp c'16( b16 a16) g16 |
     \barNumberCheck #5
-    a16-1( b16 c'16) a16 g16-2( fis16 g16) a16 dis8.\trill c'16-4 b16 a16 g16 fis16 |
-    g16 e16 e16 b,16 b,16 g,16 g,16 e,16 e,8. b,16 e16 g16 fis16 a16 |
+    a16-1( b16 c'16) a16 g16-2( fis16 g16) a16 dis8.\trill c'16-4( b16 \once \override TextScript.extra-offset = #'(0.3 . 0) a16_\markup \italic "cre" g16 \once \override TextScript.extra-offset = #'(2 . 0) fis16)_\markup "–" |
+    g16(_\markup "–" e16) e16( \once \override TextScript.extra-offset = #'(-0.5 . 0) b,16)_\markup \italic "scen" b,16( g,16) g,16( \once \override TextScript.extra-offset = #'(1.2 . 1.6) e,16)_\markup "–" e,8. b,16\downbow e16(_\markup "–" \once \override TextScript.extra-offset = #'(1 . 0) g16_\markup \italic "do" fis16 a16) |
     g16 fis16 e16 fis16 g16 cis'16 g16 fis16 g16 cis'16 e16 fis16 g16 e16 a,16 g16 |
     fis8 d16 e16 fis16 d16 g16 e16 fis16 d16 fis16 g16 a16 b16 c'16 a16 |
     b16 d16 g,16 d16 b16 g16 a16 fis16 g16 e16 g16 a16 b16 cis'16 d'16 b16 |


### PR DESCRIPTION
## Summary
- m.4: restore `mp` under the 10th note (b).
- m.5: slur the last 5 notes.
- m.6: slur in pairs (1-2, 3-4, 5-6, 7-8) plus the last 4; down-bow on note 10.
- Spelled-out crescendo "cre – ... – scen – – do" placed across m.5's last quartet through m.6.

## Test plan
- [x] `build_scores.py` clean; only `mm-1-4`, `mm-4-6`, `mm-6-8` changed (the loops containing m.4 / m.5 / m.6).
- [x] Rendered mm. 4-6 to confirm dynamic, slurs, bowing, and the crescendo word placement.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_