### PR TITLE
Allemande m.7: mf, finger 4, slurs, staccato dots

### DIFF
--- a/scores/allemande/mm-6-8.svg
+++ b/scores/allemande/mm-6-8.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="32.25mm" viewBox="-1.1267 0.0000 103.5567 18.3533">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="32.43mm" viewBox="-1.1267 0.0000 103.5567 18.4526">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
@@ -19,6 +19,12 @@ tspan { white-space: pre; }
 <g transform="translate(0.0000, 2.5000)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
+<g transform="translate(102.2399, 4.5000)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(52.4500, 4.5000)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
 <g transform="translate(0.0000, 1.5000)">
 <rect x="81.5602" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
@@ -31,16 +37,10 @@ tspan { white-space: pre; }
 <g transform="translate(0.0000, 7.5000)">
 <rect x="27.6643" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(102.2399, 4.5000)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(52.4500, 4.5000)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+<g transform="translate(75.6755, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8126" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(75.6105, 3.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(69.8347, 1.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(72.6626, 4.5000)">
@@ -53,11 +53,8 @@ tspan { white-space: pre; }
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(69.8997, 4.5000)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.7003" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(75.6755, 4.5000)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8126" ry="0.0400" fill="currentColor"/>
+<g transform="translate(69.8347, 1.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(78.6234, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -71,26 +68,32 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(81.9513, 4.5000)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="4.8139" ry="0.0400" fill="currentColor"/>
 </g>
+<g transform="translate(84.6492, 4.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(84.7142, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
+</g>
 <g transform="translate(60.0110, 4.5000)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="2.2501" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(90.6750, 7.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.8787 -0.2000 8.8787 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(90.6750, 8.3100)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.8787 -0.2000 8.8787 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(56.9330, 3.5000)">
+<g transform="translate(59.9460, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(56.9980, 4.5000)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="2.6877" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(59.9460, 4.0000)">
+<g transform="translate(56.9330, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(69.8997, 4.5000)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="4.7003" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(62.9589, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(63.6110, 2.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M-50 0c0 28 22 50 50 50s50 -22 50 -50s-22 -50 -50 -50s-50 22 -50 50z" fill="currentColor"/>
 </g>
 <g transform="translate(63.0239, 4.5000)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8125" ry="0.0400" fill="currentColor"/>
@@ -101,17 +104,20 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(66.0368, 4.5000)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1252" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 4.5000)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8001 -2.5450C1.7678 -2.9671 3.0896 -2.4887 3.5630 -1.5450L3.5630 -1.5450C3.0488 -2.3759 1.7269 -2.8543 0.8001 -2.5450z"/>
+<g transform="translate(90.6750, 7.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.8787 -0.2000 8.8787 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(99.5287, 4.5000)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(90.6750, 8.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.8787 -0.2000 8.8787 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(19.4516, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5243 2.1950C1.0361 3.1030 2.3535 3.5082 3.2872 3.0450L3.2872 3.0450C2.3888 3.3935 1.0714 2.9883 0.5243 2.1950z"/>
 </g>
 <g transform="translate(13.6758, 4.5000)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8430 -1.5450C1.8871 -1.8714 3.2217 -1.2193 3.6059 -0.1950L3.6059 -0.1950C3.1690 -1.1115 1.8344 -1.7636 0.8430 -1.5450z"/>
 </g>
-<g transform="translate(19.4516, 4.5000)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5243 2.1950C1.0361 3.1030 2.3535 3.5082 3.2872 3.0450L3.2872 3.0450C2.3888 3.3935 1.0714 2.9883 0.5243 2.1950z"/>
+<g transform="translate(7.9000, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8001 -2.5450C1.7678 -2.9671 3.0896 -2.4887 3.5630 -1.5450L3.5630 -1.5450C3.0488 -2.3759 1.7269 -2.8543 0.8001 -2.5450z"/>
 </g>
 <g transform="translate(7.9000, 6.5000)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.9900 8.6287 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
@@ -119,41 +125,8 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(7.9000, 7.3100)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.9900 8.6287 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(25.2274, 4.5000)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5042 3.0450C0.9775 3.9887 2.2994 4.4671 3.2671 4.0450L3.2671 4.0450C2.3402 4.3543 1.0183 3.8759 0.5042 3.0450z"/>
-</g>
-<g transform="translate(20.6258, 2.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.8000 8.6287 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(20.6258, 3.3100)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.8000 8.6287 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(40.1484, 4.5000)">
-<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5846 -1.5450C2.0905 -3.2416 8.1694 -4.1975 10.1233 -3.0450L10.1233 -3.0450C8.1880 -4.0789 2.1091 -3.1230 0.5846 -1.5450z"/>
-</g>
-<g transform="translate(32.1775, 3.6900)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.0611 -1.3900 6.0611 -0.9900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(37.1136, 3.5372)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.4272 1.1250 -0.0272 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(40.1484, 6.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.6287 -1.0100 9.6287 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(40.1484, 7.3100)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.6287 -1.0100 9.6287 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(53.9201, 5.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1287 -0.0100 9.1287 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(53.9201, 6.3100)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1287 -0.0100 9.1287 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(65.9718, 5.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.7287 -0.0100 9.7287 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(65.9718, 6.3100)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.7287 -0.0100 9.7287 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(53.9201, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7233 -2.5450C2.2180 -3.4881 5.6392 -2.9204 6.7491 -1.5450L6.7491 -1.5450C5.6195 -2.8020 2.1983 -3.3697 0.7233 -2.5450z"/>
 </g>
 <g transform="translate(78.6234, 5.6900)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1287 -0.2000 9.1287 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
@@ -161,29 +134,68 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(78.6234, 6.5000)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1287 -0.2000 9.1287 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(84.6492, 4.0000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(90.6750, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8595 -2.5450C2.6116 -2.9515 5.7719 -1.2357 6.3853 0.4550L6.3853 0.4550C5.7146 -1.1303 2.5543 -2.8460 0.8595 -2.5450z"/>
 </g>
-<g transform="translate(84.7142, 4.5000)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.3139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(65.9718, 5.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.7287 -0.0100 9.7287 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(87.6621, 3.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(65.9718, 6.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.7287 -0.0100 9.7287 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(87.7271, 4.5000)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+<g transform="translate(78.6234, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4705 -2.5450C0.9350 -3.6852 2.5656 -4.4348 3.7334 -4.0450L3.7334 -4.0450C2.6157 -4.3258 0.9851 -3.5762 0.4705 -2.5450z"/>
 </g>
-<g transform="translate(90.6750, 3.0000)">
+<g transform="translate(53.9201, 5.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1287 -0.0100 9.1287 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(53.9201, 6.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1287 -0.0100 9.1287 0.3900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(65.9718, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.4947 -2.5450C1.0922 -3.7743 3.0872 -4.5489 4.3576 -4.0450L4.3576 -4.0450C3.1306 -4.4371 1.1356 -3.6624 0.4947 -2.5450z"/>
+</g>
+<g transform="translate(40.1484, 6.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.6287 -1.0100 9.6287 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(40.1484, 7.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.6287 -1.0100 9.6287 -0.6100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(32.1775, 3.6900)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.0611 -1.3900 6.0611 -0.9900 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(37.1136, 3.5372)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.4272 1.1250 -0.0272 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(40.1484, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5846 -1.5450C2.0905 -3.2416 8.1694 -4.1975 10.1233 -3.0450L10.1233 -3.0450C8.1880 -4.0789 2.1091 -3.1230 0.5846 -1.5450z"/>
+</g>
+<g transform="translate(20.6258, 2.5000)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.8000 8.6287 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(20.6258, 3.3100)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.6287 0.8000 8.6287 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(25.2274, 4.5000)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5042 3.0450C0.9775 3.9887 2.2994 4.4671 3.2671 4.0450L3.2671 4.0450C2.3402 4.3543 1.0183 3.8759 0.5042 3.0450z"/>
+</g>
+<g transform="translate(93.4379, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(90.7400, 4.5000)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(93.4379, 4.0000)">
+<g transform="translate(90.6750, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(93.5029, 4.5000)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(87.7271, 4.5000)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(87.6621, 3.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(96.2008, 6.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -194,8 +206,14 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(99.4637, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(19.4516, 5.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(100.1158, 2.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M-50 0c0 28 22 50 50 50s50 -22 50 -50s-22 -50 -50 -50s-50 22 -50 50z" fill="currentColor"/>
+</g>
+<g transform="translate(99.5287, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(20.6908, 4.5000)">
+<rect x="-0.0650" y="-1.9925" width="0.1300" height="2.8064" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(23.4537, 4.5000)">
 <rect x="-0.0650" y="-1.6738" width="0.1300" height="3.4877" ry="0.0400" fill="currentColor"/>
@@ -203,8 +221,8 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(22.2145, 6.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(20.6908, 4.5000)">
-<rect x="-0.0650" y="-1.9925" width="0.1300" height="2.8064" ry="0.0400" fill="currentColor"/>
+<g transform="translate(19.4516, 5.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(16.5037, 4.5000)">
 <rect x="-0.0650" y="1.1861" width="0.1300" height="2.8050" ry="0.0400" fill="currentColor"/>
@@ -214,16 +232,13 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <tspan>scen</tspan>
 </text>
 </g>
-<g transform="translate(16.4387, 5.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(25.2274, 6.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(26.4667, 4.5000)">
-<rect x="-0.0650" y="-1.3262" width="0.1300" height="3.1401" ry="0.0400" fill="currentColor"/>
-</g>
 <g transform="translate(27.9903, 7.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(32.7575, 7.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+</g>
+<g transform="translate(31.0033, 7.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(29.2962, 10.1500)">
@@ -231,32 +246,41 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <tspan>–</tspan>
 </text>
 </g>
-<g transform="translate(29.2296, 4.5000)">
-<rect x="-0.0650" y="-1.0075" width="0.1300" height="3.8214" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 3.0000)">
+<g transform="translate(16.4387, 5.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(26.4667, 4.5000)">
+<rect x="-0.0650" y="-1.3262" width="0.1300" height="3.1401" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(25.2274, 6.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(4.3000, 3.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
+v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+</g>
+<g transform="translate(-1.1267, 1.4253)">
+<text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
+<tspan>6</tspan>
+</text>
+</g>
+<g transform="translate(7.9650, 4.5000)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1328" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(0.8000, 3.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
+c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
 <g transform="translate(8.0058, 10.1500)">
 <text font-family="serif" font-size="2.2000" text-anchor="start" fill="currentColor">
 <tspan>–</tspan>
 </text>
 </g>
-<g transform="translate(0.8000, 3.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
-c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
+<g transform="translate(7.9000, 3.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 3.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(7.9650, 4.5000)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1328" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(-1.1267, 1.4253)">
-<text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
-<tspan>6</tspan>
-</text>
+<g transform="translate(29.2296, 4.5000)">
+<rect x="-0.0650" y="-1.0075" width="0.1300" height="3.8214" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(10.6629, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
@@ -270,8 +294,11 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(13.7408, 4.5000)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.9257" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(40.2134, 4.5000)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1184" ry="0.0400" fill="currentColor"/>
+<g transform="translate(49.7521, 4.5000)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.8193" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(43.4113, 3.0000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(43.6977, 10.1500)">
 <text font-family="serif" font-style="italic" font-size="2.2000" text-anchor="start" fill="currentColor">
@@ -281,43 +308,37 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(43.4763, 4.5000)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.8451" ry="0.0400" fill="currentColor"/>
 </g>
+<g transform="translate(32.2425, 4.5000)">
+<rect x="-0.0650" y="-0.8227" width="0.1300" height="3.6366" ry="0.0400" fill="currentColor"/>
+</g>
 <g transform="translate(46.4242, 3.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(46.4892, 4.5000)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.0927" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(43.4113, 3.0000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
 <g transform="translate(49.6871, 2.5000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(49.7521, 4.5000)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.8193" ry="0.0400" fill="currentColor"/>
 </g>
 <g transform="translate(53.9201, 3.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
+<g transform="translate(53.1212, 10.1500)">
+<g>
+<path transform="scale(0.0040, -0.0040)" d="M-43 140c0 14 58 159 151 159c22 0 36 -20 41 -45c22 26 51 45 81 45c23 0 38 -21 44 -46c22 27 51 46 80 46c33 0 59 -35 59 -69c0 -5 -1 -10 -2 -15l-35 -149c0 -2 -1 -4 -1 -5c0 -5 2 -8 7 -8c21 0 48 37 61 37c6 0 11 -4 11 -10c0 -11 -77 -87 -138 -87
+c-20 0 -32 13 -32 32c0 4 0 7 1 11l39 165c1 5 2 9 2 14c0 10 -4 18 -14 18c-16 0 -33 -16 -39 -32l-53 -183c-3 -10 -12 -18 -22 -18h-41c-10 0 -16 8 -13 18l52 183c2 6 3 11 3 16c0 9 -4 16 -13 16c-15 0 -34 -14 -41 -33l-62 -182c-3 -10 -14 -18 -24 -18h-41
+c-10 0 -15 8 -12 18l63 183c2 5 2 10 2 15c0 10 -3 17 -13 17c-29 0 -54 -53 -66 -87c-4 -11 -15 -17 -23 -17c-7 0 -12 4 -12 11z" fill="currentColor"/>
+
+<path transform="translate(1.6389, 0.0000) scale(0.0040, -0.0040)" d="M253 245l-50 -163c-30 -99 -121 -255 -218 -255c-45 0 -87 27 -87 69c0 39 17 77 52 77c24 0 44 -20 44 -44c0 -30 -38 -24 -38 -54c0 -10 11 -11 23 -11h6c48 0 61 58 73 108l68 273h-49c-11 0 -19 8 -19 19s8 19 19 19h60c32 96 118 191 213 191c45 0 87 -27 87 -69
+c0 -39 -17 -77 -52 -77c-24 0 -44 19 -44 43c0 30 38 25 38 55c0 10 -10 11 -22 11h-7c-62 0 -70 -88 -86 -154h55c11 0 19 -8 19 -19s-8 -19 -19 -19h-66z" fill="currentColor"/>
+</g>
+</g>
+<g transform="translate(54.1113, 1.5710)">
+<path transform="scale(0.0022, -0.0022)" d="M148 501c10 0 41 -15 72 -15c32 0 63 15 76 15c15 0 26 -11 26 -21c0 -4 -1 -7 -4 -10l-264 -291h134v4c0 60 50 41 75 85c7 11 8 24 14 36c3 7 10 10 17 10c11 0 24 -8 24 -25v-110h70c18 0 27 -14 27 -27s-9 -27 -27 -27h-70c2 -45 36 -82 80 -82c14 0 22 -10 22 -21
+s-8 -22 -22 -22c-49 0 -96 14 -145 14s-97 -14 -146 -14c-14 0 -21 11 -21 22s7 21 21 21c44 0 79 37 81 82h-134c-43 0 -57 25 -57 42c0 5 1 10 3 12c73 81 123 182 123 291c0 17 11 31 25 31z" fill="currentColor"/>
+</g>
 <g transform="translate(53.9851, 4.5000)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1252" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(40.2542, 10.1500)">
-<text font-family="serif" font-size="2.2000" text-anchor="start" fill="currentColor">
-<tspan>–</tspan>
-</text>
-</g>
-<g transform="translate(31.0033, 7.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(32.7575, 7.0000)">
-<path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
-</g>
-<g transform="translate(32.2425, 4.5000)">
-<rect x="-0.0650" y="-0.8227" width="0.1300" height="3.6366" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(36.9744, 5.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 <g transform="translate(37.6265, 2.0727)">
 <path transform="scale(0.0040, -0.0040)" d="M-178 333h356c6 0 10 -4 10 -10v-308c0 -8 -7 -15 -15 -15s-16 7 -16 15v185h-314v-185c0 -8 -7 -15 -15 -15s-16 7 -16 15v308c0 6 4 10 10 10z" fill="currentColor"/>
@@ -325,154 +346,165 @@ v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-1
 <g transform="translate(38.2136, 4.5000)">
 <rect x="-0.0650" y="-1.9873" width="0.1300" height="2.8012" ry="0.0400" fill="currentColor"/>
 </g>
+<g transform="translate(36.9744, 5.5000)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
 <g transform="translate(40.1484, 4.0000)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 17.1133)">
+<g transform="translate(40.2134, 4.5000)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1184" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(40.2542, 10.1500)">
+<text font-family="serif" font-size="2.2000" text-anchor="start" fill="currentColor">
+<tspan>–</tspan>
+</text>
+</g>
+<g transform="translate(0.0000, 17.2126)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 16.1133)">
+<g transform="translate(0.0000, 16.2126)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 15.1133)">
+<g transform="translate(0.0000, 15.2126)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 14.1133)">
+<g transform="translate(0.0000, 14.2126)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 13.1133)">
+<g transform="translate(0.0000, 13.2126)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 12.1133)">
+<g transform="translate(0.0000, 12.2126)">
 <rect x="40.8287" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(45.6765, 15.1133)">
+<g transform="translate(45.6765, 15.2126)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(33.6421, 13.6133)">
+<g transform="translate(33.6421, 13.7126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(33.7071, 15.1133)">
+<g transform="translate(33.7071, 15.2126)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1255" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(36.1463, 13.1133)">
+<g transform="translate(36.1463, 13.2126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(36.2113, 15.1133)">
+<g transform="translate(36.2113, 15.2126)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(31.2029, 15.1133)">
+<g transform="translate(31.2029, 15.2126)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6878" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(31.1379, 14.1133)">
+<g transform="translate(31.1379, 14.2126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.4487, 15.1133)">
+<g transform="translate(28.4487, 15.2126)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.7562" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(28.3837, 15.1133)">
+<g transform="translate(28.3837, 15.2126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(26.1945, 15.1133)">
+<g transform="translate(26.1945, 15.2126)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.8123" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(26.1295, 14.1133)">
+<g transform="translate(26.1295, 14.2126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(36.1463, 15.3033)">
+<g transform="translate(36.1463, 15.4026)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(36.1463, 16.1133)">
+<g transform="translate(36.1463, 16.2126)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(26.1295, 17.3033)">
+<g transform="translate(26.1295, 17.4026)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.3900 7.6026 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(26.1295, 18.1133)">
+<g transform="translate(26.1295, 18.2126)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.3900 7.6026 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(16.3626, 17.1133)">
+<g transform="translate(16.3626, 17.2126)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(16.3626, 17.9233)">
+<g transform="translate(16.3626, 18.0226)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(11.3542, 17.1133)">
+<g transform="translate(11.3542, 17.2126)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="2.5942 -0.2000 2.5942 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(7.9000, 17.9233)">
+<g transform="translate(7.9000, 18.0226)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.0484 -0.2000 6.0484 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(38.6506, 12.6133)">
+<g transform="translate(38.6506, 12.7126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(43.4740, 15.1133)">
+<g transform="translate(43.4740, 15.2126)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(43.4090, 13.1133)">
+<g transform="translate(43.4090, 13.2126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(41.2198, 15.1133)">
+<g transform="translate(41.2198, 15.2126)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(41.1548, 12.1133)">
+<g transform="translate(41.1548, 12.2126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(38.7156, 15.1133)">
+<g transform="translate(38.7156, 15.2126)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(16.3626, 14.1133)">
+<g transform="translate(16.3626, 14.2126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 12.0386)">
+<g transform="translate(-1.1267, 12.1379)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>8</tspan>
 </text>
 </g>
-<g transform="translate(13.9234, 15.1133)">
+<g transform="translate(13.9234, 15.2126)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(13.8584, 14.6133)">
+<g transform="translate(13.8584, 14.7126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 14.1133)">
+<g transform="translate(4.3000, 14.2126)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(11.4192, 15.1133)">
+<g transform="translate(11.4192, 15.2126)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(11.3542, 15.1133)">
+<g transform="translate(11.3542, 15.2126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(7.9650, 15.1133)">
+<g transform="translate(7.9650, 15.2126)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 14.1133)">
+<g transform="translate(7.9000, 14.2126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(16.4276, 15.1133)">
+<g transform="translate(16.4276, 15.2126)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(23.6903, 15.1133)">
+<g transform="translate(23.6903, 15.2126)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(23.6253, 14.6133)">
+<g transform="translate(23.6253, 14.7126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(21.4361, 15.1133)">
+<g transform="translate(21.4361, 15.2126)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(21.3711, 13.6133)">
+<g transform="translate(21.3711, 13.7126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.6819, 15.1133)">
+<g transform="translate(18.6819, 15.2126)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(18.6169, 15.1133)">
+<g transform="translate(18.6169, 15.2126)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 14.1133)">
+<g transform="translate(0.8000, 14.2126)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>

--- a/tools/scores/allemande.ly
+++ b/tools/scores/allemande.ly
@@ -21,7 +21,7 @@ allemande = \absolute {
     \barNumberCheck #5
     \override DynamicLineSpanner.staff-padding = #3 a16-1( b16 c'16) a16 g16-2( fis16 g16) a16 dis8.\trill c'16-4( b16 \once \override DynamicText.extra-offset = #'(0.3 . 0) a16-#(make-dynamic-script (markup #:normal-text #:italic "cre")) g16 \once \override DynamicText.extra-offset = #'(2 . 0) fis16)-#(make-dynamic-script (markup #:normal-text "–")) |
     \override DynamicLineSpanner.staff-padding = #3 g16(-#(make-dynamic-script (markup #:normal-text "–")) e16) e16( \once \override DynamicText.extra-offset = #'(-0.5 . 0) b,16)-#(make-dynamic-script (markup #:normal-text #:italic "scen")) b,16( g,16) g,16( \once \override DynamicText.extra-offset = #'(1.2 . 0) e,16)-#(make-dynamic-script (markup #:normal-text "–")) e,8. b,16\downbow e16(-#(make-dynamic-script (markup #:normal-text "–")) \once \override DynamicText.extra-offset = #'(1 . 0) g16-#(make-dynamic-script (markup #:normal-text #:italic "do")) fis16 a16) |
-    g16 fis16 e16 fis16 g16 cis'16 g16 fis16 g16 cis'16 e16 fis16 g16 e16 a,16 g16 |
+    \once \set fingeringOrientations = #'(up) g16-4\mf( fis16 e16) fis16-. g16( cis'16) g16 fis16 g16( cis'16) e16 fis16 g16( e16 a,16) g16-. |
     fis8 d16 e16 fis16 d16 g16 e16 fis16 d16 fis16 g16 a16 b16 c'16 a16 |
     b16 d16 g,16 d16 b16 g16 a16 fis16 g16 e16 g16 a16 b16 cis'16 d'16 b16 |
     \barNumberCheck #10


### PR DESCRIPTION
## Summary
- m.7: `mf` under note 1, fingering 4 above note 1, slurs over notes 1-3 / 5-6 / 9-10 / 13-15, and staccato dots above notes 4 and 16.

## Test plan
- [x] `build_scores.py` clean; only `mm-6-8` changed.
- [x] Rendered mm. 6-8 to confirm dynamic, fingering, slurs, and staccato placement.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_