### PR TITLE
Keyboard "listen" mode: mic tuner that lights up the heard note

### DIFF
--- a/keyboard.html
+++ b/keyboard.html
@@ -178,6 +178,8 @@
       pointer-events: none;
       padding-bottom: 7px;
       display: none;
+      position: relative; /* keep the name above the listen-mode strobe overlay */
+      z-index: 2;
     }
     .label.tonic { display: block; color: #555; }
     .keyboard.show-labels .label { display: block; }

--- a/keyboard.html
+++ b/keyboard.html
@@ -142,6 +142,36 @@
     }
     .white.on { background: linear-gradient(#bfe6ff, #9cd8ff); }
     .black.on { background: linear-gradient(#6fb4d6, #2f6f8f); }
+
+    /* Mic "listen" mode: the heard key glows blue and a vertical strobe drifts
+       across it — up = sharp, down = flat, frozen = in tune. The drift is driven
+       from JS via the --strobe background offset; the .in-tune class greens the
+       stripes as a second (colourblind-friendly) lock cue. */
+    .white.hear { background: linear-gradient(#bfe6ff, #9cd8ff); }
+    .black.hear { background: linear-gradient(#6fb4d6, #2f6f8f); }
+    .key.hear::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      z-index: 1;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(16, 38, 64, 0.6) 0,
+        rgba(16, 38, 64, 0.6) 9px,
+        rgba(255, 255, 255, 0) 9px,
+        rgba(255, 255, 255, 0) 18px);
+      background-position-y: var(--strobe, 0px);
+    }
+    .key.hear.in-tune::after {
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(18, 84, 40, 0.6) 0,
+        rgba(18, 84, 40, 0.6) 9px,
+        rgba(255, 255, 255, 0) 9px,
+        rgba(255, 255, 255, 0) 18px);
+    }
     .label {
       font-size: 0.72rem;
       color: #777;
@@ -199,7 +229,7 @@
   <a class="back" href="index.html">← back</a>
 
   <h1>keyboard</h1>
-  <p class="hint">click, tap, or play with your computer keyboard (a&ndash;k row); z / x shift octave</p>
+  <p class="hint">click, tap, or play with your computer keyboard (a&ndash;k row); z / x shift octave<br>flip <em>listen</em> to tune by ear &mdash; sing or play a note and the strobe drifts up if sharp, down if flat</p>
 
   <div class="controls">
     <label class="ctl">
@@ -231,6 +261,11 @@
       <input id="labels" type="checkbox">
       <span class="track"><span class="thumb"></span></span>
       note names
+    </label>
+    <label class="switch">
+      <input id="mic" type="checkbox">
+      <span class="track"><span class="thumb"></span></span>
+      listen
     </label>
   </div>
 

--- a/keyboard.js
+++ b/keyboard.js
@@ -243,4 +243,142 @@ function confetti() {
 testBtn.addEventListener('click', startRound);
 replayBtn.addEventListener('click', playTarget);
 
+// --- Microphone tuner ("listen" mode) ---------------------------------------
+// Listen to the mic, detect the sung/played pitch by autocorrelation, light up
+// the nearest key, and drive a vertical strobe whose drift encodes how far off
+// it is: up = sharp, down = flat, frozen = in tune. Monophonic (one pitch at a
+// time), so exactly one key ever animates. Uses its own AudioContext, separate
+// from the synth's, and only runs while the toggle is on.
+const micToggle = document.getElementById('mic');
+let micStream = null, micCtx = null, analyser = null, micBuf = null, rafId = null;
+let litKey = null;       // the key element currently highlighted by the mic
+let strobeOffset = 0;    // accumulated strobe background-position (px)
+let smoothedCents = 0;   // low-passed cents, so the drift glides
+let lastFrameTs = 0;
+
+// px/sec of strobe drift per cent of error. 50¢ (max) ≈ 300 px/s over an 18px
+// stripe — a fast blur; a few cents is a slow, readable crawl; 0¢ is frozen.
+const STROBE_GAIN = 6;
+const IN_TUNE_CENTS = 4;
+
+function clearHeard() {
+  if (litKey) {
+    litKey.classList.remove('hear', 'in-tune');
+    litKey.style.removeProperty('--strobe');
+    litKey = null;
+  }
+}
+
+// Autocorrelation pitch detector: returns the fundamental in Hz, or -1 when the
+// signal is too quiet or too noisy to call. Rejects on low RMS, trims near-
+// silent edges, takes the first strong correlation peak, then parabolic-
+// interpolates for sub-sample (sub-cent) precision.
+function autoCorrelate(buf, sampleRate) {
+  const SIZE = buf.length;
+  let rms = 0;
+  for (let i = 0; i < SIZE; i++) rms += buf[i] * buf[i];
+  rms = Math.sqrt(rms / SIZE);
+  if (rms < 0.01) return -1; // too quiet to be a real note
+
+  let r1 = 0, r2 = SIZE - 1;
+  const thres = 0.2;
+  for (let i = 0; i < SIZE / 2; i++) if (Math.abs(buf[i]) < thres) { r1 = i; break; }
+  for (let i = 1; i < SIZE / 2; i++) if (Math.abs(buf[SIZE - i]) < thres) { r2 = SIZE - i; break; }
+  const b = buf.slice(r1, r2);
+  const n = b.length;
+  if (n < 8) return -1;
+
+  const c = new Float32Array(n);
+  for (let i = 0; i < n; i++)
+    for (let j = 0; j < n - i; j++)
+      c[i] += b[j] * b[j + i];
+
+  let d = 0;
+  while (d < n - 1 && c[d] > c[d + 1]) d++; // skip the zero-lag descent
+  let maxval = -1, maxpos = -1;
+  for (let i = d; i < n; i++) if (c[i] > maxval) { maxval = c[i]; maxpos = i; }
+  if (maxpos <= 0 || maxpos >= n - 1) return -1;
+
+  let T0 = maxpos;
+  const x1 = c[T0 - 1], x2 = c[T0], x3 = c[T0 + 1];
+  const a = (x1 + x3 - 2 * x2) / 2;
+  const bb = (x3 - x1) / 2;
+  if (a) T0 = T0 - bb / (2 * a);
+
+  return sampleRate / T0;
+}
+
+function tick(ts) {
+  rafId = requestAnimationFrame(tick);
+  const dt = Math.min((ts - lastFrameTs) / 1000, 0.05);
+  lastFrameTs = ts;
+
+  analyser.getFloatTimeDomainData(micBuf);
+  const freq = autoCorrelate(micBuf, micCtx.sampleRate);
+  if (freq <= 0) { clearHeard(); return; }
+
+  const midiFloat = 69 + 12 * Math.log2(freq / 440);
+  const midi = Math.round(midiFloat);
+  const cents = (midiFloat - midi) * 100; // -50..+50 from the nearest key
+  const el = keyEl(midi);
+  if (!el) { clearHeard(); return; } // outside the current keyboard range
+
+  if (el !== litKey) {
+    clearHeard();
+    litKey = el;
+    el.classList.add('hear');
+    strobeOffset = 0;
+    smoothedCents = cents;
+  } else {
+    smoothedCents += (cents - smoothedCents) * 0.25;
+  }
+
+  // Up = sharp, down = flat. CSS background-position-y grows downward, so a
+  // positive (sharp) reading must subtract to drift the stripes upward.
+  strobeOffset -= smoothedCents * STROBE_GAIN * dt;
+  el.style.setProperty('--strobe', strobeOffset.toFixed(1) + 'px');
+
+  const inTune = Math.abs(smoothedCents) < IN_TUNE_CENTS;
+  el.classList.toggle('in-tune', inTune);
+  now.textContent = noteLabel(midi) + (inTune ? ' · in tune'
+    : ' · ' + (smoothedCents > 0 ? '+' : '') + Math.round(smoothedCents) + '¢');
+}
+
+async function startMic() {
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+    micToggle.checked = false;
+    now.textContent = 'mic unavailable';
+    return;
+  }
+  try {
+    micStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: false, noiseSuppression: false, autoGainControl: false },
+    });
+  } catch (e) {
+    micToggle.checked = false;
+    now.textContent = 'mic blocked';
+    return;
+  }
+  micCtx = new (window.AudioContext || window.webkitAudioContext)();
+  analyser = micCtx.createAnalyser();
+  analyser.fftSize = 2048;
+  micBuf = new Float32Array(analyser.fftSize);
+  micCtx.createMediaStreamSource(micStream).connect(analyser);
+  lastFrameTs = performance.now();
+  rafId = requestAnimationFrame(tick);
+}
+
+function stopMic() {
+  if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+  if (micStream) { micStream.getTracks().forEach(t => t.stop()); micStream = null; }
+  if (micCtx) { try { micCtx.close(); } catch (e) {} micCtx = null; }
+  analyser = null; micBuf = null;
+  clearHeard();
+  now.textContent = ' ';
+}
+
+micToggle.addEventListener('change', e => {
+  if (e.target.checked) startMic(); else stopMic();
+});
+
 build('2');

--- a/keyboard.js
+++ b/keyboard.js
@@ -42,6 +42,7 @@ function noteLabel(midi) {
 let lowMidi = 48, highMidi = 72;
 
 function build(rangeKey) {
+  clearHeard(); // drop any mic highlight bound to keys we're about to replace
   [lowMidi, highMidi] = RANGES[rangeKey] || RANGES['2'];
   kbd.innerHTML = '';
   for (let m = lowMidi; m <= highMidi; m++) {
@@ -346,9 +347,12 @@ function tick(ts) {
   }
 
   if (curMidi == null) return;
+  // A key the user is actually pressing owns the `now` readout; the tuner only
+  // writes it when nothing is held, so the two don't clobber each other.
+  const free = pointers.size === 0 && downKeys.size === 0;
   // Drop the highlight only after a short hold, so the momentary detection
   // dropouts between and within notes don't make the key flicker.
-  if (ts - lastGoodTs > HOLD_MS) { clearHeard(); now.textContent = ' '; return; }
+  if (ts - lastGoodTs > HOLD_MS) { clearHeard(); if (free) now.textContent = ' '; return; }
 
   // Up = sharp, down = flat. CSS background-position-y grows downward, so a
   // positive (sharp) reading must subtract to drift the stripes upward.
@@ -356,7 +360,7 @@ function tick(ts) {
   litKey.style.setProperty('--strobe', strobeOffset.toFixed(1) + 'px');
   const inTune = Math.abs(smoothedCents) < IN_TUNE_CENTS;
   litKey.classList.toggle('in-tune', inTune);
-  now.textContent = noteLabel(curMidi) + (inTune ? ' · in tune'
+  if (free) now.textContent = noteLabel(curMidi) + (inTune ? ' · in tune'
     : ' · ' + (smoothedCents > 0 ? '+' : '') + Math.round(smoothedCents) + '¢');
 }
 
@@ -380,6 +384,14 @@ async function startMic() {
   micStream = stream;
   micCtx = new (window.AudioContext || window.webkitAudioContext)();
   analyser = micCtx.createAnalyser();
+  // getFloatTimeDomainData arrived in Safari 14.1; bail clearly on anything older
+  // rather than throwing every frame inside the loop.
+  if (typeof analyser.getFloatTimeDomainData !== 'function') {
+    stopMic();
+    micToggle.checked = false;
+    now.textContent = 'listen needs a newer browser';
+    return;
+  }
   analyser.fftSize = 2048;
   micBuf = new Float32Array(analyser.fftSize);
   micCtx.createMediaStreamSource(micStream).connect(analyser);
@@ -388,6 +400,7 @@ async function startMic() {
   lastGoodTs = 0;
   curMidi = null;
   strobeOffset = 0;
+  if (rafId) cancelAnimationFrame(rafId); // never run two loops at once
   rafId = requestAnimationFrame(tick);
 }
 
@@ -403,6 +416,16 @@ function stopMic() {
 
 micToggle.addEventListener('change', e => {
   if (e.target.checked) startMic(); else stopMic();
+});
+
+// iOS suspends/interrupts the mic context when the tab is backgrounded; resume
+// it on return (the synth has its own resume in audio.js, but this context
+// isn't registered there). Reset the frame clock so the strobe doesn't lurch.
+document.addEventListener('visibilitychange', () => {
+  if (!document.hidden && micCtx && micCtx.state !== 'running') {
+    micCtx.resume().catch(() => {});
+    lastFrameTs = performance.now();
+  }
 });
 
 build('2');

--- a/keyboard.js
+++ b/keyboard.js
@@ -252,14 +252,18 @@ replayBtn.addEventListener('click', playTarget);
 const micToggle = document.getElementById('mic');
 let micStream = null, micCtx = null, analyser = null, micBuf = null, rafId = null;
 let litKey = null;       // the key element currently highlighted by the mic
+let curMidi = null;      // its MIDI number (null = nothing heard right now)
 let strobeOffset = 0;    // accumulated strobe background-position (px)
 let smoothedCents = 0;   // low-passed cents, so the drift glides
-let lastFrameTs = 0;
+let lastFrameTs = 0, lastDetectTs = 0, lastGoodTs = 0;
+let micGen = 0;          // bumped on each start/stop to abandon stale async starts
 
 // px/sec of strobe drift per cent of error. 50¢ (max) ≈ 300 px/s over an 18px
 // stripe — a fast blur; a few cents is a slow, readable crawl; 0¢ is frozen.
 const STROBE_GAIN = 6;
 const IN_TUNE_CENTS = 4;
+const DETECT_MS = 30;    // run the O(n²) detector ~33×/s, not once per frame
+const HOLD_MS = 250;     // keep the last key lit through brief detection dropouts
 
 function clearHeard() {
   if (litKey) {
@@ -267,6 +271,7 @@ function clearHeard() {
     litKey.style.removeProperty('--strobe');
     litKey = null;
   }
+  curMidi = null;
 }
 
 // Autocorrelation pitch detector: returns the fundamental in Hz, or -1 when the
@@ -313,34 +318,45 @@ function tick(ts) {
   const dt = Math.min((ts - lastFrameTs) / 1000, 0.05);
   lastFrameTs = ts;
 
-  analyser.getFloatTimeDomainData(micBuf);
-  const freq = autoCorrelate(micBuf, micCtx.sampleRate);
-  if (freq <= 0) { clearHeard(); return; }
-
-  const midiFloat = 69 + 12 * Math.log2(freq / 440);
-  const midi = Math.round(midiFloat);
-  const cents = (midiFloat - midi) * 100; // -50..+50 from the nearest key
-  const el = keyEl(midi);
-  if (!el) { clearHeard(); return; } // outside the current keyboard range
-
-  if (el !== litKey) {
-    clearHeard();
-    litKey = el;
-    el.classList.add('hear');
-    strobeOffset = 0;
-    smoothedCents = cents;
-  } else {
-    smoothedCents += (cents - smoothedCents) * 0.25;
+  // Detection is O(n²) per call, so throttle it well below the frame rate; the
+  // strobe still animates every frame from the last good reading (below).
+  if (ts - lastDetectTs >= DETECT_MS) {
+    lastDetectTs = ts;
+    analyser.getFloatTimeDomainData(micBuf);
+    const freq = autoCorrelate(micBuf, micCtx.sampleRate);
+    if (freq > 0) {
+      const midiFloat = 69 + 12 * Math.log2(freq / 440);
+      const midi = Math.round(midiFloat);
+      const cents = (midiFloat - midi) * 100; // -50..+50 from the nearest key
+      const el = keyEl(midi);                 // null if outside the current range
+      if (el) {
+        if (midi !== curMidi) {               // new note: snap rather than smooth across
+          clearHeard();
+          litKey = el;
+          curMidi = midi;
+          el.classList.add('hear');
+          smoothedCents = cents;
+          strobeOffset = 0;
+        } else {
+          smoothedCents += (cents - smoothedCents) * 0.25;
+        }
+        lastGoodTs = ts;
+      }
+    }
   }
+
+  if (curMidi == null) return;
+  // Drop the highlight only after a short hold, so the momentary detection
+  // dropouts between and within notes don't make the key flicker.
+  if (ts - lastGoodTs > HOLD_MS) { clearHeard(); now.textContent = ' '; return; }
 
   // Up = sharp, down = flat. CSS background-position-y grows downward, so a
   // positive (sharp) reading must subtract to drift the stripes upward.
   strobeOffset -= smoothedCents * STROBE_GAIN * dt;
-  el.style.setProperty('--strobe', strobeOffset.toFixed(1) + 'px');
-
+  litKey.style.setProperty('--strobe', strobeOffset.toFixed(1) + 'px');
   const inTune = Math.abs(smoothedCents) < IN_TUNE_CENTS;
-  el.classList.toggle('in-tune', inTune);
-  now.textContent = noteLabel(midi) + (inTune ? ' · in tune'
+  litKey.classList.toggle('in-tune', inTune);
+  now.textContent = noteLabel(curMidi) + (inTune ? ' · in tune'
     : ' · ' + (smoothedCents > 0 ? '+' : '') + Math.round(smoothedCents) + '¢');
 }
 
@@ -350,25 +366,33 @@ async function startMic() {
     now.textContent = 'mic unavailable';
     return;
   }
+  const gen = ++micGen;
+  let stream;
   try {
-    micStream = await navigator.mediaDevices.getUserMedia({
+    stream = await navigator.mediaDevices.getUserMedia({
       audio: { echoCancellation: false, noiseSuppression: false, autoGainControl: false },
     });
   } catch (e) {
-    micToggle.checked = false;
-    now.textContent = 'mic blocked';
+    if (gen === micGen) { micToggle.checked = false; now.textContent = 'mic blocked'; }
     return;
   }
+  if (gen !== micGen) { stream.getTracks().forEach(t => t.stop()); return; } // toggled off while awaiting
+  micStream = stream;
   micCtx = new (window.AudioContext || window.webkitAudioContext)();
   analyser = micCtx.createAnalyser();
   analyser.fftSize = 2048;
   micBuf = new Float32Array(analyser.fftSize);
   micCtx.createMediaStreamSource(micStream).connect(analyser);
   lastFrameTs = performance.now();
+  lastDetectTs = 0;
+  lastGoodTs = 0;
+  curMidi = null;
+  strobeOffset = 0;
   rafId = requestAnimationFrame(tick);
 }
 
 function stopMic() {
+  micGen++;
   if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
   if (micStream) { micStream.getTracks().forEach(t => t.stop()); micStream = null; }
   if (micCtx) { try { micCtx.close(); } catch (e) {} micCtx = null; }


### PR DESCRIPTION
Adds a **listen** toggle to the keyboard page. Flip it on, grant the mic, and the page detects the sung or played pitch and lights up the nearest piano key, with a vertical **strobe** showing how far off it is — **up = sharp, down = flat, frozen = in tune** — like a tuner, but the feedback *is* the keyboard.

## How it works
- `getUserMedia(mic)` → `AnalyserNode` → a `requestAnimationFrame` loop runs an **autocorrelation** pitch detector (parabolic-interpolated for sub-cent precision, RMS/noise gated).
- Detection is throttled to ~33 Hz; the strobe still animates every frame off the last reading, so motion stays smooth while CPU stays low.
- Nearest MIDI lights the key (`.hear`); the cents offset drives the strobe drift (`--strobe` → `background-position-y`). Stripes turn **green** and the readout shows the offset within the ±4¢ lock window.
- Monophonic by design — exactly one key animates at a time. No dependencies, own `AudioContext`, runs only while the toggle is on.

## Robustness (from two review passes)
- 250 ms **hold** so frequent single-frame detection dropouts don't make the key flicker.
- `build()` clears the highlight before rebuilding the keyboard, so a range change can't strand `litKey` on a detached node.
- The tuner yields the `now` readout when a key is physically held, so playing and listening don't clobber each other.
- Resumes the mic `AudioContext` on `visibilitychange` (iOS interrupts it when backgrounded).
- Feature-detects `getFloatTimeDomainData` (Safari <14.1) with a graceful message; generation token guards rapid toggling.

## Testing
- `node --check` passes on `keyboard.js` / `audio.js`.
- Mic capture needs a real browser + microphone over HTTPS, so the live behavior (drift direction, `STROBE_GAIN`, lock window) hasn't been exercised headlessly — these are one-line tweaks at the top of the mic block if they need tuning in practice.

https://claude.ai/code/session_018c7pdf8stKujUZWB2Qo49J

---
_Generated by [Claude Code](https://claude.ai/code/session_018c7pdf8stKujUZWB2Qo49J)_