### PR TITLE
Add virtual keyboard page

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -223,5 +223,125 @@ const AudioKit = (() => {
     };
   }
 
-  return { FIFTH_RATIO, midiToFreq, pitchToMidi, midiToName, playSequence, stopSequence, currentTime, createDrone };
+  // Polyphonic, press-and-hold synth for the virtual keyboard. Two timbres:
+  // 'piano' (struck string: bright attack, decaying tail) and 'cello' (bowed:
+  // sustained, reuses the shared cello voice). With the fifth toggle on, every
+  // note also sounds the pitch seven semitones above — a *tempered* fifth
+  // (equal-tempered, ratio 2^(7/12) ≈ 1.498), not the just 3:2 the drone uses.
+  function createPolySynth() {
+    let ctx = null, master = null;
+    let instrument = 'piano';
+    let fifthOn = false;
+    let pianoWave = null;
+    // midi -> { count, voices }. count tracks how many inputs (pointers, keys)
+    // are holding the note so overlapping presses don't cut each other off.
+    const held = new Map();
+
+    function ensure() {
+      if (!ctx) {
+        ctx = new (window.AudioContext || window.webkitAudioContext)();
+        master = ctx.createGain();
+        master.gain.value = 0.85;
+        // Soft knee so dense chords don't clip.
+        const comp = ctx.createDynamicsCompressor();
+        master.connect(comp);
+        comp.connect(ctx.destination);
+      }
+      if (ctx.state === 'suspended') { try { ctx.resume(); } catch (e) {} }
+      return ctx;
+    }
+
+    function getPianoWave() {
+      if (!pianoWave) {
+        const real = new Float32Array([0, 1, 0.62, 0.42, 0.28, 0.19, 0.13, 0.09, 0.06, 0.04, 0.028, 0.02]);
+        pianoWave = ctx.createPeriodicWave(real, new Float32Array(real.length));
+      }
+      return pianoWave;
+    }
+
+    function pianoVoice(freq, now) {
+      const osc = ctx.createOscillator();
+      osc.setPeriodicWave(getPianoWave());
+      osc.frequency.value = freq;
+      const lp = ctx.createBiquadFilter();
+      lp.type = 'lowpass'; lp.frequency.value = Math.min(freq * 7 + 800, 12000); lp.Q.value = 0.4;
+      const gain = ctx.createGain();
+      const peak = 0.22;
+      gain.gain.setValueAtTime(0.0001, now);
+      gain.gain.linearRampToValueAtTime(peak, now + 0.005);
+      gain.gain.exponentialRampToValueAtTime(peak * 0.3, now + 0.5);
+      gain.gain.setTargetAtTime(0.0001, now + 0.5, 2.5); // slow tail while held
+      osc.connect(lp); lp.connect(gain); gain.connect(master);
+      osc.start(now);
+      return { gain, oscs: [osc], release: 0.18 };
+    }
+
+    function celloVoice(freq, now) {
+      const osc = ctx.createOscillator();
+      osc.type = 'sawtooth'; osc.frequency.value = freq;
+      const voice = celloFilters(ctx);
+      const gain = ctx.createGain();
+      const peak = 0.16;
+      gain.gain.setValueAtTime(0.0001, now);
+      gain.gain.linearRampToValueAtTime(peak, now + 0.09);       // bow attack
+      gain.gain.setTargetAtTime(peak * 0.82, now + 0.09, 0.4);   // settle to sustain
+      const lfo = ctx.createOscillator();
+      const lfoGain = ctx.createGain();
+      lfo.frequency.value = 5;
+      lfoGain.gain.setValueAtTime(0.0001, now);
+      lfoGain.gain.linearRampToValueAtTime(freq * 0.006, now + 0.6); // vibrato fades in
+      lfo.connect(lfoGain); lfoGain.connect(osc.frequency);
+      osc.connect(voice.input); voice.output.connect(gain); gain.connect(master);
+      osc.start(now); lfo.start(now);
+      return { gain, oscs: [osc, lfo], release: 0.15 };
+    }
+
+    function makeVoice(midi) {
+      const freq = midiToFreq(midi);
+      const now = ctx.currentTime;
+      return instrument === 'cello' ? celloVoice(freq, now) : pianoVoice(freq, now);
+    }
+
+    function stopVoice(v) {
+      const t = ctx.currentTime;
+      try {
+        v.gain.gain.cancelScheduledValues(t);
+        if (v.gain.gain.cancelAndHoldAtTime) v.gain.gain.cancelAndHoldAtTime(t);
+        else v.gain.gain.setValueAtTime(Math.max(v.gain.gain.value, 0.0001), t);
+        v.gain.gain.setTargetAtTime(0.0001, t, v.release);
+        const end = t + v.release * 8 + 0.1;
+        v.oscs.forEach(o => { try { o.stop(end); } catch (e) {} });
+      } catch (e) {}
+    }
+
+    function noteOn(midi) {
+      ensure();
+      const entry = held.get(midi);
+      if (entry) { entry.count++; return; }
+      const voices = [makeVoice(midi)];
+      if (fifthOn) voices.push(makeVoice(midi + 7)); // tempered fifth: +7 semitones
+      held.set(midi, { count: 1, voices });
+    }
+
+    function noteOff(midi) {
+      const entry = held.get(midi);
+      if (!entry) return;
+      if (--entry.count > 0) return;
+      entry.voices.forEach(stopVoice);
+      held.delete(midi);
+    }
+
+    function allOff() {
+      held.forEach(entry => entry.voices.forEach(stopVoice));
+      held.clear();
+    }
+
+    return {
+      noteOn, noteOff, allOff,
+      setInstrument(name) { instrument = name === 'cello' ? 'cello' : 'piano'; },
+      setFifth(on) { fifthOn = !!on; },
+    };
+  }
+
+  return { FIFTH_RATIO, midiToFreq, pitchToMidi, midiToName, playSequence, stopSequence, currentTime, createDrone, createPolySynth };
 })();

