### PR TITLE
Allemande m.10 + hairpin start/end extension standard

### DIFF
--- a/.claude/skills/score-workflow/SKILL.md
+++ b/.claude/skills/score-workflow/SKILL.md
@@ -54,6 +54,16 @@ Done a few measures at a time from screen captures of the edition being marked:
 5. Treat each batch as a first pass the user verifies; small marks are
    error-prone. Confirm ambiguous spots (e.g. which note of a chord) before moving on.
 
+## Project standard: hairpins (`\<` / `\>`)
+A crescendo/decrescendo hairpin **begins just before its first note and ends
+just after its last note**. This is enforced globally in `build_scores.py`'s
+`\layout` block via `\override Hairpin.shorten-pair = #'(-1 . -1)` (negative
+values *lengthen* each end), so you do **not** add per-hairpin tweaks — just
+attach `\<` to the start note and terminate with `\!` (or a dynamic like `\p`,
+`\mf`) on the end note. To place the terminating dynamic under the next
+bar line, attach it to the measure's last note and nudge it with
+`\once \override DynamicText.extra-offset = #'(1.5 . 0)`.
+
 ## HARD CONSTRAINT: one measure per line
 `build_scores.py` splits the music **by line = by measure**. Any
 `\set` / `\once` / `\override` must sit on the **same line** as the measure it

--- a/scores/allemande/mm-10-12.svg
+++ b/scores/allemande/mm-10-12.svg
@@ -1,455 +1,475 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="32.82mm" viewBox="-2.2535 -0.0000 104.6834 18.6750">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="36.39mm" viewBox="-2.2535 -0.0000 104.6834 20.7085">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
 ]]>
 </style>
-<g transform="translate(0.0000, 6.5450)">
+<g transform="translate(0.0000, 8.5785)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 5.5450)">
+<g transform="translate(0.0000, 7.5785)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 4.5450)">
+<g transform="translate(0.0000, 6.5785)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 3.5450)">
+<g transform="translate(0.0000, 5.5785)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 2.5450)">
+<g transform="translate(0.0000, 4.5785)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="102.3799" y2="0"/>
 </g>
-<g transform="translate(0.0000, 1.5450)">
+<g transform="translate(102.2399, 6.5785)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(56.0368, 6.5785)">
+<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 3.5785)">
 <rect x="63.1636" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 0.5450)">
+<g transform="translate(0.0000, 2.5785)">
 <rect x="50.1445" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 1.5450)">
+<g transform="translate(0.0000, 3.5785)">
 <rect x="50.1445" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 1.5450)">
+<g transform="translate(0.0000, 3.5785)">
 <rect x="44.0916" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 1.5450)">
+<g transform="translate(0.0000, 3.5785)">
 <rect x="38.2887" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 1.5450)">
+<g transform="translate(0.0000, 3.5785)">
 <rect x="32.2357" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 1.5450)">
+<g transform="translate(0.0000, 3.5785)">
 <rect x="29.2092" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 1.5450)">
+<g transform="translate(0.0000, 3.5785)">
 <rect x="20.1298" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 1.5450)">
+<g transform="translate(0.0000, 3.5785)">
 <rect x="8.1750" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(102.2399, 4.5450)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
+<g transform="translate(81.7135, 6.5785)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.7450" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(56.0368, 4.5450)">
-<rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
-</g>
-<g transform="translate(72.3841, 4.5450)">
-<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.3520" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(66.2661, 2.5450)">
+<g transform="translate(69.2926, 5.0785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(72.3191, 3.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(69.3576, 4.5450)">
+<g transform="translate(69.3576, 6.5785)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="3.5858" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(69.2926, 3.0450)">
+<g transform="translate(72.3191, 5.5785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(66.3311, 4.5450)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.8196" ry="0.0400" fill="currentColor"/>
+<g transform="translate(72.3841, 6.5785)">
+<rect x="-0.0650" y="-0.8139" width="0.1300" height="3.3520" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(75.3455, 4.0450)">
+<g transform="translate(75.3455, 6.0785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(75.4105, 4.5450)">
+<g transform="translate(75.4105, 6.5785)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1182" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(78.3720, 4.5450)">
+<g transform="translate(78.3720, 6.5785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(78.4370, 4.5450)">
+<g transform="translate(78.4370, 6.5785)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.8126" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(53.3121, 4.5450)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.8103" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(90.4779, 6.7350)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.3000 8.9194 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(90.4779, 7.5450)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.3000 8.9194 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(57.4835, 3.5450)">
+<g transform="translate(81.6485, 4.5785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(58.1356, 2.2450)">
+<g transform="translate(90.4779, 8.7685)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.3000 8.9194 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(90.4779, 9.5785)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.3000 8.9194 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(57.4835, 5.5785)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(58.1356, 4.2785)">
 <path transform="scale(0.0040, -0.0040)" d="M-297 227c0 -15 8 -30 39 -30c10 0 46 2 103 28l5 24c-23 17 -50 29 -81 29c-51 0 -66 -31 -66 -51zM-26 104c0 -61 -47 -115 -98 -115c-39 0 -56 44 -56 91c0 14 1 28 4 41l15 76c-20 -8 -63 -25 -101 -25c-19 0 -60 6 -60 51c0 38 32 80 96 80c31 0 58 -10 82 -25
 l46 232c6 -3 13 -5 20 -5c22 0 48 16 68 35l-53 -266l64 36c26 14 51 20 74 20c29 0 53 -10 64 -28c18 20 44 30 69 30c36 0 69 -22 69 -69c0 -49 -31 -90 -65 -90c-25 0 -38 22 -38 48c0 50 37 64 60 64h3c-8 14 -23 20 -38 20c-24 0 -50 -16 -55 -43l-54 -270
 c-11 7 -24 11 -38 11s-29 -4 -43 -11l54 270v7c0 16 -12 26 -29 26c-7 0 -16 -3 -24 -7l-79 -44l-7 -31c27 -31 50 -67 50 -109zM-86 39c23 0 35 34 35 61c0 30 -14 55 -32 78l-5 -27c-4 -18 -13 -56 -13 -83c0 -17 4 -29 15 -29z" fill="currentColor"/>
 </g>
