### PR TITLE
Allemande m.8: slurs, finger 1, decrescendo-to-p and crescendo

### DIFF
--- a/scores/allemande/mm-6-8.svg
+++ b/scores/allemande/mm-6-8.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="32.43mm" viewBox="-1.1267 0.0000 103.5567 18.4526">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="37.30mm" viewBox="-1.1267 0.0000 103.5567 21.2285">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
@@ -360,152 +360,184 @@ s-8 -22 -22 -22c-49 0 -96 14 -145 14s-97 -14 -146 -14c-14 0 -21 11 -21 22s7 21 2
 <tspan>–</tspan>
 </text>
 </g>
-<g transform="translate(0.0000, 17.2126)">
+<g transform="translate(0.0000, 17.6914)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 16.2126)">
+<g transform="translate(0.0000, 16.6914)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 15.2126)">
+<g transform="translate(0.0000, 15.6914)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 14.2126)">
+<g transform="translate(0.0000, 14.6914)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 13.2126)">
+<g transform="translate(0.0000, 13.6914)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.8165" y2="0"/>
 </g>
-<g transform="translate(0.0000, 12.2126)">
+<g transform="translate(0.0000, 12.6914)">
 <rect x="40.8287" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(45.6765, 15.2126)">
+<g transform="translate(45.6765, 15.6914)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(33.6421, 13.7126)">
+<g transform="translate(36.1463, 13.6914)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(33.7071, 15.2126)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1255" ry="0.0400" fill="currentColor"/>
+<g transform="translate(36.3887, 11.9780)">
+<path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
+c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
 </g>
