### PR TITLE
Pin the scale-row staff so it doesn't reflow during playback

### DIFF
--- a/scales.html
+++ b/scales.html
@@ -202,7 +202,11 @@
       gap: 0.6em;
     }
     .note-readout {
-      flex: 0 0 auto;
+      /* Fixed-width reservation so the staff to its left never reflows when a
+         played-note name appears/changes (letter + optional accidental). */
+      flex: 0 0 2.6ch;
+      text-align: left;
+      white-space: nowrap;
       color: #9cd8ff;
     }
 


### PR DESCRIPTION
## Problem

On the scales page, the played-note readout sat to the right of each row's mini-staff with `flex: 0 0 auto`, so it had **zero width when empty** and grew when a note name appeared. Because the readout is to the right of the staff inside a right-anchored group, growing it shoved the staff leftward — visible jitter on every note, especially on mobile.

## Fix

Reserve a fixed-width slot (`2.6ch`) for `.note-readout` so the staff-and-note group keeps a constant width. This both bumps the staff into a stable position and stops it reflowing as notes play. `2.6ch` comfortably holds any name these scales produce (a letter plus at most one accidental).

CSS-only change to `scales.html`.

https://claude.ai/code/session_019mLbKdMjqCKxnngZGtjKaJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019mLbKdMjqCKxnngZGtjKaJ)_