### PR TITLE
Add pitch ear-training game to the keyboard page

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -336,8 +336,32 @@ const AudioKit = (() => {
       held.clear();
     }
 
+    // Game-show "wrong answer" buzzer: two clashing detuned saws that slide
+    // down at the end for that deflating "ahhght".
+    function buzzer() {
+      ensure();
+      const t = ctx.currentTime;
+      const lp = ctx.createBiquadFilter();
+      lp.type = 'lowpass'; lp.frequency.value = 1100; lp.Q.value = 1;
+      const g = ctx.createGain();
+      g.gain.setValueAtTime(0.0001, t);
+      g.gain.linearRampToValueAtTime(0.3, t + 0.02);
+      g.gain.setValueAtTime(0.3, t + 0.32);
+      g.gain.exponentialRampToValueAtTime(0.0001, t + 0.55);
+      lp.connect(g); g.connect(master);
+      [150, 159].forEach(f0 => {
+        const o = ctx.createOscillator();
+        o.type = 'sawtooth';
+        o.frequency.setValueAtTime(f0, t);
+        o.frequency.setValueAtTime(f0, t + 0.3);
+        o.frequency.linearRampToValueAtTime(f0 * 0.85, t + 0.55);
+        o.connect(lp);
+        o.start(t); o.stop(t + 0.6);
+      });
+    }
+
     return {
-      noteOn, noteOff, allOff,
+      noteOn, noteOff, allOff, buzzer,
       setInstrument(name) { instrument = name === 'cello' ? 'cello' : 'piano'; },
       setFifth(on) { fifthOn = !!on; },
     };

--- a/keyboard.html
+++ b/keyboard.html
@@ -156,6 +156,43 @@
       .keyboard { height: 150px; }
       .white { flex: 1 0 26px; }
     }
+
+    .test {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 0.7rem 1rem;
+      font-size: 0.95rem;
+    }
+    button {
+      background: none;
+      border: 1px solid #666;
+      color: #ddd;
+      font-family: inherit;
+      font-size: 1rem;
+      padding: 0.4em 0.8em;
+      cursor: pointer;
+    }
+    button:hover { border-color: #9cd8ff; color: #fff; }
+    .test-msg { color: rgba(255, 255, 255, 0.7); font-style: italic; }
+    .test-msg.win { color: #8cff9c; font-style: normal; }
+    .test-msg.lose { color: #ff7a9c; font-style: normal; }
+    .test-score { color: #9cd8ff; }
+
+    .confetti { position: fixed; inset: 0; pointer-events: none; overflow: hidden; z-index: 50; }
+    .confetti i {
+      position: absolute;
+      top: -5vh;
+      width: 8px;
+      height: 13px;
+      background: var(--c);
+      opacity: 0.9;
+      animation: confetti-fall linear forwards;
+    }
+    @keyframes confetti-fall {
+      to { transform: translate(var(--dx), 110vh) rotate(var(--rot)); opacity: 0.5; }
+    }
   </style>
 </head>
 <body>
@@ -201,6 +238,13 @@
 
   <div class="kbd-wrap">
     <div class="keyboard" id="keyboard"></div>
+  </div>
+
+  <div class="test">
+    <button id="test-btn" type="button">test my pitch</button>
+    <button id="replay-btn" type="button" hidden>replay</button>
+    <span id="test-msg" class="test-msg"></span>
+    <span id="test-score" class="test-score"></span>
   </div>
 
   <script src="audio.js"></script>

--- a/keyboard.js
+++ b/keyboard.js
@@ -61,6 +61,7 @@ function keyEl(midi) {
 }
 
 function press(midi) {
+  if (awaitingGuess) guess(midi); // first press during a pitch test is the answer
   synth.noteOn(midi);
   const el = keyEl(midi);
   if (el) el.classList.add('on');
@@ -161,5 +162,74 @@ document.getElementById('fifth').addEventListener('change', e => synth.setFifth(
 document.getElementById('labels').addEventListener('change', e => {
   kbd.classList.toggle('show-labels', e.target.checked);
 });
+
+// --- Pitch test (ear training) ----------------------------------------------
+// Play a random pitch from the current range; the first key the player presses
+// is their guess. Right note name (any octave) = confetti; wrong = buzzer.
+const testBtn = document.getElementById('test-btn');
+const replayBtn = document.getElementById('replay-btn');
+const testMsg = document.getElementById('test-msg');
+const testScore = document.getElementById('test-score');
+
+let targetMidi = null;
+let awaitingGuess = false;
+let correct = 0, total = 0;
+let playTimer = null;
+
+function playTarget() {
+  clearTimeout(playTimer);
+  synth.noteOff(targetMidi);
+  synth.noteOn(targetMidi);
+  playTimer = setTimeout(() => synth.noteOff(targetMidi), 1300);
+}
+
+function startRound() {
+  targetMidi = lowMidi + Math.floor(Math.random() * (highMidi - lowMidi + 1));
+  awaitingGuess = true;
+  testMsg.textContent = 'listen, then press the key you heard';
+  testMsg.className = 'test-msg';
+  replayBtn.hidden = false;
+  testBtn.textContent = 'new note';
+  playTarget();
+}
+
+function guess(midi) {
+  awaitingGuess = false;
+  total++;
+  const answer = AudioKit.midiToName(targetMidi, false);
+  if (pcOf(midi) === pcOf(targetMidi)) {
+    correct++;
+    testMsg.textContent = 'correct — it was ' + answer;
+    testMsg.className = 'test-msg win';
+    confetti();
+  } else {
+    testMsg.textContent = 'nope — that was ' + AudioKit.midiToName(midi, false) + ', it was ' + answer;
+    testMsg.className = 'test-msg lose';
+    synth.buzzer();
+  }
+  replayBtn.hidden = true;
+  testScore.textContent = 'score: ' + Math.round(correct / total * 100) + '% (' + correct + '/' + total + ')';
+}
+
+function confetti() {
+  const colors = ['#9cd8ff', '#ffd86f', '#ff7a9c', '#8cff9c', '#c89cff', '#ffffff'];
+  const box = document.createElement('div');
+  box.className = 'confetti';
+  for (let i = 0; i < 80; i++) {
+    const p = document.createElement('i');
+    p.style.setProperty('--c', colors[i % colors.length]);
+    p.style.setProperty('--dx', (Math.random() * 2 - 1) * 30 + 'vw');
+    p.style.setProperty('--rot', Math.round(Math.random() * 720 - 360) + 'deg');
+    p.style.left = Math.random() * 100 + 'vw';
+    p.style.animationDelay = Math.random() * 0.2 + 's';
+    p.style.animationDuration = 1.2 + Math.random() * 0.9 + 's';
+    box.appendChild(p);
+  }
+  document.body.appendChild(box);
+  setTimeout(() => box.remove(), 2400);
+}
+
+testBtn.addEventListener('click', startRound);
+replayBtn.addEventListener('click', playTarget);
 
 build('2');


### PR DESCRIPTION
## Summary

Adds a "test my pitch" ear-training game below the virtual keyboard.

- **test my pitch** plays a random pitch from the current range and prompts for the key you heard; a **replay** button re-plays it
- the first key pressed is the guess — correct **note name (any octave)** rains confetti, a wrong one plays a deflating buzzer
- a running **score percentage** (`score: 67% (2/3)`) accumulates across rounds
- adds a `buzzer()` sound to the shared synth in `audio.js`

Matching is by pitch class (note name), not exact octave — absolute-octave identification by ear is unreasonably hard, and on a 1-octave range the two are identical anyway.

## Test plan

- [x] Headless (jsdom) game-flow check: round start shows prompt + replay; correct guess → win styling, confetti (80 pieces), score `100% (1/1)`; wrong guess → lose styling, message naming both notes, score `50% (1/2)`
- [ ] Live browser check: confetti animation, buzzer audio, replay button, behavior across ranges and via touch/computer-keyboard input

https://claude.ai/code/session_01Lj13PPExCGxKV1L93ZFjA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj13PPExCGxKV1L93ZFjA9)_