### PR TITLE
Allemande m.10: extend crescendo to note 16

### DIFF
--- a/scores/allemande/mm-10-12.svg
+++ b/scores/allemande/mm-10-12.svg
@@ -130,10 +130,10 @@ c-11 7 -24 11 -38 11s-29 -4 -43 -11l54 270v7c0 16 -12 26 -29 26c-7 0 -16 -3 -24 
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="8.9194 0.9900 8.9194 1.3900 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
 <g transform="translate(31.5618, 9.9451)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="21.2130" y2="0.6666"/>
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="23.9895" y2="0.6666"/>
 </g>
 <g transform="translate(31.5618, 9.9451)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="21.2130" y2="-0.6666"/>
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="23.9895" y2="-0.6666"/>
 </g>
 <g transform="translate(20.4559, 6.5785)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="9.1694 -0.2000 9.1694 0.2000 0.0400 0.2000 0.0400 -0.2000"/>

--- a/scores/allemande/mm-8-10.svg
+++ b/scores/allemande/mm-8-10.svg
@@ -449,10 +449,10 @@ c-5 -10 -14 -15 -23 -15c-14 0 -28 12 -28 27c0 4 1 8 3 13l129 250c2 4 7 6 11 6c18
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.3526 0.8000 7.3526 1.2000 0.0400 0.2000 0.0400 -0.2000"/>
 </g>
 <g transform="translate(27.3837, 21.2459)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="18.0795" y2="0.6666"/>
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="0.0000" x2="20.3337" y2="0.6666"/>
 </g>
 <g transform="translate(27.3837, 21.2459)">
-<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="18.0795" y2="-0.6666"/>
+<line stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0000" y1="-0.0000" x2="20.3337" y2="-0.6666"/>
 </g>
 <g transform="translate(18.3669, 17.8793)">
 <polygon stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="7.6026 -0.2000 7.6026 0.2000 0.0400 0.2000 0.0400 -0.2000"/>

--- a/tools/scores/allemande.ly
+++ b/tools/scores/allemande.ly
@@ -25,7 +25,7 @@ allemande = \absolute {
     \revert DynamicLineSpanner.staff-padding fis8\>( d16\p) e16 fis16( d16) g16\< e16 fis16( d16) fis16 g16 \once \set fingeringOrientations = #'(up) a16-1( b16 c'16) a16\! |
     b16\p( d16-1 g,16-1 d16 b16) g16-2 a16 fis16 g16\< e16( g16 a16 b16 cis'16 d'16 \once \override DynamicText.extra-offset = #'(1.5 . 0) b16)\mf |
     \barNumberCheck #10
-    cis'16( e16 g,16 e16 cis'16) a16\p b16 d'16 cis'16\< a16( d'16 b16 cis'16 a16 e'16-4\! g16) |
+    cis'16( e16 g,16 e16 cis'16) a16\p b16 d'16 cis'16\< a16( d'16 b16 cis'16 a16 e'16-4 g16)\! |
     fis8.\trill d'16 a16 g16 fis16 e16 d16 a16 g16 e16 fis16 d16 a16 c16 |
     b,8.\trill g16 d16 c16 b,16 a,16 g,16 d16 c16 a,16 b,16 g,16 d16 fis,16 |
     e,16 g,16 a,16 b,16 cis16 d16 e16 fis16 g16 a16 cis'16 d'16 e'16 a16 g'8 |


### PR DESCRIPTION
## Summary
- m.10: extend the crescendo to end at note 16 (was note 15). Fingering 4 stays on note 15.

## Test plan
- [x] `build_scores.py` clean; only `mm-8-10` and `mm-10-12` changed.
- [x] Rendered mm. 10-12: crescendo now reaches just past the final note.

https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUzshUfUnrJKrfQPURGSA)_