### PR TITLE
Unlock Web Audio on first gesture (iOS sound fix)

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -336,6 +336,19 @@ const AudioKit = (() => {
       held.clear();
     }
 
+    // iOS won't produce sound until the context is resumed inside a user
+    // gesture; a one-sample silent buffer reliably kick-starts output. Call
+    // this from the first touch/click so later notes actually sound.
+    function unlock() {
+      ensure();
+      try {
+        const src = ctx.createBufferSource();
+        src.buffer = ctx.createBuffer(1, 1, ctx.sampleRate);
+        src.connect(ctx.destination);
+        src.start(0);
+      } catch (e) {}
+    }
+
     // Game-show "wrong answer" buzzer: two clashing detuned saws that slide
     // down at the end for that deflating "ahhght".
     function buzzer() {
@@ -361,7 +374,7 @@ const AudioKit = (() => {
     }
 
     return {
-      noteOn, noteOff, allOff, buzzer,
+      noteOn, noteOff, allOff, buzzer, unlock,
       setInstrument(name) { instrument = name === 'cello' ? 'cello' : 'piano'; },
       setFifth(on) { fifthOn = !!on; },
     };

--- a/keyboard.js
+++ b/keyboard.js
@@ -8,6 +8,16 @@ const synth = AudioKit.createPolySynth();
 const kbd = document.getElementById('keyboard');
 const now = document.getElementById('now');
 
+// iOS gates Web Audio behind a user gesture: unlock the context on the very
+// first interaction anywhere (capture phase, so it runs before play handlers).
+function unlockAudio() {
+  synth.unlock();
+  ['pointerdown', 'touchstart', 'mousedown', 'keydown'].forEach(ev =>
+    window.removeEventListener(ev, unlockAudio, true));
+}
+['pointerdown', 'touchstart', 'mousedown', 'keydown'].forEach(ev =>
+  window.addEventListener(ev, unlockAudio, true));
+
 // Low..high MIDI (inclusive), all starting/ending on C except the 88-key full
 // range (A0–C8). Larger ranges grow downward then upward around middle C.
 const RANGES = {


### PR DESCRIPTION
## Summary

Fixes the keyboard/pitch-test producing no sound on iPhone.

iOS Safari only lets an `AudioContext` produce sound after it's resumed **inside a user gesture**, and routinely drops the `resume()` attached to the first note. This adds an explicit unlock (`resume()` + a one-sample silent buffer) fired on the first touch/click anywhere on the page, in the capture phase so it runs before the play handlers.

- `audio.js`: new `unlock()` on the poly synth
- `keyboard.js`: calls `unlock()` on the first `pointerdown`/`touchstart`/`mousedown`/`keydown`

## Test plan

- [x] jsdom game-flow test still passes (round start, correct → confetti + score, wrong → buzzer + score)
- [ ] **iPhone**: tap "test my pitch" → hear a pitch; tap a key → hear it. Note: iOS also silences Web Audio when the physical **ring/silent switch** is on — confirm that's off.

https://claude.ai/code/session_01Lj13PPExCGxKV1L93ZFjA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj13PPExCGxKV1L93ZFjA9)_