### PR TITLE
Add Burgmüller 3 Nocturnes for Cello and Guitar

### DIFF
--- a/songs.json
+++ b/songs.json
@@ -16,6 +16,10 @@
   },
   "concerts": {},
   "songs": {
+    "burgmuller-nocturnes": {
+      "title": "Friedrich Burgmüller (1806–1874) — 3 Nocturnes for Cello and Guitar",
+      "videoId": "Hdj6Hv6ANsY"
+    },
     "allemande": {
       "title": "allemande",
       "videoId": "7qpvIepLWPI",


### PR DESCRIPTION
Adds a new song entry for Friedrich Burgmüller (1806–1874) — 3 Nocturnes for Cello and Guitar (YouTube videoId `Hdj6Hv6ANsY`).

Minimal entry (title + video); loops/scales can be added later.

https://claude.ai/code/session_019LqXym5KYejb7Cn9TPp4At

---
_Generated by [Claude Code](https://claude.ai/code/session_019LqXym5KYejb7Cn9TPp4At)_