### PR TITLE
Decouple played-note readout from the scale-row staff

### DIFF
--- a/scales.html
+++ b/scales.html
@@ -121,11 +121,28 @@
       display: none;
     }
     body.show-staves .row-staff { display: inline-block; }
+    /* The staff sits in normal flow on the left; the played-note name is taken
+       OUT of flow (absolutely positioned) so it can never shift the staff
+       horizontally, and is centered with a transform so it can't jiggle
+       vertically as the text appears/changes. The container reserves a fixed
+       slot for both, so the staff holds one position throughout playback. */
     .staff-and-note {
+      position: relative;
       display: inline-flex;
       align-items: center;
-      gap: 0.45em;
       flex-shrink: 0;
+      width: 3.6ch;                 /* readout-only width when staves are hidden */
+    }
+    body.show-staves .staff-and-note {
+      width: calc(80px + 0.5em + 3.6ch);
+    }
+    .note-readout {
+      position: absolute;
+      right: 0;
+      top: 50%;
+      transform: translateY(-50%);
+      white-space: nowrap;
+      color: #9cd8ff;
     }
     .staff-line { stroke: rgba(255, 255, 255, 0.55); stroke-width: 0.8; }
     .staff-line.ledger { stroke-width: 1; }
@@ -201,19 +218,6 @@
       justify-content: space-between;
       gap: 0.6em;
     }
-    .note-readout {
-      /* Fixed-width reservation so the staff to its left never reflows when a
-         played-note name appears/changes. min-width:0 is essential: a flex
-         item's default min-width:auto is its content width, which would
-         otherwise override flex-basis and shove the staff once a note name
-         (in the page font) is wider than the basis. */
-      flex: 0 0 3.4ch;
-      min-width: 0;
-      text-align: left;
-      white-space: nowrap;
-      color: #9cd8ff;
-    }
-
     button {
       background: none;
       border: 1px solid #666;


### PR DESCRIPTION
## Problem

Two prior attempts (#85 fixed-width slot, #86 `min-width:0`) still left the scale-row key-signature staff appearing to move during playback. Real-playback instrumentation in headless Chrome showed the staff x/y staying constant in my environment, but the readout sat next to it as an in-flow flex item — leaving residual ways for it to shift the staff (the `min-width:auto` content floor in certain fonts, and an empty-vs-filled vertical recenter).

## Fix

Stop relying on flex sizing tricks and **decouple the readout from the staff entirely**:
- The played-note name is now `position: absolute` within the `.staff-and-note` box — out of layout flow, so it physically cannot move the staff horizontally.
- It's centered with `top: 50%; transform: translateY(-50%)`, so it can't jiggle vertically as text appears/changes.
- `.staff-and-note` reserves a fixed slot (`calc(80px + 0.5em + 3.6ch)` with staves shown, `3.6ch` without), so the staff holds one position throughout.

## Verified

Headless Chrome, staff x/y constant across empty / `C` / `C♯` / `A♭` / over-wide content:

```
w=390 staves=on:  staff x=[170.5] y=[797.7]
w=390 staves=off: staff hidden, readout still centered
w=900 staves=on:  staff x=[307.5] y=[718.1]
```

CSS-only change to `scales.html`.

https://claude.ai/code/session_019mLbKdMjqCKxnngZGtjKaJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019mLbKdMjqCKxnngZGtjKaJ)_