### PR TITLE
Chords page (stage 2): mini keyboard highlight + first inversion toggle

### DIFF
--- a/chords.html
+++ b/chords.html
@@ -72,6 +72,39 @@
     .node.selected circle { fill: #9cd8ff; stroke: #9cd8ff; }
     .node.selected text { fill: #06121c; }
 
+    /* --- mini keyboard (chord visualization) --- */
+    .mini-kbd {
+      display: flex;
+      align-items: flex-start;
+      height: 70px;
+      margin: 0 auto;
+    }
+    .mini-key { position: relative; box-sizing: border-box; }
+    .mini-key.white {
+      flex: 0 0 18px;
+      height: 100%;
+      background: linear-gradient(#fafafa, #e6e6e6);
+      border: 1px solid #2a2a2a;
+      border-radius: 0 0 3px 3px;
+    }
+    .mini-key.black {
+      position: absolute;
+      top: 0;
+      right: -32%;
+      width: 64%;
+      height: 62%;
+      background: linear-gradient(#2a2a2a, #000);
+      border: 1px solid #000;
+      border-radius: 0 0 3px 3px;
+      z-index: 2;
+    }
+    .mini-key.white.on { background: linear-gradient(#bfe6ff, #9cd8ff); }
+    .mini-key.black.on { background: linear-gradient(#6fb4d6, #2f6f8f); }
+    @media (max-width: 600px) {
+      .mini-kbd { height: 56px; }
+      .mini-key.white { flex: 0 0 14px; }
+    }
+
     /* --- controls --- */
     .controls {
       display: flex;
@@ -92,6 +125,37 @@
       padding: 0.2em 0.35em;
     }
     .ctl select:hover { border-color: #9cd8ff; }
+
+    /* --- toggle switch (matches scales/keyboard pages) --- */
+    .switch {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45em;
+      cursor: pointer;
+      user-select: none;
+    }
+    .switch input { position: absolute; opacity: 0; width: 0; height: 0; }
+    .switch .track {
+      width: 2.4em;
+      height: 1.2em;
+      border: 1px solid #666;
+      border-radius: 1em;
+      position: relative;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .switch .thumb {
+      position: absolute;
+      top: 50%;
+      left: 0.15em;
+      width: 0.9em;
+      height: 0.9em;
+      transform: translateY(-50%);
+      background: #ddd;
+      border-radius: 50%;
+      transition: left 0.15s, background 0.15s;
+    }
+    .switch input:checked + .track { background: #2f6f8f; border-color: #9cd8ff; }
+    .switch input:checked + .track .thumb { left: calc(100% - 1.05em); background: #9cd8ff; }
 
     /* --- focus panel ("now showing") --- */
     .focus {
@@ -150,6 +214,8 @@
 
   <svg id="circle" viewBox="0 0 360 360" aria-label="circle of fifths root picker"></svg>
 
+  <div class="mini-kbd" id="mini-kbd" aria-label="chord on the keyboard"></div>
+
   <div class="controls">
     <label class="ctl">
       chord
@@ -169,6 +235,11 @@
     <div class="chord-quality" id="chord-quality">&nbsp;</div>
     <div class="chord-notes" id="chord-notes">&nbsp;</div>
     <div class="play-controls">
+      <label class="switch">
+        <input id="invert" type="checkbox">
+        <span class="track"><span class="thumb"></span></span>
+        first inversion
+      </label>
       <button id="play-block" type="button">play chord</button>
       <button id="play-arp" type="button">arpeggiate</button>
     </div>

--- a/chords.js
+++ b/chords.js
@@ -86,34 +86,43 @@ const { pitchToMidi } = AudioKit;
 
 let rootIndex = 0;        // index into CIRCLE
 let qualityIndex = 0;     // index into QUALITIES
+let firstInversion = false;
 
 // --- chord building --------------------------------------------------------
-function spellChord(root, quality) {
+// One source of truth: build the voicing as an ordered list of { midi, name },
+// applying first inversion if active (the root jumps up an octave so the 3rd
+// — or whatever the next tone is — becomes the bass). Everything downstream
+// (display, keyboard, playback) reads from this list.
+function buildVoicing(root, quality) {
   const { letterIdx, pc } = parseRoot(root);
-  return quality.intervals.map((iv, i) => {
-    const li = (letterIdx + quality.letterSteps[i]) % 7;
-    return spellPc(li, (pc + iv) % 12);
-  });
-}
-
-function chordName(root, quality) {
-  const { letterIdx, pc } = parseRoot(root);
-  return spellPc(letterIdx, pc) + quality.symbol;
-}
-
-// MIDI notes for playback, rooted near middle C so chords sit in a sweet spot.
-function chordMidis(root, quality) {
   const base = pitchToMidi(root, 4);
-  return quality.intervals.map(iv => base + iv);
+  const tones = quality.intervals.map((iv, i) => ({
+    midi: base + iv,
+    name: spellPc((letterIdx + quality.letterSteps[i]) % 7, (pc + iv) % 12),
+  }));
+  if (firstInversion && tones.length > 1) {
+    tones[0].midi += 12;
+    tones.sort((a, b) => a.midi - b.midi);
+  }
+  return tones;
+}
+
+function chordName(root, quality, voicing) {
+  const { letterIdx, pc } = parseRoot(root);
+  const base = spellPc(letterIdx, pc) + quality.symbol;
+  if (!firstInversion || quality.intervals.length < 2) return base;
+  // Slash chord: lowest voiced tone over the chord symbol (e.g. C/E).
+  return base + '/' + voicing[0].name;
 }
 
 // --- playback (poly synth in audio.js) -------------------------------------
+// AudioKit installs global resume handlers on visibilitychange + first gesture,
+// so no per-page wiring is needed for sound to recover after backgrounding.
 const synth = AudioKit.createPolySynth();
-
-// iOS gates Web Audio behind a user gesture; resume on any interaction.
+// iOS still needs the silent-buffer kickstart on first user gesture for sound
+// to come out at all on a fresh page load.
 ['pointerdown', 'touchstart', 'mousedown', 'keydown'].forEach(ev =>
   window.addEventListener(ev, () => synth.unlock(), true));
-document.addEventListener('visibilitychange', () => { if (!document.hidden) synth.unlock(); });
 
 let playTimers = [];
 let activeBtn = null;
@@ -122,6 +131,7 @@ function stopChord() {
   playTimers.forEach(id => clearTimeout(id));
   playTimers = [];
   synth.allOff();
+  clearHighlights();
   if (activeBtn) { activeBtn.classList.remove('playing'); activeBtn = null; }
 }
 
@@ -131,17 +141,57 @@ function play(mode, btn) {
   const wasActive = activeBtn === btn;
   stopChord();
   if (wasActive) return; // clicking the lit button again stops
-  const midis = chordMidis(CIRCLE[rootIndex].root, QUALITIES[qualityIndex]);
+  const midis = buildVoicing(CIRCLE[rootIndex].root, QUALITIES[qualityIndex]).map(t => t.midi);
   activeBtn = btn;
   btn.classList.add('playing');
   if (mode === 'block') {
-    midis.forEach(m => synth.noteOn(m));
+    midis.forEach(m => { synth.noteOn(m); highlightKey(m, true); });
     playTimers.push(setTimeout(stopChord, 1800));
   } else {
     const step = 180; // ms between rolled notes
-    midis.forEach((m, i) => playTimers.push(setTimeout(() => synth.noteOn(m), i * step)));
+    midis.forEach((m, i) => playTimers.push(setTimeout(() => {
+      synth.noteOn(m);
+      highlightKey(m, true);
+    }, i * step)));
     playTimers.push(setTimeout(stopChord, midis.length * step + 1400));
   }
+}
+
+// --- mini keyboard ---------------------------------------------------------
+// A small two-octave-plus piano under the circle that lights up to show the
+// chord as it sounds. C4–D6 covers every supported quality in both root
+// position and first inversion (e.g. B add9 first inversion tops out at C♯6).
+const KBD_LOW = 60, KBD_HIGH = 86;
+const WHITE_PCS = new Set([0, 2, 4, 5, 7, 9, 11]);
+const pcOf = m => ((m % 12) + 12) % 12;
+
+function buildMiniKeyboard() {
+  const k = document.getElementById('mini-kbd');
+  for (let m = KBD_LOW; m <= KBD_HIGH; m++) {
+    if (!WHITE_PCS.has(pcOf(m))) continue;
+    const w = document.createElement('div');
+    w.className = 'mini-key white';
+    w.dataset.midi = m;
+    // The black key (if any) sits as a child of the white key to its left so
+    // it straddles the boundary cleanly — same trick as the keyboard page.
+    const bm = m + 1;
+    if (bm <= KBD_HIGH && !WHITE_PCS.has(pcOf(bm))) {
+      const b = document.createElement('div');
+      b.className = 'mini-key black';
+      b.dataset.midi = bm;
+      w.appendChild(b);
+    }
+    k.appendChild(w);
+  }
+}
+
+function highlightKey(midi, on) {
+  const el = document.querySelector(`.mini-key[data-midi="${midi}"]`);
+  if (el) el.classList.toggle('on', on);
+}
+
+function clearHighlights() {
+  document.querySelectorAll('.mini-key.on').forEach(el => el.classList.remove('on'));
 }
 
 // --- UI --------------------------------------------------------------------
@@ -216,18 +266,25 @@ function renderFocus() {
   stopChord(); // changing the chord shouldn't leave the old one ringing
   const root = CIRCLE[rootIndex].root;
   const quality = QUALITIES[qualityIndex];
-  document.getElementById('chord-name').textContent = chordName(root, quality);
-  document.getElementById('chord-quality').textContent = quality.label;
-  document.getElementById('chord-notes').textContent = spellChord(root, quality).join(' – ');
+  const voicing = buildVoicing(root, quality);
+  document.getElementById('chord-name').textContent = chordName(root, quality, voicing);
+  document.getElementById('chord-quality').textContent =
+    quality.label + (firstInversion && quality.intervals.length > 1 ? ' (1st inversion)' : '');
+  document.getElementById('chord-notes').textContent = voicing.map(t => t.name).join(' – ');
 }
 
 document.getElementById('tone').addEventListener('change', e => {
   stopChord();
   synth.setInstrument(e.target.value);
 });
+document.getElementById('invert').addEventListener('change', e => {
+  firstInversion = e.target.checked;
+  renderFocus();
+});
 document.getElementById('play-block').addEventListener('click', e => play('block', e.currentTarget));
 document.getElementById('play-arp').addEventListener('click', e => play('arp', e.currentTarget));
 
 buildCircle();
 buildQualityMenu();
+buildMiniKeyboard();
 selectRoot(0);


### PR DESCRIPTION
## Summary

Stage 2 of the chords page: a small piano under the circle that lights up as the chord sounds, plus a first-inversion toggle.

- **Mini keyboard** (C4–D6, two-plus octaves — wide enough to fit every supported chord in both root and first-inversion voicings) sits under the circle. Block chord lights all tones at once; arpeggio lights them one-by-one as they sound; both clear when the chord ends.
- **First inversion toggle**: the root jumps up an octave so the third becomes the bass. The chord symbol becomes a slash name (e.g. `C/E`), the note display reorders to match the voicing (`E – G – C`), and the keyboard highlights + playback follow.
- Internals: chord building is unified through a single `buildVoicing()` that returns `{midi, name}` pairs in voicing order, so display, keyboard, and audio always agree.
- Removed the per-page `visibilitychange` handler now that the shared engine (PR #91) handles foreground/gesture resume globally — duplicate listener was harmless but redundant.

## Test plan

- [ ] Pick a root on the circle, try a few qualities — keyboard sits empty until you play.
- [ ] Click **play chord**: keys light all at once; click again or wait — they clear.
- [ ] Click **arpeggiate**: keys light one-by-one and stay lit, then clear at the end.
- [ ] Flip **first inversion** on: chord name shows a slash (e.g. `C/E`), notes reorder, the bass note on the keyboard is the third, and audio plays the inverted voicing.
- [ ] Try high roots (B, E, A) with extended qualities (add9, 6/9) — voicing fits on the keyboard in both root position and first inversion.

https://claude.ai/code/session_01VUYKqwfjvRCZSuhoVrPeLi

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUYKqwfjvRCZSuhoVrPeLi)_