### PR TITLE
Actually pin the scale-row staff: defeat flex min-width:auto floor

### DIFF
--- a/scales.html
+++ b/scales.html
@@ -203,8 +203,12 @@
     }
     .note-readout {
       /* Fixed-width reservation so the staff to its left never reflows when a
-         played-note name appears/changes (letter + optional accidental). */
-      flex: 0 0 2.6ch;
+         played-note name appears/changes. min-width:0 is essential: a flex
+         item's default min-width:auto is its content width, which would
+         otherwise override flex-basis and shove the staff once a note name
+         (in the page font) is wider than the basis. */
+      flex: 0 0 3.4ch;
+      min-width: 0;
       text-align: left;
       white-space: nowrap;
       color: #9cd8ff;


### PR DESCRIPTION
## Problem

PR #85 reserved a fixed `2.6ch` slot for the played-note readout to stop the scale-row staff reflowing during playback — but the staff still moved on the live site.

Root cause: a flex item's default `min-width` is `auto`, which resolves to its **content** width and **overrides `flex-basis`**. Once a note name — rendered in the page's Cormorant Garamond font — is wider than the `2.6ch` basis, the readout box expands to fit it and shoves the staff left. (A serif fallback font fit the names inside `2.6ch`, which is why headless testing didn't catch it initially.)

## Fix

Add `min-width: 0` so `flex-basis` is authoritative regardless of content width, and widen the slot slightly (`3.4ch`).

## Verified

Headless Chrome at 390px width — staff x-position is now constant across every note name **and** even an over-wide stress value:

```
name=""       staffX=173.41
name="C♯"     staffX=173.41
name="A♭"     staffX=173.41
name="WWWW"   staffX=173.41   <- content floor defeated
```

(For contrast, without `min-width:0` the staff jumped from 181 → 90 once content exceeded the basis.)

CSS-only change to `scales.html`.

https://claude.ai/code/session_019mLbKdMjqCKxnngZGtjKaJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019mLbKdMjqCKxnngZGtjKaJ)_