### PR TITLE
Fix bass clef vertical position to sit on the F line

### DIFF
--- a/scales.js
+++ b/scales.js
@@ -438,7 +438,7 @@ function renderStaff(svg, sig, treble) {
   const clef = document.createElementNS(NS, 'text');
   clef.setAttribute('class', 'clef');
   clef.setAttribute('x', clefX);
-  clef.setAttribute('y', treble ? baseY - 1 : baseY - 4);
+  clef.setAttribute('y', baseY - 1);
   clef.setAttribute('font-size', treble ? 22 : 20);
   clef.textContent = treble ? '\u{1D11E}' : '\u{1D122}';
   svg.appendChild(clef);


### PR DESCRIPTION
## Change

The bass clef baseline was a staff line too high, so its dots straddled the top line instead of the F line (2nd from top). Set the bass clef `y` to `baseY - 1` (matching the treble baseline; sizes still differ — treble 22, bass 20) so the F-clef eye sits on the F line with the dots straddling it.

JS-only change to `scales.js`.

https://claude.ai/code/session_019mLbKdMjqCKxnngZGtjKaJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019mLbKdMjqCKxnngZGtjKaJ)_