### PR TITLE
Resume audio after backgrounding on iOS

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -247,7 +247,9 @@ const AudioKit = (() => {
         master.connect(comp);
         comp.connect(ctx.destination);
       }
-      if (ctx.state === 'suspended') { try { ctx.resume(); } catch (e) {} }
+      // iOS uses an "interrupted" state after backgrounding, not just
+      // "suspended" — resume whenever it isn't actively running.
+      if (ctx.state !== 'running') { try { ctx.resume(); } catch (e) {} }
       return ctx;
     }
 

--- a/keyboard.js
+++ b/keyboard.js
@@ -8,15 +8,16 @@ const synth = AudioKit.createPolySynth();
 const kbd = document.getElementById('keyboard');
 const now = document.getElementById('now');
 
-// iOS gates Web Audio behind a user gesture: unlock the context on the very
-// first interaction anywhere (capture phase, so it runs before play handlers).
-function unlockAudio() {
-  synth.unlock();
-  ['pointerdown', 'touchstart', 'mousedown', 'keydown'].forEach(ev =>
-    window.removeEventListener(ev, unlockAudio, true));
-}
+// iOS gates Web Audio behind a user gesture and suspends/"interrupts" the
+// context whenever the page is backgrounded. Resume it on every interaction
+// (capture phase, before play handlers) and when the tab becomes visible
+// again, so sound keeps working without a refresh.
+function resumeAudio() { synth.unlock(); }
 ['pointerdown', 'touchstart', 'mousedown', 'keydown'].forEach(ev =>
-  window.addEventListener(ev, unlockAudio, true));
+  window.addEventListener(ev, resumeAudio, true));
+document.addEventListener('visibilitychange', () => {
+  if (!document.hidden) synth.unlock();
+});
 
 // Low..high MIDI (inclusive), all starting/ending on C except the 88-key full
 // range (A0–C8). Larger ranges grow downward then upward around middle C.


### PR DESCRIPTION
## Summary

Fixes sound dying after the page is backgrounded on iPhone (worked again only after a refresh).

iOS suspends/"interrupts" the `AudioContext` when the page goes to the background. The previous unlock was one-shot — it removed its listeners after the first gesture — so nothing re-resumed the context on return.

- `keyboard.js`: resume on **every** interaction (not just the first) and on `visibilitychange` when the tab becomes visible again
- `audio.js`: resume whenever the context state isn't `running` (iOS reports `interrupted`, which the old `=== 'suspended'` check missed)

## Test plan

- [x] jsdom game-flow test still passes
- [ ] **iPhone**: play a note, switch to another app, come back, tap a key / "test my pitch" → sound works without refreshing

https://claude.ai/code/session_01Lj13PPExCGxKV1L93ZFjA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj13PPExCGxKV1L93ZFjA9)_