-<g transform="translate(36.1463, 13.2126)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(36.2113, 15.2126)">
+<g transform="translate(36.2113, 15.6914)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(31.2029, 15.2126)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6878" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(31.1379, 14.2126)">
+<g transform="translate(38.6506, 13.1914)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.4487, 15.2126)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.7562" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(28.3837, 15.2126)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(26.1945, 15.2126)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.8123" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(26.1295, 14.2126)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(36.1463, 15.4026)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(36.1463, 16.2126)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(26.1295, 17.4026)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.3900 7.6026 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(26.1295, 18.2126)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.3900 7.6026 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(16.3626, 17.2126)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(16.3626, 18.0226)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(11.3542, 17.2126)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="2.5942 -0.2000 2.5942 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(7.9000, 18.0226)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.0484 -0.2000 6.0484 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(38.6506, 12.7126)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(43.4740, 15.2126)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(43.4090, 13.2126)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(41.2198, 15.2126)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(41.1548, 12.2126)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(38.7156, 15.2126)">
+<g transform="translate(38.7156, 15.6914)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(16.3626, 14.2126)">
+<g transform="translate(36.1463, 15.8814)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(36.1463, 16.6914)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(28.3837, 15.6914)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 12.1379)">
+<g transform="translate(28.4487, 15.6914)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.7562" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(33.7071, 15.6914)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1255" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(31.1379, 14.6914)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(31.2029, 15.6914)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6878" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(33.6421, 14.1914)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(16.3626, 15.6914)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -2.2285C1.6921 -2.6008 2.7332 -2.1390 3.0826 -1.2285L3.0826 -1.2285C2.6846 -2.0293 1.6434 -2.4911 0.8284 -2.2285z"/>
+</g>
+<g transform="translate(7.9000, 20.0445)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.6666" x2="2.3722" y2="0.0000"/>
+</g>
+<g transform="translate(7.9000, 20.0445)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.6666" x2="2.3722" y2="-0.0000"/>
+</g>
+<g transform="translate(7.9000, 15.6914)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7730 -2.1950C1.8711 -2.7545 3.5978 -2.2546 4.2272 -1.1950L4.2272 -1.1950C3.5644 -2.1393 1.8378 -2.6392 0.7730 -2.1950z"/>
+</g>
+<g transform="translate(11.3542, 17.6914)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="2.5942 -0.2000 2.5942 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(7.9000, 18.5014)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.0484 -0.2000 6.0484 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(21.3711, 19.7470)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="23.3421" y2="0.6666"/>
+</g>
+<g transform="translate(21.3711, 19.7470)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="23.3421" y2="-0.6666"/>
+</g>
+<g transform="translate(26.1295, 15.6914)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -2.2285C1.6921 -2.6008 2.7332 -2.1390 3.0826 -1.2285L3.0826 -1.2285C2.6846 -2.0293 1.6434 -2.4911 0.8284 -2.2285z"/>
+</g>
+<g transform="translate(16.3626, 17.6914)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(16.3626, 18.5014)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(36.1463, 15.6914)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5670 -3.0450C1.5034 -4.3147 4.2232 -4.8578 5.5754 -4.0450L5.5754 -4.0450C4.2467 -4.7401 1.5269 -4.1970 0.5670 -3.0450z"/>
+</g>
+<g transform="translate(26.1295, 17.8814)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.3900 7.6026 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(26.1295, 18.6914)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.3900 7.6026 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(41.1548, 12.6914)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(41.2198, 15.6914)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(43.4090, 13.6914)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(43.4740, 15.6914)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(11.3542, 15.6914)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(11.2722, 20.6445)">
+<path transform="scale(0.0040, -0.0040)" d="M161 32c78 0 97 176 97 178c0 18 -7 33 -25 33c-61 0 -102 -124 -102 -173c0 -22 8 -38 30 -38zM-53 141c0 2 51 151 134 151c35 0 59 -21 66 -52c29 31 67 52 103 52c69 0 107 -49 107 -114c0 -118 -105 -186 -159 -186c-53 0 -70 20 -84 20c-7 0 -14 -3 -16 -9l-29 -86
+c-1 -2 -1 -5 -1 -7c0 -37 57 -18 57 -42c0 -7 -4 -14 -13 -14c-3 0 -50 5 -116 5s-112 -5 -115 -5c-9 0 -14 7 -14 14c0 31 87 -1 102 41l102 300c2 7 4 14 4 20c0 8 -2 14 -11 14c-33 0 -63 -60 -79 -97c-5 -12 -15 -17 -24 -17c-8 0 -14 4 -14 12z" fill="currentColor"/>
+</g>
+<g transform="translate(11.4192, 15.6914)">
+<rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(7.9650, 15.6914)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(13.8584, 15.1914)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(13.9234, 15.6914)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(0.8000, 14.6914)">
+<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
+c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
+</g>
+<g transform="translate(4.3000, 14.6914)">
+<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
+v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+</g>
+<g transform="translate(-1.1267, 12.6167)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>8</tspan>
 </text>
 </g>
-<g transform="translate(13.9234, 15.2126)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(13.8584, 14.7126)">
+<g transform="translate(7.9000, 14.6914)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 14.2126)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+<g transform="translate(26.1945, 15.6914)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.8123" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(11.4192, 15.2126)">
-<rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(11.3542, 15.2126)">
+<g transform="translate(23.6253, 15.1914)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(7.9650, 15.2126)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(7.9000, 14.2126)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(16.4276, 15.2126)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(23.6903, 15.2126)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(23.6253, 14.7126)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(21.4361, 15.2126)">
+<g transform="translate(21.4361, 15.6914)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(21.3711, 13.7126)">
+<g transform="translate(23.6903, 15.6914)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(21.3711, 14.1914)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.6819, 15.2126)">
+<g transform="translate(16.3626, 14.6914)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(18.6819, 15.6914)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(18.6169, 15.2126)">
+<g transform="translate(18.6169, 15.6914)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 14.2126)">
-<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
-c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
+<g transform="translate(26.1295, 14.6914)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(16.4276, 15.6914)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
 </svg>