--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
         // Special pages
         const extras = [
           { href: 'scales.html', title: 'scales' },
+          { href: 'keyboard.html', title: 'keyboard' },
           { href: 'john.html', title: 'john' },
         ];
 

--- a/keyboard.html
+++ b/keyboard.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>keyboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      background: #000;
+      color: #fff;
+      font-family: "Cormorant Garamond", serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+      padding: 2.5rem 1rem 4rem;
+      box-sizing: border-box;
+    }
+    a { color: #9cd8ff; }
+    .back {
+      position: fixed;
+      top: 1rem;
+      left: 1rem;
+      font-size: 1rem;
+      color: #666;
+      text-decoration: none;
+    }
+    .back:hover { color: #d8d8ff; }
+
+    h1 {
+      margin: 0;
+      font-size: 2.2rem;
+      font-weight: 500;
+      letter-spacing: 0.06em;
+      text-transform: lowercase;
+    }
+    .hint {
+      margin: -0.5rem 0 0;
+      font-size: 1rem;
+      color: rgba(255, 255, 255, 0.5);
+      font-style: italic;
+      text-align: center;
+    }
+
+    .now {
+      font-size: 1.5rem;
+      letter-spacing: 0.04em;
+      min-height: 1.5em;
+      color: #9cd8ff;
+    }
+
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 0.7rem 1.4rem;
+      font-size: 0.95rem;
+      color: rgba(255, 255, 255, 0.6);
+    }
+    .ctl { display: inline-flex; align-items: center; gap: 0.5em; }
+    .ctl select {
+      background: #000;
+      border: 1px solid #666;
+      color: #ddd;
+      font-family: inherit;
+      font-size: 0.95rem;
+      padding: 0.2em 0.35em;
+    }
+    .ctl select:hover { border-color: #9cd8ff; }
+
+    .switch {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45em;
+      cursor: pointer;
+      user-select: none;
+    }
+    .switch input { position: absolute; opacity: 0; width: 0; height: 0; }
+    .switch .track {
+      width: 2.4em;
+      height: 1.2em;
+      border: 1px solid #666;
+      border-radius: 1em;
+      position: relative;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .switch .thumb {
+      position: absolute;
+      top: 50%;
+      left: 0.15em;
+      width: 0.9em;
+      height: 0.9em;
+      transform: translateY(-50%);
+      background: #ddd;
+      border-radius: 50%;
+      transition: left 0.15s, background 0.15s;
+    }
+    .switch input:checked + .track { background: #2f6f8f; border-color: #9cd8ff; }
+    .switch input:checked + .track .thumb { left: calc(100% - 1.05em); background: #9cd8ff; }
+
+    .kbd-wrap {
+      width: 100%;
+      max-width: 960px;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+    .keyboard {
+      display: flex;
+      align-items: flex-start;
+      height: 180px;
+      min-width: min-content;
+      margin: 0 auto;
+      touch-action: none;
+    }
+    .key { position: relative; box-sizing: border-box; }
+    .white {
+      flex: 1 0 34px;
+      height: 100%;
+      background: linear-gradient(#fafafa, #e6e6e6);
+      border: 1px solid #2a2a2a;
+      border-radius: 0 0 5px 5px;
+      display: flex;
+      align-items: flex-end;
+      justify-content: center;
+    }
+    .black {
+      position: absolute;
+      top: 0;
+      right: -32%;
+      width: 64%;
+      height: 62%;
+      background: linear-gradient(#2a2a2a, #000);
+      border: 1px solid #000;
+      border-radius: 0 0 4px 4px;
+      z-index: 2;
+    }
+    .white.on { background: linear-gradient(#bfe6ff, #9cd8ff); }
+    .black.on { background: linear-gradient(#6fb4d6, #2f6f8f); }
+    .label {
+      font-size: 0.72rem;
+      color: #777;
+      pointer-events: none;
+      padding-bottom: 7px;
+      display: none;
+    }
+    .label.tonic { display: block; color: #555; }
+    .keyboard.show-labels .label { display: block; }
+
+    @media (max-width: 600px) {
+      .keyboard { height: 150px; }
+      .white { flex: 1 0 26px; }
+    }
+  </style>
+</head>
+<body>
+  <a class="back" href="index.html">← back</a>
+
+  <h1>keyboard</h1>
+  <p class="hint">click, tap, or play with your computer keyboard (a&ndash;k row); z / x shift octave</p>
+
+  <div class="controls">
+    <label class="ctl">
+      range
+      <select id="range">
+        <option value="1">1 octave</option>
+        <option value="2" selected>2 octaves</option>
+        <option value="3">3 octaves</option>
+        <option value="4">4 octaves</option>
+        <option value="5">5 octaves</option>
+        <option value="6">6 octaves</option>
+        <option value="7">7 octaves</option>
+        <option value="full">full (88 keys)</option>
+      </select>
+    </label>
+    <label class="ctl">
+      tone
+      <select id="tone">
+        <option value="piano" selected>piano</option>
+        <option value="cello">cello</option>
+      </select>
+    </label>
+    <label class="switch">
+      <input id="fifth" type="checkbox">
+      <span class="track"><span class="thumb"></span></span>
+      add 5th
+    </label>
+    <label class="switch">
+      <input id="labels" type="checkbox">
+      <span class="track"><span class="thumb"></span></span>
+      note names
+    </label>
+  </div>
+
+  <div class="now" id="now">&nbsp;</div>
+
+  <div class="kbd-wrap">
+    <div class="keyboard" id="keyboard"></div>
+  </div>
+
+  <script src="audio.js"></script>
+  <script src="keyboard.js"></script>
+</body>
+</html>

--- a/keyboard.js
+++ b/keyboard.js
@@ -1,0 +1,165 @@
+// Virtual keyboard page. Renders a piano (white keys flex-laid-out, black keys
+// straddling the boundary between them) over a selectable range, and drives the
+// polyphonic synth in audio.js. Plays with mouse/touch (glissando + multitouch)
+// or the computer keyboard. Range, timbre (piano/cello), the tempered-fifth
+// toggle, and note-name labels are all live.
+
+const synth = AudioKit.createPolySynth();
+const kbd = document.getElementById('keyboard');
+const now = document.getElementById('now');
+
+// Low..high MIDI (inclusive), all starting/ending on C except the 88-key full
+// range (A0–C8). Larger ranges grow downward then upward around middle C.
+const RANGES = {
+  '1': [60, 72],   // C4–C5
+  '2': [48, 72],   // C3–C5
+  '3': [48, 84],   // C3–C6
+  '4': [36, 84],   // C2–C6
+  '5': [36, 96],   // C2–C7
+  '6': [24, 96],   // C1–C7
+  '7': [24, 108],  // C1–C8
+  'full': [21, 108], // A0–C8, 88 keys
+};
+
+const WHITE_PCS = new Set([0, 2, 4, 5, 7, 9, 11]);
+const pcOf = m => ((m % 12) + 12) % 12;
+
+function noteLabel(midi) {
+  return AudioKit.midiToName(midi, false) + (Math.floor(midi / 12) - 1);
+}
+
+let lowMidi = 48, highMidi = 72;
+
+function build(rangeKey) {
+  [lowMidi, highMidi] = RANGES[rangeKey] || RANGES['2'];
+  kbd.innerHTML = '';
+  for (let m = lowMidi; m <= highMidi; m++) {
+    if (!WHITE_PCS.has(pcOf(m))) continue; // black keys are added as children below
+    const white = document.createElement('div');
+    white.className = 'key white';
+    white.dataset.midi = m;
+    const label = document.createElement('span');
+    label.className = 'label';
+    const name = AudioKit.midiToName(m, false);
+    label.textContent = name === 'C' ? noteLabel(m) : name;
+    if (name === 'C') label.classList.add('tonic');
+    white.appendChild(label);
+    // Black key immediately to the right of this white, if any and in range.
+    const bm = m + 1;
+    if (bm <= highMidi && !WHITE_PCS.has(pcOf(bm))) {
+      const black = document.createElement('div');
+      black.className = 'key black';
+      black.dataset.midi = bm;
+      white.appendChild(black);
+    }
+    kbd.appendChild(white);
+  }
+}
+
+function keyEl(midi) {
+  return kbd.querySelector('.key[data-midi="' + midi + '"]');
+}
+
+function press(midi) {
+  synth.noteOn(midi);
+  const el = keyEl(midi);
+  if (el) el.classList.add('on');
+  now.textContent = noteLabel(midi);
+}
+
+function lift(midi) {
+  synth.noteOff(midi);
+  const el = keyEl(midi);
+  if (el) el.classList.remove('on');
+}
+
+// --- Pointer (mouse / touch) input -----------------------------------------
+// Track the key each active pointer is currently over so dragging across keys
+// glides (note-off the old, note-on the new). Capture keeps moves flowing even
+// when the finger leaves the key it started on.
+const pointers = new Map(); // pointerId -> midi (or null)
+
+function midiFromPoint(x, y) {
+  const el = document.elementFromPoint(x, y);
+  const key = el && el.closest('.key');
+  if (!key || !kbd.contains(key)) return null;
+  return parseInt(key.dataset.midi, 10);
+}
+
+kbd.addEventListener('pointerdown', e => {
+  e.preventDefault();
+  try { kbd.setPointerCapture(e.pointerId); } catch (_) {}
+  const midi = midiFromPoint(e.clientX, e.clientY);
+  pointers.set(e.pointerId, midi);
+  if (midi != null) press(midi);
+});
+
+kbd.addEventListener('pointermove', e => {
+  if (!pointers.has(e.pointerId)) return;
+  const prev = pointers.get(e.pointerId);
+  const midi = midiFromPoint(e.clientX, e.clientY);
+  if (midi === prev) return;
+  if (prev != null) lift(prev);
+  if (midi != null) press(midi);
+  pointers.set(e.pointerId, midi);
+});
+
+function endPointer(e) {
+  if (!pointers.has(e.pointerId)) return;
+  const prev = pointers.get(e.pointerId);
+  if (prev != null) lift(prev);
+  pointers.delete(e.pointerId);
+  try { kbd.releasePointerCapture(e.pointerId); } catch (_) {}
+}
+kbd.addEventListener('pointerup', endPointer);
+kbd.addEventListener('pointercancel', endPointer);
+
+// --- Computer keyboard input ------------------------------------------------
+const KEYMAP = {
+  a: 60, w: 61, s: 62, e: 63, d: 64, f: 65,
+  t: 66, g: 67, y: 68, h: 69, u: 70, j: 71, k: 72, o: 73, l: 74,
+};
+let transpose = 0;
+const downKeys = new Map(); // key char -> the midi that was actually sounded
+
+window.addEventListener('keydown', e => {
+  if (e.metaKey || e.ctrlKey || e.altKey) return;
+  const k = e.key.toLowerCase();
+  if (k === 'z') { transpose -= 12; return; }
+  if (k === 'x') { transpose += 12; return; }
+  if (!(k in KEYMAP) || downKeys.has(k)) return;
+  const midi = KEYMAP[k] + transpose;
+  downKeys.set(k, midi);
+  press(midi);
+});
+
+window.addEventListener('keyup', e => {
+  const k = e.key.toLowerCase();
+  if (!downKeys.has(k)) return;
+  lift(downKeys.get(k));
+  downKeys.delete(k);
+});
+
+// Silence everything if the page loses focus mid-press.
+window.addEventListener('blur', () => {
+  pointers.clear();
+  downKeys.clear();
+  synth.allOff();
+  kbd.querySelectorAll('.key.on').forEach(el => el.classList.remove('on'));
+});
+
+// --- Controls ---------------------------------------------------------------
+document.getElementById('range').addEventListener('change', e => {
+  synth.allOff();
+  build(e.target.value);
+});
+document.getElementById('tone').addEventListener('change', e => {
+  synth.allOff();
+  synth.setInstrument(e.target.value);
+});
+document.getElementById('fifth').addEventListener('change', e => synth.setFifth(e.target.checked));
+document.getElementById('labels').addEventListener('change', e => {
+  kbd.classList.toggle('show-labels', e.target.checked);
+});
+
+build('2');


### PR DESCRIPTION
## Summary

A playable piano keyboard page, linked from the home index between `scales` and `john`.

- **range** — `1 octave` (C4–C5) up through `7 octaves`, plus `full (88 keys)` (A0–C8)
- **tone** — `piano` (struck-string: bright attack + decaying tail) or `cello` (bowed/sustained, reusing the site's existing cello voice with gentle vibrato)
- **add 5th** — sounds a **tempered** fifth (+7 equal-tempered semitones, ≈1.498), explicitly *not* the just 3:2 fifth the drone uses
- **note names** — toggles key labels (C keys always show their octave)
- input via mouse/touch (glissando + multitouch) or the computer keyboard (`a`–`k` row; `z`/`x` shift octave)
- adds a refcounted polyphonic synth (`createPolySynth`) to the shared `audio.js` engine, with a soft-knee compressor to avoid clipping on chords

## Test plan

- [x] Headless (jsdom) check of key generation across every range, including 52 white / 36 black = 88 for the full keyboard, black keys nested between the correct whites
- [x] Headless check that the "add 5th" toggle adds exactly one voice at +7 semitones and is distinct from the just 3:2 fifth
- [ ] Live browser check: black-key placement/appearance, audio playback for piano and cello, multitouch + glissando, computer-keyboard input

https://claude.ai/code/session_01Lj13PPExCGxKV1L93ZFjA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj13PPExCGxKV1L93ZFjA9)_