-<g transform="translate(59.2377, 3.0450)">
+<g transform="translate(59.2377, 5.0785)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(57.5485, 4.5450)">
+<g transform="translate(57.5485, 6.5785)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="2.9893" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(63.4897, 1.0450)">
+<g transform="translate(66.3311, 6.5785)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="3.8196" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(63.4897, 3.0785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(63.5547, 4.5450)">
+<g transform="translate(63.5547, 6.5785)">
 <rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1385" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(96.5308, 2.5450)">
+<g transform="translate(66.2661, 4.5785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(96.5958, 4.5450)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="5.1553" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(99.3073, 5.0450)">
+<g transform="translate(99.3073, 7.0785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(99.3723, 4.5450)">
+<g transform="translate(99.3723, 6.5785)">
 <rect x="-0.0650" y="0.6861" width="0.1300" height="2.8103" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(8.3500, 7.5450)">
+<g transform="translate(8.3500, 6.5785)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -4.0450C2.6281 -5.5980 10.7820 -5.5980 12.7580 -4.0450L12.7580 -4.0450C10.7820 -5.4780 2.6281 -5.4780 0.6521 -4.0450z"/>
+</g>
+<g transform="translate(8.3500, 9.5785)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.9900 8.9194 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(8.3500, 8.3550)">
+<g transform="translate(8.3500, 10.3885)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.9900 8.9194 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(20.4559, 4.5450)">
+<g transform="translate(31.5618, 9.9451)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="21.2130" y2="0.6666"/>
+</g>
+<g transform="translate(31.5618, 9.9451)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="21.2130" y2="-0.6666"/>
+</g>
+<g transform="translate(20.4559, 6.5785)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 -0.2000 9.1694 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(20.4559, 5.3550)">
+<g transform="translate(20.4559, 7.3885)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 -0.2000 9.1694 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(32.5618, 4.5450)">
+<g transform="translate(35.3382, 6.5785)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6279 -3.5450C2.8940 -5.3819 16.0801 -6.1182 18.5367 -4.5450L18.5367 -4.5450C16.0868 -5.9984 2.9007 -5.2621 0.6279 -3.5450z"/>
+</g>
+<g transform="translate(32.5618, 6.5785)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 -0.2000 8.9194 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(32.5618, 5.3550)">
+<g transform="translate(32.5618, 7.3885)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 -0.2000 8.9194 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(44.4177, 4.7350)">
+<g transform="translate(44.4177, 6.7685)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.3000 8.9194 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(44.4177, 5.5450)">
+<g transform="translate(44.4177, 7.5785)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.3000 8.9194 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(62.4547, 4.8070)">
+<g transform="translate(62.4547, 6.8405)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.4620 1.1250 -0.0620 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(57.4835, 6.7350)">
+<g transform="translate(57.4835, 8.7685)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.0962 -1.5800 6.0962 -1.1800 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(66.2661, 5.7350)">
+<g transform="translate(66.2661, 7.7685)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 0.6100 9.1694 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(66.2661, 6.5450)">
+<g transform="translate(66.2661, 8.5785)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 0.6100 9.1694 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(78.3720, 6.7350)">
+<g transform="translate(78.3720, 8.7685)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 -0.3900 9.1694 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(78.3720, 7.5450)">
+<g transform="translate(78.3720, 9.5785)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 -0.3900 9.1694 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(81.6485, 2.5450)">
+<g transform="translate(90.4779, 5.5785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(81.7135, 4.5450)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="4.7450" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(84.6749, 3.0450)">
+<g transform="translate(84.6749, 5.0785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(84.7399, 4.5450)">
+<g transform="translate(84.7399, 6.5785)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1825" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(87.4514, 4.0450)">
+<g transform="translate(87.4514, 6.0785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(87.5164, 4.5450)">
+<g transform="translate(87.5164, 6.5785)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="3.1252" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(90.4779, 3.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(90.5429, 4.5450)">
+<g transform="translate(90.5429, 6.5785)">
 <rect x="-0.0650" y="-0.8139" width="0.1300" height="3.8175" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(93.2544, 4.5450)">
+<g transform="translate(93.2544, 6.5785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(93.3194, 4.5450)">
+<g transform="translate(93.3194, 6.5785)">
 <rect x="-0.0650" y="0.1861" width="0.1300" height="2.9725" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(23.2324, 2.5450)">