--- a/scores/allemande/mm-8-10.svg
+++ b/scores/allemande/mm-8-10.svg
@@ -1,467 +1,499 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="33.64mm" viewBox="-2.2535 -0.0000 104.6834 19.1450">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="35.06mm" viewBox="-2.2535 -0.0000 104.6834 19.9495">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
-<g transform="translate(0.0000, 6.5000)">
+<g transform="translate(0.0000, 6.8136)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 5.5000)">
+<g transform="translate(0.0000, 5.8136)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 4.5000)">
+<g transform="translate(0.0000, 4.8136)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 3.5000)">
+<g transform="translate(0.0000, 3.8136)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 2.5000)">
+<g transform="translate(0.0000, 2.8136)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(102.2399, 4.5000)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(53.2338, 4.5000)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 1.5000)">
+<g transform="translate(0.0000, 1.8136)">
 <rect x="96.4251" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 1.5000)">
+<g transform="translate(0.0000, 1.8136)">
 <rect x="93.5996" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 1.5000)">
+<g transform="translate(0.0000, 1.8136)">
 <rect x="47.4414" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(66.6357, 2.0000)">
+<g transform="translate(53.2338, 4.8136)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(102.2399, 4.8136)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(75.0653, 3.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(66.7007, 4.5000)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3200" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(69.3622, 3.0000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(69.4272, 4.5000)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.5781" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(72.3388, 2.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(72.4038, 4.5000)">
+<g transform="translate(72.4038, 4.8136)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="3.3597" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(75.0653, 3.5000)">
+<g transform="translate(72.3388, 2.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(75.1303, 4.5000)">
+<g transform="translate(69.4272, 4.8136)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.5781" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(69.3622, 3.3136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(75.1303, 4.8136)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="2.6177" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(78.0419, 3.0000)">
+<g transform="translate(78.0419, 3.3136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(78.1069, 4.5000)">
+<g transform="translate(78.1069, 4.8136)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.3125" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(57.5210, 4.5000)">
+<g transform="translate(80.7684, 4.3136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(80.8334, 4.8136)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.2553" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(89.9480, 4.8136)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.6196 -0.2000 9.6196 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(89.9480, 5.6236)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.6196 -0.2000 9.6196 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(57.4560, 4.8136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(57.5210, 4.8136)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="3.9408" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(89.9480, 4.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.6196 -0.2000 9.6196 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(89.9480, 5.3100)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.6196 -0.2000 9.6196 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(54.7945, 4.5000)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.1313" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(57.4560, 4.5000)">
+<g transform="translate(60.1826, 6.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(60.1826, 6.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(60.2476, 4.5000)">
+<g transform="translate(60.2476, 4.8136)">
 <rect x="-0.0650" y="2.1861" width="0.1300" height="2.2503" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(63.4091, 4.5000)">
+<g transform="translate(63.4091, 4.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(63.4741, 4.5000)">
+<g transform="translate(63.4741, 4.8136)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="4.6165" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(96.7511, 1.0000)">
+<g transform="translate(66.6357, 2.3136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(96.8161, 4.5000)">
-<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(66.7007, 4.8136)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3200" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(99.4777, 2.0000)">
+<g transform="translate(99.4777, 2.3136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(99.5427, 4.5000)">
+<g transform="translate(99.5427, 4.8136)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(92.3246, 1.5000)">
+<g transform="translate(7.9000, 9.1705)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.6666" x2="3.3169" y2="0.0000"/>
+</g>
+<g transform="translate(7.9000, 9.1705)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.6666" x2="3.3169" y2="-0.0000"/>
+</g>
+<g transform="translate(7.9000, 4.8136)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7485 -2.1950C2.0068 -2.9170 4.3248 -2.3900 5.1474 -1.1950L5.1474 -1.1950C4.2982 -2.2730 1.9802 -2.8000 0.7485 -2.1950z"/>
+</g>
+<g transform="translate(18.2520, 4.8136)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8018 -2.2030C1.7623 -2.6343 3.0636 -2.1570 3.5283 -1.2030L3.5283 -1.2030C3.0223 -2.0444 1.7210 -2.5216 0.8018 -2.2030z"/>
+</g>
+<g transform="translate(12.2989, 6.8136)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="3.0665 -0.2000 3.0665 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(7.9000, 7.6236)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.4654 -0.2000 7.4654 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(24.2051, 8.8715)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="27.5931" y2="0.6666"/>
+</g>
+<g transform="translate(24.2051, 8.8715)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="27.5931" y2="-0.6666"/>
+</g>
+<g transform="translate(29.9082, 4.8136)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8018 -2.2030C1.7623 -2.6343 3.0636 -2.1570 3.5283 -1.2030L3.5283 -1.2030C3.0223 -2.0444 1.7210 -2.5216 0.8018 -2.2030z"/>
+</g>
+<g transform="translate(18.2520, 6.8136)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 -0.2000 8.7696 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(18.2520, 7.6236)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 -0.2000 8.7696 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(41.8143, 4.8136)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5801 -3.0450C1.6782 -4.4135 5.0482 -4.9796 6.5332 -4.0450L6.5332 -4.0450C5.0680 -4.8613 1.6981 -4.2952 0.5801 -3.0450z"/>
+</g>
+<g transform="translate(29.9082, 7.0036)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0196 -0.3900 9.0196 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(29.9082, 7.8136)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0196 -0.3900 9.0196 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(41.8143, 5.0036)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 -0.2000 8.7696 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(41.8143, 5.8136)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 -0.2000 8.7696 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(54.7295, 7.8136)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 0.8000 8.7696 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(54.7295, 8.6236)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 0.8000 8.7696 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(66.6357, 5.0036)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.5196 0.6100 8.5196 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(66.6357, 5.8136)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.5196 0.6100 8.5196 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(78.0419, 6.0036)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0196 -0.3900 9.0196 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(78.0419, 6.8136)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0196 -0.3900 9.0196 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(83.9949, 3.3136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(84.0599, 4.8136)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1877" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(86.9715, 2.8136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(87.0365, 4.8136)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6253" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(89.9480, 2.3136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(90.0130, 4.8136)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(93.7746, 1.8136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(93.8396, 4.8136)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(92.3246, 1.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(12.2989, 6.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="3.0665 -0.2000 3.0665 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(7.9000, 7.3100)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.4654 -0.2000 7.4654 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(18.2520, 6.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 -0.2000 8.7696 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(18.2520, 7.3100)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 -0.2000 8.7696 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(29.9082, 6.6900)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0196 -0.3900 9.0196 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(29.9082, 7.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0196 -0.3900 9.0196 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(41.8143, 4.6900)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 -0.2000 8.7696 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(41.8143, 5.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 -0.2000 8.7696 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(54.7295, 7.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 0.8000 8.7696 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(54.7295, 8.3100)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 0.8000 8.7696 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(66.6357, 4.6900)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.5196 0.6100 8.5196 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(66.6357, 5.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.5196 0.6100 8.5196 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(78.0419, 5.6900)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0196 -0.3900 9.0196 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(78.0419, 6.5000)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.0196 -0.3900 9.0196 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(80.7684, 4.0000)">
+<g transform="translate(96.7511, 1.3136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(80.8334, 4.5000)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="2.2553" ry="0.0400" fill="currentColor"/>
+<g transform="translate(96.8161, 4.8136)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(83.9949, 3.0000)">
+<g transform="translate(18.2520, 3.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(84.0599, 4.5000)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="3.1877" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(86.9715, 2.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(87.0365, 4.5000)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.6253" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(89.9480, 2.0000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(90.0130, 4.5000)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(93.7746, 1.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(93.8396, 4.5000)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(18.2520, 3.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(18.3170, 4.5000)">
+<g transform="translate(18.3170, 4.8136)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(20.9785, 4.5000)">
+<g transform="translate(20.9785, 4.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(21.0435, 4.5000)">
+<g transform="translate(21.0435, 4.8136)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(24.2051, 3.0000)">
+<g transform="translate(24.2051, 3.3136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(24.2701, 4.5000)">
+<g transform="translate(24.2701, 4.8136)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(26.9316, 4.0000)">
+<g transform="translate(26.9316, 4.3136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(26.9966, 4.5000)">
+<g transform="translate(26.9966, 4.8136)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(29.9082, 3.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(29.9732, 4.5000)">
+<g transform="translate(29.9732, 4.8136)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.8125" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 3.5000)">
+<g transform="translate(32.6347, 4.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 3.5000)">
+<g transform="translate(7.9000, 3.8136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(0.8000, 3.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 3.5000)">
+<g transform="translate(4.3000, 3.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(7.9650, 4.5000)">
+<g transform="translate(7.9650, 4.8136)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(-1.1267, 1.4253)">
+<g transform="translate(-1.1267, 1.7389)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>8</tspan>
 </text>
 </g>
-<g transform="translate(12.2989, 4.5000)">
+<g transform="translate(29.9082, 3.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.3639, 4.5000)">
+<g transform="translate(12.2989, 4.8136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(12.2169, 9.7705)">
+<path transform="scale(0.0040, -0.0040)" d="M161 32c78 0 97 176 97 178c0 18 -7 33 -25 33c-61 0 -102 -124 -102 -173c0 -22 8 -38 30 -38zM-53 141c0 2 51 151 134 151c35 0 59 -21 66 -52c29 31 67 52 103 52c69 0 107 -49 107 -114c0 -118 -105 -186 -159 -186c-53 0 -70 20 -84 20c-7 0 -14 -3 -16 -9l-29 -86
+c-1 -2 -1 -5 -1 -7c0 -37 57 -18 57 -42c0 -7 -4 -14 -13 -14c-3 0 -50 5 -116 5s-112 -5 -115 -5c-9 0 -14 7 -14 14c0 31 87 -1 102 41l102 300c2 7 4 14 4 20c0 8 -2 14 -11 14c-33 0 -63 -60 -79 -97c-5 -12 -15 -17 -24 -17c-8 0 -14 4 -14 12z" fill="currentColor"/>
+</g>
+<g transform="translate(12.3639, 4.8136)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.2754, 4.0000)">
+<g transform="translate(15.2754, 4.3136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(15.3404, 4.5000)">
+<g transform="translate(15.3404, 4.8136)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(41.8143, 2.5000)">
+<g transform="translate(41.8143, 2.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(41.8793, 4.5000)">
+<g transform="translate(42.0567, 1.1360)">
+<path transform="scale(0.0022, -0.0022)" d="M194 486c16 0 29 15 41 15c13 0 24 -13 24 -31v-341c0 -47 35 -86 81 -86c14 0 21 -10 21 -21s-7 -22 -21 -22c-49 0 -97 14 -146 14s-96 -14 -145 -14c-14 0 -22 11 -22 22s8 21 22 21c46 0 80 39 80 86v137c0 23 -16 35 -30 35c-7 0 -13 -4 -17 -11l-34 -65
+c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18 0 37 -20 54 -20z" fill="currentColor"/>
+</g>
+<g transform="translate(41.8793, 4.8136)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(44.7909, 2.0000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(44.8559, 4.5000)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(47.7674, 1.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(47.8324, 4.5000)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(50.4940, 2.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(50.5590, 4.5000)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(54.7295, 2.0000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(35.9262, 4.5000)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6877" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(35.8612, 3.5000)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(32.6997, 4.5000)">
+<g transform="translate(32.6997, 4.8136)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.7553" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(38.8378, 3.0000)">
+<g transform="translate(44.7909, 2.3136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(32.6347, 4.5000)">
+<g transform="translate(44.8559, 4.8136)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(47.7674, 1.8136)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(38.9028, 4.5000)">
+<g transform="translate(47.8324, 4.8136)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(50.4940, 2.8136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(50.5590, 4.8136)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(54.7295, 2.3136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(54.7945, 4.8136)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="6.1313" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(35.9262, 4.8136)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.6877" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(35.8612, 3.8136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(38.8378, 3.3136)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(38.9028, 4.8136)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1253" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 16.0950)">
+<g transform="translate(0.0000, 16.8995)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
 </g>
-<g transform="translate(0.0000, 15.0950)">
+<g transform="translate(0.0000, 15.8995)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
 </g>
-<g transform="translate(0.0000, 14.0950)">
+<g transform="translate(0.0000, 14.8995)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
 </g>
-<g transform="translate(0.0000, 13.0950)">
+<g transform="translate(0.0000, 13.8995)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
 </g>
-<g transform="translate(0.0000, 12.0950)">
+<g transform="translate(0.0000, 12.8995)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
 </g>
-<g transform="translate(0.0000, 10.0950)">
+<g transform="translate(0.0000, 10.8995)">
 <rect x="42.8329" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 11.0950)">
+<g transform="translate(0.0000, 11.8995)">
 <rect x="42.8329" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 11.0950)">
+<g transform="translate(0.0000, 11.8995)">
 <rect x="37.8245" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 11.0950)">
+<g transform="translate(0.0000, 11.8995)">
 <rect x="33.0661" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 11.0950)">
+<g transform="translate(0.0000, 11.8995)">
 <rect x="28.0577" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 11.0950)">
+<g transform="translate(0.0000, 11.8995)">
 <rect x="25.5534" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 11.0950)">
+<g transform="translate(0.0000, 11.8995)">
 <rect x="18.0408" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 11.0950)">
+<g transform="translate(0.0000, 11.8995)">
 <rect x="8.1750" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(47.6807, 14.0950)">
+<g transform="translate(47.6807, 14.8995)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(33.3921, 10.5950)">
+<g transform="translate(33.3921, 11.3995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(33.4571, 14.0950)">
+<g transform="translate(33.4571, 14.8995)">
 <rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(35.6463, 11.5950)">
+<g transform="translate(35.6463, 12.3995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(35.7113, 14.0950)">
+<g transform="translate(35.7113, 14.8995)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(38.1506, 11.0950)">
+<g transform="translate(38.1506, 11.8995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(38.2156, 14.0950)">
+<g transform="translate(38.2156, 14.8995)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8183" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(25.9445, 14.0950)">
+<g transform="translate(25.9445, 14.8995)">
 <rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(38.1506, 14.2850)">
+<g transform="translate(38.1506, 15.0895)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.3000 7.3526 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(38.1506, 15.0950)">
+<g transform="translate(38.1506, 15.8995)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.3000 7.3526 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(28.3837, 11.0950)">
+<g transform="translate(28.3837, 11.8995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.4487, 14.0950)">
+<g transform="translate(28.4487, 14.8995)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(30.6379, 12.0950)">
+<g transform="translate(30.6379, 12.8995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(30.7029, 14.0950)">
+<g transform="translate(30.7029, 14.8995)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(8.3500, 17.0950)">
+<g transform="translate(8.3500, 17.8995)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(8.3500, 17.9050)">
+<g transform="translate(8.3500, 18.7095)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(18.3669, 14.0950)">
+<g transform="translate(18.3669, 14.8995)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(18.3669, 14.9050)">
+<g transform="translate(18.3669, 15.7095)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(28.3837, 14.0950)">
+<g transform="translate(28.3837, 14.8995)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(28.3837, 14.9050)">
+<g transform="translate(28.3837, 15.7095)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(45.4782, 14.0950)">
+<g transform="translate(45.4782, 14.8995)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="2.8095" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(45.4132, 12.5950)">
+<g transform="translate(45.4132, 13.3995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(43.2240, 14.0950)">
+<g transform="translate(43.2240, 14.8995)">
 <rect x="-0.0650" y="-3.8139" width="0.1300" height="5.1570" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(43.1590, 10.0950)">
+<g transform="translate(43.1590, 10.8995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(40.4698, 14.0950)">
+<g transform="translate(40.4698, 14.8995)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.9708" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(40.4048, 12.0950)">
+<g transform="translate(40.4048, 12.8995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(6.9000, 11.0950)">
+<g transform="translate(6.9000, 11.8995)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(10.6042, 13.5950)">
+<g transform="translate(10.6042, 14.3995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(10.6692, 14.0950)">
+<g transform="translate(10.6692, 14.8995)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="4.4376" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(8.4150, 14.0950)">
+<g transform="translate(8.4150, 14.8995)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="6.6327" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(12.8584, 16.0950)">
+<g transform="translate(12.8584, 16.8995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(25.8795, 10.5950)">
+<g transform="translate(25.8795, 11.3995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 13.0950)">
+<g transform="translate(0.8000, 13.8995)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 13.0950)">
+<g transform="translate(4.3000, 13.8995)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(-2.2535, 11.0203)">
+<g transform="translate(-2.2535, 11.8248)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>10</tspan>
 </text>
 </g>
-<g transform="translate(12.9234, 14.0950)">
+<g transform="translate(12.9234, 14.8995)">
 <rect x="-0.0650" y="2.1861" width="0.1300" height="2.2425" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(8.3500, 11.0950)">
+<g transform="translate(8.3500, 11.8995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.3669, 11.0950)">
+<g transform="translate(18.3669, 11.8995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(20.6861, 14.0950)">
+<g transform="translate(20.6861, 14.8995)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(20.6211, 12.0950)">
+<g transform="translate(20.6211, 12.8995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(23.1253, 11.5950)">
+<g transform="translate(23.1253, 12.3995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.4319, 14.0950)">
+<g transform="translate(18.4319, 14.8995)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(23.1903, 14.0950)">
+<g transform="translate(23.1903, 14.8995)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.6776, 14.0950)">
+<g transform="translate(15.6776, 14.8995)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="5.1151" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.6126, 13.5950)">
+<g transform="translate(15.6126, 14.3995)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 </svg>

--- a/tools/scores/allemande.ly
+++ b/tools/scores/allemande.ly
@@ -22,7 +22,7 @@ allemande = \absolute {
     \override DynamicLineSpanner.staff-padding = #3 a16-1( b16 c'16) a16 g16-2( fis16 g16) a16 dis8.\trill c'16-4( b16 \once \override DynamicText.extra-offset = #'(0.3 . 0) a16-#(make-dynamic-script (markup #:normal-text #:italic "cre")) g16 \once \override DynamicText.extra-offset = #'(2 . 0) fis16)-#(make-dynamic-script (markup #:normal-text "–")) |
     \override DynamicLineSpanner.staff-padding = #3 g16(-#(make-dynamic-script (markup #:normal-text "–")) e16) e16( \once \override DynamicText.extra-offset = #'(-0.5 . 0) b,16)-#(make-dynamic-script (markup #:normal-text #:italic "scen")) b,16( g,16) g,16( \once \override DynamicText.extra-offset = #'(1.2 . 0) e,16)-#(make-dynamic-script (markup #:normal-text "–")) e,8. b,16\downbow e16(-#(make-dynamic-script (markup #:normal-text "–")) \once \override DynamicText.extra-offset = #'(1 . 0) g16-#(make-dynamic-script (markup #:normal-text #:italic "do")) fis16 a16) |
     \once \set fingeringOrientations = #'(up) g16-4\mf( fis16 e16) fis16-. g16( cis'16) g16 fis16 g16( cis'16) e16 fis16 g16( e16 a,16) g16-. |
-    fis8 d16 e16 fis16 d16 g16 e16 fis16 d16 fis16 g16 a16 b16 c'16 a16 |
+    \revert DynamicLineSpanner.staff-padding fis8\>( d16\p) e16 fis16( d16) g16\< e16 fis16( d16) fis16 g16 \once \set fingeringOrientations = #'(up) a16-1( b16 c'16) a16\! |
     b16 d16 g,16 d16 b16 g16 a16 fis16 g16 e16 g16 a16 b16 cis'16 d'16 b16 |
     \barNumberCheck #10
     cis'16 e16 g,16 e16 cis'16 a16 b16 d'16 cis'16 a16 d'16 b16 cis'16 a16 e'16 g16 |


### PR DESCRIPTION
## Summary
- m.8: slurs over notes 1-2 / 4-5 / 8-9 / 12-14; fingering 1 above note 12; a decrescendo from the barline terminating in `p` at note 2; a crescendo from note 6 extending past note 15.
- Revert the m.6 `DynamicLineSpanner` padding at the start of m.8 so its dynamics keep the natural height and render identically in the "mm 6-8" and "mm 8-10" loops.

## Test plan
- [x] `build_scores.py` clean; only `mm-6-8` and `mm-8-10` changed.
- [x] Rendered m.8 in both loop contexts — dynamics now at the same (natural) height in each.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_