### PR TITLE
Add a synchronized metronome to the scales page

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -65,6 +65,28 @@ const AudioKit = (() => {
     window.addEventListener('pageshow', resumeCtxs);
   }
 
+  // A single metronome tick scheduled on the shared sequence clock at time `t`.
+  // A short high "click" (square burst with a near-instant decay) so it cuts
+  // through the sustained cello tone; the downbeat is pitched up and a touch
+  // louder. Registered in activeVoices so stopSequence() silences any ticks
+  // still pending in the future when playback is stopped.
+  function scheduleClick(ctx, t, accent) {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'square';
+    osc.frequency.value = accent ? 2000 : 1400;
+    const peak = accent ? 0.22 : 0.13;
+    gain.gain.setValueAtTime(0.0001, t);
+    gain.gain.linearRampToValueAtTime(peak, t + 0.001);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.045);
+    osc.connect(gain).connect(ctx.destination);
+    osc.start(t);
+    osc.stop(t + 0.06);
+    const rec = { osc, gain };
+    activeVoices.push(rec);
+    osc.onended = () => { const k = activeVoices.indexOf(rec); if (k >= 0) activeVoices.splice(k, 1); };
+  }
+
   // Stop the current scale: cancel pending visual callbacks and fade out any
   // scheduled oscillators. Safe to call when nothing is playing.
   function stopSequence() {
@@ -113,7 +135,10 @@ const AudioKit = (() => {
   // release (release length, s), onNote(semi, i) fired as each note sounds,
   // when (absolute audio-clock start time; default = now + 0.05), chain (true =
   // keep the previous sequence's voices instead of stopping them, for gapless
-  // looping). Returns the audio-clock time the next contiguous note would start
+  // looping), clickInterval (beat length in s; >0 adds a metronome tick on each
+  // beat across this pass, locked to the note grid), clickAccent (accent the
+  // pass's first tick — the downbeat where the tonic sounds). Returns the
+  // audio-clock time the next contiguous note would start
   // (= start + seq.length * step), so a loop can schedule the next pass exactly.
   function playSequence(baseMidi, seq, opts = {}) {
     const ctx = getSeqCtx();
@@ -164,6 +189,17 @@ const AudioKit = (() => {
         seqTimers.push(id);
       }
     });
+    // Metronome ticks, locked to the same start as the notes. Beats are a coarser
+    // grid than the note subdivision, so a tick can fall between notes (e.g. four
+    // ticks under a whole note). Round the pass to a whole number of beats so the
+    // grid resets cleanly at each loop seam, keeping the tonic on the downbeat.
+    if (opts.clickInterval > 0) {
+      const dur = seq.length * step;
+      const beats = Math.max(1, Math.round(dur / opts.clickInterval));
+      for (let b = 0; b < beats; b++) {
+        scheduleClick(ctx, start + b * opts.clickInterval, !!opts.clickAccent && b === 0);
+      }
+    }
     return start + seq.length * step;
   }
 

--- a/scales.html
+++ b/scales.html
@@ -357,6 +357,11 @@
       <span class="note-eq">&#x2669; =</span>
       <input id="tempo" type="number" min="40" max="300" step="1" value="112">
     </label>
+    <label class="switch">
+      <input id="metronome" type="checkbox">
+      <span class="track"><span class="thumb"></span></span>
+      metronome
+    </label>
     <label class="ctl">
       note
       <input id="subdiv" type="range" min="0" max="5" step="1" value="2">

--- a/scales.js
+++ b/scales.js
@@ -148,6 +148,7 @@ const { pitchToMidi } = AudioKit;
 // --- scale playback ---
 let autoDescend = false;
 let tempoBpm = 112;
+let metronomeOn = false; // audible click on each beat while a scale plays
 let articulation = 'legato';
 let loopOn = false;
 let repeatEnds = false; // when looping, repeat the turnaround (top/bottom) notes
@@ -266,6 +267,8 @@ function schedulePass(baseMidi, makeSeq, rowReadout, namer, when, chain, rowStaf
     release: art.release,
     when,
     chain,
+    clickInterval: metronomeOn ? 60 / tempoBpm : 0,
+    clickAccent: true, // accent each pass's first beat (the tonic downbeat)
     onNote: (semi) => {
       const name = namer(semi);
       if (center) center.textContent = name;
@@ -665,6 +668,13 @@ function initScaleOptions() {
     if (Number.isFinite(v) && v > 0) tempoBpm = v;
   });
 
+  const metro = document.getElementById('metronome');
+  metronomeOn = metro.checked; // honor a restored value
+  metro.addEventListener('change', () => {
+    metronomeOn = metro.checked;
+    restartIfLooping(); // start/stop ticks immediately on a running loop
+  });
+
   const subdiv = document.getElementById('subdiv');
   const subdivVal = document.getElementById('subdiv-val');
   const showSubdiv = () => {
@@ -732,6 +742,7 @@ const PREFS = [
   { id: 'toggle-extra',  key: 'extra',       kind: 'bool',   ev: 'change' },
   { id: 'octaves',       key: 'octaves',     kind: 'num', min: 1,  max: 3,   ev: 'input' },
   { id: 'tempo',         key: 'tempo',       kind: 'num', min: 40, max: 300, ev: 'input' },
+  { id: 'metronome',     key: 'metronome',   kind: 'bool',   ev: 'change' },
   { id: 'subdiv',        key: 'subdiv',      kind: 'num', min: 0,  max: SUBDIVS.length - 1, ev: 'input' },
   { id: 'loop',          key: 'loop',        kind: 'bool',   ev: 'change' },
   { id: 'repeat-ends',   key: 'repeatEnds',  kind: 'bool',   ev: 'change' },


### PR DESCRIPTION
Adds an optional metronome that clicks on each beat while a scale plays, locked to the same audio-clock start as the notes so it drives the playback grid.

## Changes
- **`audio.js`** — a short square-wave tick voice (downbeat pitched up and louder). `playSequence` now schedules a tick on every beat across each pass, registered with the active voices so stopping playback silences any pending ticks.
- **`scales.js`** — `metronomeOn` flag passed in as `clickInterval = 60/BPM`, with the first beat of each pass accented (the tonic downbeat). Toggling mid-loop takes effect immediately; the setting persists across reloads.
- **`scales.html`** — a "metronome" switch beside the tempo control.

## Notes
Beats are a coarser grid than the note subdivision (e.g. four ticks under a whole note). Each loop pass rounds to a whole number of beats so the grid resets cleanly at the seam and the tonic always lands on the accented click. For the odd combo (triplets over an odd-length scale) that means one slightly-short beat at the loop seam — a deliberate tradeoff to keep the tonic on the downbeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019QSr1KG33nSndM1xHRqNbj)_