+<g transform="translate(96.5308, 4.5785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(17.1794, 4.0450)">
+<g transform="translate(96.5958, 6.5785)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="5.1553" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(23.1504, 10.3966)">
+<path transform="scale(0.0040, -0.0040)" d="M161 32c78 0 97 176 97 178c0 18 -7 33 -25 33c-61 0 -102 -124 -102 -173c0 -22 8 -38 30 -38zM-53 141c0 2 51 151 134 151c35 0 59 -21 66 -52c29 31 67 52 103 52c69 0 107 -49 107 -114c0 -118 -105 -186 -159 -186c-53 0 -70 20 -84 20c-7 0 -14 -3 -16 -9l-29 -86
+c-1 -2 -1 -5 -1 -7c0 -37 57 -18 57 -42c0 -7 -4 -14 -13 -14c-3 0 -50 5 -116 5s-112 -5 -115 -5c-9 0 -14 7 -14 14c0 31 87 -1 102 41l102 300c2 7 4 14 4 20c0 8 -2 14 -11 14c-33 0 -63 -60 -79 -97c-5 -12 -15 -17 -24 -17c-8 0 -14 4 -14 12z" fill="currentColor"/>
+</g>
+<g transform="translate(17.1794, 6.0785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(17.2444, 4.5450)">
+<g transform="translate(17.2444, 6.5785)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="5.3053" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(20.4559, 1.5450)">
+<g transform="translate(20.4559, 3.5785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(20.5209, 4.5450)">
+<g transform="translate(20.5209, 6.5785)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(23.2974, 4.5450)">
+<g transform="translate(23.2324, 4.5785)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(23.2974, 6.5785)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(26.2588, 2.0450)">
+<g transform="translate(26.2588, 4.0785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(26.3238, 4.5450)">
+<g transform="translate(26.3238, 6.5785)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(53.2471, 3.0450)">
+<g transform="translate(53.3121, 6.5785)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.8103" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(29.5353, 3.0785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(29.5353, 1.0450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(29.6003, 4.5450)">
+<g transform="translate(29.6003, 6.5785)">
 <rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(8.3500, 1.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(0.8000, 3.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
-c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
-</g>
-<g transform="translate(4.3000, 3.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(8.4150, 4.5450)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="6.6325" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(6.9000, 1.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
-v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
-</g>
-<g transform="translate(-2.2535, 1.4703)">
+<g transform="translate(-2.2535, 3.5038)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>10</tspan>
 </text>
 </g>
-<g transform="translate(11.1265, 4.0450)">
+<g transform="translate(8.3500, 3.5785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(11.1915, 4.5450)">
+<g transform="translate(0.8000, 5.5785)">
+<path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
+c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
+</g>
+<g transform="translate(4.3000, 5.5785)">
+<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
+v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+</g>
+<g transform="translate(8.4150, 6.5785)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="6.6325" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(6.9000, 3.5785)">
+<path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
+v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
+</g>
+<g transform="translate(11.1265, 6.0785)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(11.1915, 6.5785)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="4.5013" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(13.9030, 6.5450)">
+<g transform="translate(13.9030, 8.5785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(13.9680, 4.5450)">
+<g transform="translate(13.9680, 6.5785)">
 <rect x="-0.0650" y="2.1861" width="0.1300" height="2.3701" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(41.3912, 2.0450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(38.6147, 1.0450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(38.6797, 4.5450)">
-<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(47.2591, 4.5450)">
+<g transform="translate(47.2591, 6.5785)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.9725" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(47.1941, 2.5450)">
+<g transform="translate(38.6147, 3.0785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(41.4562, 4.5450)">
+<g transform="translate(38.6797, 6.5785)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(41.3912, 4.0785)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(53.2471, 5.0785)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(41.4562, 6.5785)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(44.4177, 1.5450)">
+<g transform="translate(47.1941, 4.5785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(44.4827, 4.5450)">
+<g transform="translate(44.4177, 3.5785)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(44.4827, 6.5785)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8175" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(32.6268, 4.5450)">
+<g transform="translate(35.3382, 4.5785)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(32.5618, 3.5785)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(32.6268, 6.5785)">
 <rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(32.5618, 1.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(35.3382, 2.5450)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(35.4032, 4.5450)">
+<g transform="translate(35.4032, 6.5785)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(50.5356, 4.5450)">
+<g transform="translate(50.5356, 6.5785)">
 <rect x="-0.0650" y="-3.8139" width="0.1300" height="5.1553" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(50.4706, 0.5450)">
+<g transform="translate(50.4706, 2.5785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 16.2450)">
+<g transform="translate(50.6618, 1.1248)">
+<path transform="scale(0.0022, -0.0022)" d="M148 501c10 0 41 -15 72 -15c32 0 63 15 76 15c15 0 26 -11 26 -21c0 -4 -1 -7 -4 -10l-264 -291h134v4c0 60 50 41 75 85c7 11 8 24 14 36c3 7 10 10 17 10c11 0 24 -8 24 -25v-110h70c18 0 27 -14 27 -27s-9 -27 -27 -27h-70c2 -45 36 -82 80 -82c14 0 22 -10 22 -21
+s-8 -22 -22 -22c-49 0 -96 14 -145 14s-97 -14 -146 -14c-14 0 -21 11 -21 22s7 21 21 21c44 0 79 37 81 82h-134c-43 0 -57 25 -57 42c0 5 1 10 3 12c73 81 123 182 123 291c0 17 11 31 25 31z" fill="currentColor"/>
+</g>
+<g transform="translate(0.0000, 18.2785)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0898" y2="0"/>
 </g>
-<g transform="translate(0.0000, 15.2450)">
+<g transform="translate(0.0000, 17.2785)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0898" y2="0"/>
 </g>
-<g transform="translate(0.0000, 14.2450)">
+<g transform="translate(0.0000, 16.2785)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0898" y2="0"/>
 </g>
-<g transform="translate(0.0000, 13.2450)">
+<g transform="translate(0.0000, 15.2785)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0898" y2="0"/>
 </g>
-<g transform="translate(0.0000, 12.2450)">
+<g transform="translate(0.0000, 14.2785)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="45.0898" y2="0"/>
 </g>
-<g transform="translate(44.9498, 14.2450)">
+<g transform="translate(44.9498, 16.2785)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(37.1872, 16.2450)">
+<g transform="translate(37.1872, 18.2785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(32.4288, 15.7450)">
+<g transform="translate(32.4288, 17.7785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(33.6680, 14.2450)">
+<g transform="translate(33.6680, 16.2785)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(34.9330, 15.2450)">
+<g transform="translate(34.9330, 17.2785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(36.1722, 14.2450)">
+<g transform="translate(36.1722, 16.2785)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(26.1553, 14.2450)">
+<g transform="translate(26.1553, 16.2785)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(31.4138, 14.2450)">
+<g transform="translate(31.4138, 16.2785)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(30.1745, 14.7450)">
+<g transform="translate(30.1745, 16.7785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(28.9095, 14.2450)">
+<g transform="translate(28.9095, 16.2785)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(27.6703, 14.2450)">
+<g transform="translate(27.6703, 16.2785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(36.1072, 11.4350)">
+<g transform="translate(36.1072, 13.4685)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(36.1072, 12.2450)">
+<g transform="translate(36.1072, 14.2785)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(26.0903, 11.4350)">
+<g transform="translate(26.0903, 13.4685)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(26.0903, 12.2450)">
+<g transform="translate(26.0903, 14.2785)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(16.0735, 11.4350)">
+<g transform="translate(16.0735, 13.4685)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 0.6100 7.6026 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(16.0735, 12.2450)">
+<g transform="translate(16.0735, 14.2785)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 0.6100 7.6026 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(11.5212, 16.5809)">
+<g transform="translate(11.5212, 18.6144)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="1.1250 -0.5359 1.1250 -0.1359 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(7.9000, 18.4350)">
+<g transform="translate(7.9000, 20.4685)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="4.7462 -1.5800 4.7462 -1.1800 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(38.4264, 14.2450)">
+<g transform="translate(38.4264, 16.2785)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="4.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(43.4348, 14.2450)">
+<g transform="translate(43.4348, 16.2785)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="5.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(42.1956, 16.7450)">
+<g transform="translate(42.1956, 18.7785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(41.1806, 14.2450)">
+<g transform="translate(41.1806, 16.2785)">
 <rect x="-0.0650" y="-2.8100" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(39.9414, 14.2450)">
+<g transform="translate(39.9414, 16.2785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(7.9000, 15.2450)">
+<g transform="translate(7.9000, 17.2785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(14.8993, 14.2450)">
+<g transform="translate(14.8993, 16.2785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(24.9161, 16.2450)">
+<g transform="translate(24.9161, 18.2785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.6212, 14.2450)">
+<g transform="translate(12.6212, 16.2785)">
 <rect x="-0.0650" y="-1.3139" width="0.1300" height="4.1426" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(12.5562, 12.7450)">
+<g transform="translate(12.5562, 14.7785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(7.9650, 14.2450)">
+<g transform="translate(7.9650, 16.2785)">
 <rect x="-0.0650" y="1.1861" width="0.1300" height="2.9852" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(9.6542, 14.7450)">
+<g transform="translate(9.6542, 16.7785)">
 <path transform="scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
 </g>
-<g transform="translate(8.5521, 11.9450)">
+<g transform="translate(8.5521, 13.9785)">
 <path transform="scale(0.0040, -0.0040)" d="M-297 227c0 -15 8 -30 39 -30c10 0 46 2 103 28l5 24c-23 17 -50 29 -81 29c-51 0 -66 -31 -66 -51zM-26 104c0 -61 -47 -115 -98 -115c-39 0 -56 44 -56 91c0 14 1 28 4 41l15 76c-20 -8 -63 -25 -101 -25c-19 0 -60 6 -60 51c0 38 32 80 96 80c31 0 58 -10 82 -25
 l46 232c6 -3 13 -5 20 -5c22 0 48 16 68 35l-53 -266l64 36c26 14 51 20 74 20c29 0 53 -10 64 -28c18 20 44 30 69 30c36 0 69 -22 69 -69c0 -49 -31 -90 -65 -90c-25 0 -38 22 -38 48c0 50 37 64 60 64h3c-8 14 -23 20 -38 20c-24 0 -50 -16 -55 -43l-54 -270
 c-11 7 -24 11 -38 11s-29 -4 -43 -11l54 270v7c0 16 -12 26 -29 26c-7 0 -16 -3 -24 -7l-79 -44l-7 -31c27 -31 50 -67 50 -109zM-86 39c23 0 35 34 35 61c0 30 -14 55 -32 78l-5 -27c-4 -18 -13 -56 -13 -83c0 -17 4 -29 15 -29z" fill="currentColor"/>
 </g>
-<g transform="translate(-2.2535, 11.1950)">
+<g transform="translate(-2.2535, 13.2285)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>12</tspan>
 </text>
 </g>
-<g transform="translate(4.3000, 13.2450)">
+<g transform="translate(4.3000, 15.2785)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 13.2450)">
+<g transform="translate(0.8000, 15.2785)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(21.1469, 14.2450)">
+<g transform="translate(21.1469, 16.2785)">
 <rect x="-0.0650" y="-2.2723" width="0.1300" height="3.0862" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(22.4119, 15.7450)">
+<g transform="translate(22.4119, 17.7785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(19.9077, 15.2450)">
+<g transform="translate(19.9077, 17.2785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(16.1385, 14.2450)">
+<g transform="translate(16.1385, 16.2785)">
 <rect x="-0.0650" y="-2.8031" width="0.1300" height="2.6170" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(23.6511, 14.2450)">
+<g transform="translate(23.6511, 16.2785)">
 <rect x="-0.0650" y="-2.0069" width="0.1300" height="3.3208" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(18.6427, 14.2450)">
+<g transform="translate(18.6427, 16.2785)">
 <rect x="-0.0650" y="-2.5377" width="0.1300" height="2.8516" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(17.4035, 14.7450)">
+<g transform="translate(17.4035, 16.7785)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
 </svg>

--- a/scores/allemande/mm-6-8.svg
+++ b/scores/allemande/mm-6-8.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="37.30mm" viewBox="-1.1267 0.0000 103.5567 21.2285">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="181.98mm" height="37.05mm" viewBox="-1.1267 0.0000 103.5567 21.0855">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
@@ -424,11 +424,11 @@ c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18
 <g transform="translate(16.3626, 15.6914)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -2.2285C1.6921 -2.6008 2.7332 -2.1390 3.0826 -1.2285L3.0826 -1.2285C2.6846 -2.0293 1.6434 -2.4911 0.8284 -2.2285z"/>
 </g>
-<g transform="translate(7.9000, 20.0445)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.6666" x2="2.3722" y2="0.0000"/>
+<g transform="translate(6.9000, 19.9015)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.6666" x2="4.3722" y2="0.0000"/>
 </g>
-<g transform="translate(7.9000, 20.0445)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.6666" x2="2.3722" y2="-0.0000"/>
+<g transform="translate(6.9000, 19.9015)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.6666" x2="4.3722" y2="-0.0000"/>
 </g>
 <g transform="translate(7.9000, 15.6914)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7730 -2.1950C1.8711 -2.7545 3.5978 -2.2546 4.2272 -1.1950L4.2272 -1.1950C3.5644 -2.1393 1.8378 -2.6392 0.7730 -2.1950z"/>
@@ -439,11 +439,11 @@ c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18
 <g transform="translate(7.9000, 18.5014)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="6.0484 -0.2000 6.0484 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(21.3711, 19.7470)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="23.3421" y2="0.6666"/>
+<g transform="translate(20.3711, 19.7454)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="25.3421" y2="0.6666"/>
 </g>
-<g transform="translate(21.3711, 19.7470)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="23.3421" y2="-0.6666"/>
+<g transform="translate(20.3711, 19.7454)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="25.3421" y2="-0.6666"/>
 </g>
 <g transform="translate(26.1295, 15.6914)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8284 -2.2285C1.6921 -2.6008 2.7332 -2.1390 3.0826 -1.2285L3.0826 -1.2285C2.6846 -2.0293 1.6434 -2.4911 0.8284 -2.2285z"/>
@@ -478,7 +478,7 @@ c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18
 <g transform="translate(11.3542, 15.6914)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(11.2722, 20.6445)">
+<g transform="translate(11.2722, 20.5015)">
 <path transform="scale(0.0040, -0.0040)" d="M161 32c78 0 97 176 97 178c0 18 -7 33 -25 33c-61 0 -102 -124 -102 -173c0 -22 8 -38 30 -38zM-53 141c0 2 51 151 134 151c35 0 59 -21 66 -52c29 31 67 52 103 52c69 0 107 -49 107 -114c0 -118 -105 -186 -159 -186c-53 0 -70 20 -84 20c-7 0 -14 -3 -16 -9l-29 -86
 c-1 -2 -1 -5 -1 -7c0 -37 57 -18 57 -42c0 -7 -4 -14 -13 -14c-3 0 -50 5 -116 5s-112 -5 -115 -5c-9 0 -14 7 -14 14c0 31 87 -1 102 41l102 300c2 7 4 14 4 20c0 8 -2 14 -11 14c-33 0 -63 -60 -79 -97c-5 -12 -15 -17 -24 -17c-8 0 -14 4 -14 12z" fill="currentColor"/>
 </g>

--- a/scores/allemande/mm-8-10.svg
+++ b/scores/allemande/mm-8-10.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="36.80mm" viewBox="-2.2535 -0.0000 104.6834 20.9425">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="183.96mm" height="40.29mm" viewBox="-2.2535 -0.0000 104.6834 22.9294">
 <style type="text/css">
 <![CDATA[
 tspan { white-space: pre; }
@@ -115,11 +115,11 @@ c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18
 <g transform="translate(7.9000, 4.9812)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.7485 -2.1950C2.0068 -2.9170 4.3248 -2.3900 5.1474 -1.1950L5.1474 -1.1950C4.2982 -2.2730 1.9802 -2.8000 0.7485 -2.1950z"/>
 </g>
-<g transform="translate(7.9000, 9.3381)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.6666" x2="3.3169" y2="0.0000"/>
+<g transform="translate(6.9000, 9.2186)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.6666" x2="5.3169" y2="0.0000"/>
 </g>
-<g transform="translate(7.9000, 9.3381)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.6666" x2="3.3169" y2="-0.0000"/>
+<g transform="translate(6.9000, 9.2186)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.6666" x2="5.3169" y2="-0.0000"/>
 </g>
 <g transform="translate(18.2520, 4.9812)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8018 -2.2030C1.7623 -2.6343 3.0636 -2.1570 3.5283 -1.2030L3.5283 -1.2030C3.0223 -2.0444 1.7210 -2.5216 0.8018 -2.2030z"/>
@@ -142,11 +142,11 @@ c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18
 <g transform="translate(66.6357, 5.9812)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.5196 0.6100 8.5196 1.0100 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
-<g transform="translate(78.0419, 8.9273)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="19.6368" y2="0.6666"/>
+<g transform="translate(77.0419, 8.9273)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="21.6368" y2="0.6666"/>
 </g>
-<g transform="translate(78.0419, 8.9273)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="19.6368" y2="-0.6666"/>
+<g transform="translate(77.0419, 8.9273)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="21.6368" y2="-0.6666"/>
 </g>
 <g transform="translate(54.7295, 7.9812)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.7696 0.8000 8.7696 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
@@ -178,11 +178,11 @@ c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18
 <g transform="translate(29.9082, 4.9812)">
 <path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.8018 -2.2030C1.7623 -2.6343 3.0636 -2.1570 3.5283 -1.2030L3.5283 -1.2030C3.0223 -2.0444 1.7210 -2.5216 0.8018 -2.2030z"/>
 </g>
-<g transform="translate(24.2051, 9.0391)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="27.5931" y2="0.6666"/>
+<g transform="translate(23.2051, 9.0376)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="29.5931" y2="0.6666"/>
 </g>
-<g transform="translate(24.2051, 9.0391)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="27.5931" y2="-0.6666"/>
+<g transform="translate(23.2051, 9.0376)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="29.5931" y2="-0.6666"/>
 </g>
 <g transform="translate(12.2989, 6.9812)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="3.0665 -0.2000 3.0665 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
@@ -292,7 +292,7 @@ c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22
 <g transform="translate(12.2989, 4.9812)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(12.2169, 9.9381)">
+<g transform="translate(12.2169, 9.8186)">
 <path transform="scale(0.0040, -0.0040)" d="M161 32c78 0 97 176 97 178c0 18 -7 33 -25 33c-61 0 -102 -124 -102 -173c0 -22 8 -38 30 -38zM-53 141c0 2 51 151 134 151c35 0 59 -21 66 -52c29 31 67 52 103 52c69 0 107 -49 107 -114c0 -118 -105 -186 -159 -186c-53 0 -70 20 -84 20c-7 0 -14 -3 -16 -9l-29 -86
 c-1 -2 -1 -5 -1 -7c0 -37 57 -18 57 -42c0 -7 -4 -14 -13 -14c-3 0 -50 5 -116 5s-112 -5 -115 -5c-9 0 -14 7 -14 14c0 31 87 -1 102 41l102 300c2 7 4 14 4 20c0 8 -2 14 -11 14c-33 0 -63 -60 -79 -97c-5 -12 -15 -17 -24 -17c-8 0 -14 4 -14 12z" fill="currentColor"/>
 </g>
@@ -355,183 +355,203 @@ c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18
 <g transform="translate(41.8143, 2.9812)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(0.0000, 17.8925)">
+<g transform="translate(0.0000, 19.8793)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
 </g>
-<g transform="translate(0.0000, 16.8925)">
+<g transform="translate(0.0000, 18.8793)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
 </g>
-<g transform="translate(0.0000, 15.8925)">
+<g transform="translate(0.0000, 17.8793)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
 </g>
-<g transform="translate(0.0000, 14.8925)">
+<g transform="translate(0.0000, 16.8793)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
 </g>
-<g transform="translate(0.0000, 13.8925)">
+<g transform="translate(0.0000, 15.8793)">
 <line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="0" x2="47.8207" y2="0"/>
 </g>
-<g transform="translate(0.0000, 11.8925)">
-<rect x="42.8329" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 12.8925)">
-<rect x="42.8329" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 12.8925)">
-<rect x="37.8245" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 12.8925)">
-<rect x="33.0661" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 12.8925)">
-<rect x="28.0577" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 12.8925)">
-<rect x="25.5534" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 12.8925)">
-<rect x="18.0408" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(0.0000, 12.8925)">
-<rect x="8.1750" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
-</g>
-<g transform="translate(47.6807, 15.8925)">
+<g transform="translate(47.6807, 17.8793)">
 <rect x="0.0000" y="-2.0000" width="0.1900" height="4.0000" ry="0.0000" fill="currentColor"/>
 </g>
-<g transform="translate(33.3921, 12.3925)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(0.0000, 13.8793)">
+<rect x="42.8329" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(33.4571, 15.8925)">
-<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(0.0000, 14.8793)">
+<rect x="42.8329" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(35.6463, 13.3925)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(0.0000, 14.8793)">
+<rect x="37.8245" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(35.7113, 15.8925)">
-<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(0.0000, 14.8793)">
+<rect x="33.0661" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(38.1506, 12.8925)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(0.0000, 14.8793)">
+<rect x="28.0577" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(38.2156, 15.8925)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8183" ry="0.0400" fill="currentColor"/>
+<g transform="translate(0.0000, 14.8793)">
+<rect x="25.5534" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(25.9445, 15.8925)">
-<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+<g transform="translate(0.0000, 14.8793)">
+<rect x="18.0408" y="-0.1000" width="1.9563" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(38.1506, 16.0825)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.3000 7.3526 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
+<g transform="translate(0.0000, 14.8793)">
+<rect x="8.1750" y="-0.1000" width="1.8053" height="0.2000" ry="0.1000" fill="currentColor"/>
 </g>
-<g transform="translate(38.1506, 16.8925)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.3000 7.3526 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(28.3837, 12.8925)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(28.4487, 15.8925)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(30.6379, 13.8925)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(30.7029, 15.8925)">
-<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(8.3500, 18.8925)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(8.3500, 19.7025)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(18.3669, 15.8925)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(18.3669, 16.7025)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(28.3837, 15.8925)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(28.3837, 16.7025)">
-<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
-</g>
-<g transform="translate(45.4782, 15.8925)">
-<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.8095" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(45.4132, 14.3925)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(43.2240, 15.8925)">
-<rect x="-0.0650" y="-3.8139" width="0.1300" height="5.1570" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(43.1590, 11.8925)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
-</g>
-<g transform="translate(40.4698, 15.8925)">
+<g transform="translate(40.4698, 17.8793)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.9708" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(40.4048, 13.8925)">
+<g transform="translate(35.6463, 15.3793)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(6.9000, 12.8925)">
+<g transform="translate(35.7113, 17.8793)">
+<rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(38.1506, 14.8793)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(38.2156, 17.8793)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.8183" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(40.4048, 15.8793)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(38.1506, 18.0693)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.3000 7.3526 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(38.1506, 18.8793)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.3000 7.3526 0.7000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(28.3837, 14.8793)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(28.4487, 17.8793)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(30.6379, 15.8793)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(30.7029, 17.8793)">
+<rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(33.3921, 14.3793)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(33.4571, 17.8793)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(8.3500, 17.8793)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6521 -4.0450C2.4395 -5.5061 8.8816 -5.5061 10.6690 -4.0450L10.6690 -4.0450C8.8816 -5.3861 2.4395 -5.3861 0.6521 -4.0450z"/>
+</g>
+<g transform="translate(8.3500, 20.8793)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(8.3500, 21.6893)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(27.3837, 21.2459)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="18.0795" y2="0.6666"/>
+</g>
+<g transform="translate(27.3837, 21.2459)">
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="18.0795" y2="-0.6666"/>
+</g>
+<g transform="translate(18.3669, 17.8793)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(18.3669, 18.6893)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(30.6379, 17.8793)">
+<path stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.6227 -3.5450C2.6842 -5.3265 13.1153 -6.0325 15.3980 -4.5450L15.3980 -4.5450C13.1234 -5.9128 2.6923 -5.2068 0.6227 -3.5450z"/>
+</g>
+<g transform="translate(28.3837, 17.8793)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(28.3837, 18.6893)">
+<polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 -0.2000 7.3526 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+</g>
+<g transform="translate(43.1590, 13.8793)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(43.3501, 12.4722)">
+<path transform="scale(0.0022, -0.0022)" d="M148 501c10 0 41 -15 72 -15c32 0 63 15 76 15c15 0 26 -11 26 -21c0 -4 -1 -7 -4 -10l-264 -291h134v4c0 60 50 41 75 85c7 11 8 24 14 36c3 7 10 10 17 10c11 0 24 -8 24 -25v-110h70c18 0 27 -14 27 -27s-9 -27 -27 -27h-70c2 -45 36 -82 80 -82c14 0 22 -10 22 -21
+s-8 -22 -22 -22c-49 0 -96 14 -145 14s-97 -14 -146 -14c-14 0 -21 11 -21 22s7 21 21 21c44 0 79 37 81 82h-134c-43 0 -57 25 -57 42c0 5 1 10 3 12c73 81 123 182 123 291c0 17 11 31 25 31z" fill="currentColor"/>
+</g>
+<g transform="translate(43.2240, 17.8793)">
+<rect x="-0.0650" y="-3.8139" width="0.1300" height="5.1570" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(45.4132, 16.3793)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(45.4782, 17.8793)">
+<rect x="-0.0650" y="-1.3139" width="0.1300" height="2.8095" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(6.9000, 14.8793)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(10.6042, 15.3925)">
+<g transform="translate(10.6042, 17.3793)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(10.6692, 15.8925)">
+<g transform="translate(10.6692, 17.8793)">
 <rect x="-0.0650" y="-0.3139" width="0.1300" height="4.4376" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(8.4150, 15.8925)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="6.6327" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(12.8584, 17.8925)">
+<g transform="translate(12.8584, 19.8793)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(25.8795, 12.3925)">
-<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+<g transform="translate(12.9234, 17.8793)">
+<rect x="-0.0650" y="2.1861" width="0.1300" height="2.2425" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(0.8000, 14.8925)">
+<g transform="translate(0.8000, 16.8793)">
 <path transform="scale(0.0040, -0.0040)" d="M557 -125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM557 125c0 28 23 51 51 51s51 -23 51 -51s-23 -51 -51 -51s-51 23 -51 51zM232 263c172 0 293 -88 293 -251c0 -263 -263 -414 -516 -521c-3 -3 -6 -4 -9 -4c-7 0 -13 6 -13 13c0 3 1 6 4 9
 c202 118 412 265 412 493c0 120 -63 235 -171 235c-74 0 -129 -54 -154 -126c11 5 22 8 34 8c55 0 100 -45 100 -100c0 -58 -44 -106 -100 -106c-60 0 -112 47 -112 106c0 133 102 244 232 244z" fill="currentColor"/>
 </g>
-<g transform="translate(4.3000, 14.8925)">
+<g transform="translate(4.3000, 16.8793)">
 <path transform="scale(0.0040, -0.0040)" d="M0 119c0 8 5 15 13 18l46 17v158c0 10 8 19 18 19s19 -9 19 -19v-145l83 31v158c0 10 9 19 19 19s18 -9 18 -19v-145l32 12c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -16 -13 -19l-46 -16v-160l32 11c2 1 5 1 7 1c11 0 20 -9 20 -20v-60c0 -8 -5 -15 -13 -18l-46 -17
 v-158c0 -10 -8 -19 -18 -19s-19 9 -19 19v145l-83 -31v-158c0 -10 -9 -19 -19 -19s-18 9 -18 19v145l-32 -12c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60c0 8 5 16 13 19l46 16v160l-32 -11c-2 -1 -5 -1 -7 -1c-11 0 -20 9 -20 20v60zM179 95l-83 -30v-160l83 30v160z" fill="currentColor"/>
 </g>
-<g transform="translate(-2.2535, 12.8178)">
+<g transform="translate(-2.2535, 14.8046)">
 <text font-family="serif" font-size="1.7459" text-anchor="start" fill="currentColor">
 <tspan>10</tspan>
 </text>
 </g>
-<g transform="translate(12.9234, 15.8925)">
-<rect x="-0.0650" y="2.1861" width="0.1300" height="2.2425" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(8.3500, 12.8925)">
+<g transform="translate(8.3500, 14.8793)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.3669, 12.8925)">
+<g transform="translate(8.4150, 17.8793)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="6.6327" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(15.6126, 17.3793)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(20.6861, 15.8925)">
+<g transform="translate(20.5391, 21.6974)">
+<path transform="scale(0.0040, -0.0040)" d="M161 32c78 0 97 176 97 178c0 18 -7 33 -25 33c-61 0 -102 -124 -102 -173c0 -22 8 -38 30 -38zM-53 141c0 2 51 151 134 151c35 0 59 -21 66 -52c29 31 67 52 103 52c69 0 107 -49 107 -114c0 -118 -105 -186 -159 -186c-53 0 -70 20 -84 20c-7 0 -14 -3 -16 -9l-29 -86
+c-1 -2 -1 -5 -1 -7c0 -37 57 -18 57 -42c0 -7 -4 -14 -13 -14c-3 0 -50 5 -116 5s-112 -5 -115 -5c-9 0 -14 7 -14 14c0 31 87 -1 102 41l102 300c2 7 4 14 4 20c0 8 -2 14 -11 14c-33 0 -63 -60 -79 -97c-5 -12 -15 -17 -24 -17c-8 0 -14 4 -14 12z" fill="currentColor"/>
+</g>
+<g transform="translate(20.6861, 17.8793)">
 <rect x="-0.0650" y="-1.8139" width="0.1300" height="2.6239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(20.6211, 13.8925)">
+<g transform="translate(20.6211, 15.8793)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(23.1253, 13.3925)">
+<g transform="translate(23.1253, 15.3793)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
 </g>
-<g transform="translate(18.4319, 15.8925)">
-<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(23.1903, 15.8925)">
+<g transform="translate(23.1903, 17.8793)">
 <rect x="-0.0650" y="-2.3139" width="0.1300" height="3.1239" ry="0.0400" fill="currentColor"/>
 </g>
-<g transform="translate(15.6776, 15.8925)">
-<rect x="-0.0650" y="-0.3139" width="0.1300" height="5.1151" ry="0.0400" fill="currentColor"/>
-</g>
-<g transform="translate(15.6126, 15.3925)">
+<g transform="translate(25.8795, 14.3793)">
 <path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(25.9445, 17.8793)">
+<rect x="-0.0650" y="-3.3139" width="0.1300" height="4.1239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(18.4319, 17.8793)">
+<rect x="-0.0650" y="-2.8139" width="0.1300" height="3.6239" ry="0.0400" fill="currentColor"/>
+</g>
+<g transform="translate(18.3669, 14.8793)">
+<path transform="scale(0.0040, -0.0040)" d="M218 136c66 0 108 -36 108 -89c0 -89 -113 -183 -218 -183c-66 0 -108 36 -108 89c0 89 113 183 218 183z" fill="currentColor"/>
+</g>
+<g transform="translate(15.6776, 17.8793)">
+<rect x="-0.0650" y="-0.3139" width="0.1300" height="5.1151" ry="0.0400" fill="currentColor"/>
 </g>
 </svg>

--- a/tools/scores/allemande.ly
+++ b/tools/scores/allemande.ly
@@ -25,7 +25,7 @@ allemande = \absolute {
     \revert DynamicLineSpanner.staff-padding fis8\>( d16\p) e16 fis16( d16) g16\< e16 fis16( d16) fis16 g16 \once \set fingeringOrientations = #'(up) a16-1( b16 c'16) a16\! |
     b16\p( d16-1 g,16-1 d16 b16) g16-2 a16 fis16 g16\< e16( g16 a16 b16 cis'16 d'16 \once \override DynamicText.extra-offset = #'(1.5 . 0) b16)\mf |
     \barNumberCheck #10
-    cis'16 e16 g,16 e16 cis'16 a16 b16 d'16 cis'16 a16 d'16 b16 cis'16 a16 e'16 g16 |
+    cis'16( e16 g,16 e16 cis'16) a16\p b16 d'16 cis'16\< a16( d'16 b16 cis'16 a16 e'16-4\! g16) |
     fis8.\trill d'16 a16 g16 fis16 e16 d16 a16 g16 e16 fis16 d16 a16 c16 |
     b,8.\trill g16 d16 c16 b,16 a,16 g,16 d16 c16 a,16 b,16 g,16 d16 fis,16 |
     e,16 g,16 a,16 b,16 cis16 d16 e16 fis16 g16 a16 cis'16 d'16 e'16 a16 g'8 |

--- a/tools/scores/build_scores.py
+++ b/tools/scores/build_scores.py
@@ -55,7 +55,11 @@ def make_ly(start, end):
     \\set Timing.beatStructure = #'(4 4 4 4)
 {body}
   }}
-  \\layout {{ }}
+  \\layout {{
+    % Project standard: hairpins begin just before their first note and end
+    % just after their last note (negative shorten-pair lengthens each end).
+    \\override Hairpin.shorten-pair = #'(-1 . -1)
+  }}
 }}
 '''
 


### PR DESCRIPTION
## Summary
- m.10: slurs over notes 1-5 and 10-16; fingering 4 on note 15; `p` on note 6; crescendo under notes 9-15.
- New project standard: hairpins begin just before their first note and end just after their last note. Enforced globally via `Hairpin.shorten-pair = #'(-1 . -1)` in `build_scores.py`'s layout, and documented in the `score-workflow` skill.
- Rebuilds the existing hairpin loops (mm 6-8, mm 8-10) so they match the new standard.

## Test plan
- [x] `build_scores.py` clean; changed only the loops with hairpins (`mm-6-8`, `mm-8-10`, `mm-10-12`).
- [x] Rendered mm. 8-10 and mm. 10-12: hairpins extend just past their end notes; dynamics-terminated hairpins (m8 `>`→`p`, m9 `<`→`mf`) don't collide.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_