### PR TITLE
Scales: add whole and half notes to the note-length slider

### DIFF
--- a/scales.html
+++ b/scales.html
@@ -336,7 +336,7 @@
     </label>
     <label class="ctl">
       note
-      <input id="subdiv" type="range" min="0" max="3" step="1" value="0">
+      <input id="subdiv" type="range" min="0" max="5" step="1" value="2">
       <span id="subdiv-val" class="subdiv-val">&#x2669; quarter</span>
     </label>
     <label class="switch">

--- a/scales.js
+++ b/scales.js
@@ -128,10 +128,12 @@ let loopTimerId = null; // pending timer that schedules the next loop pass
 // Note value per beat: how many scale notes fit in one quarter-note beat.
 let subdivIndex = 0;
 const SUBDIVS = [
-  { label: '♩', name: 'quarter',   perBeat: 1 },
-  { label: '♪', name: 'eighth',    perBeat: 2 },
-  { label: '♪³', name: 'triplet',  perBeat: 3 },
-  { label: '♬', name: 'sixteenth', perBeat: 4 },
+  { label: '𝅝',  name: 'whole',     perBeat: 0.25 },
+  { label: '𝅗𝅥',  name: 'half',      perBeat: 0.5  },
+  { label: '♩',  name: 'quarter',   perBeat: 1 },
+  { label: '♪',  name: 'eighth',    perBeat: 2 },
+  { label: '♪³', name: 'triplet',   perBeat: 3 },
+  { label: '♬',  name: 'sixteenth', perBeat: 4 },
 ];
 
 // gate = fraction of the beat the note sounds; sustain = held level; atk/release


### PR DESCRIPTION
## Summary

- Adds whole-note (0.25/beat) and half-note (0.5/beat) options to the note-length slider so scales can be practiced at slower durations.
- Slider now spans six positions: whole → half → quarter → eighth → triplet → sixteenth. Default stays on quarter.

## Test plan

- [ ] Open scales.html, drag the note slider — confirm six positions and labels.
- [ ] Pick whole, play a scale, confirm each note lasts ~4 beats at the current tempo.
- [ ] Pick half, confirm ~2 beats per note.
- [ ] Confirm quarter / eighth / triplet / sixteenth still play as before.

https://claude.ai/code/session_01X7wU2zXHNvsU2ugRZdgfEi

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7wU2zXHNvsU2ugRZdgfEi)_