### PR TITLE
Add Simone tone generator page

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
           { href: 'scales.html', title: 'scales' },
           { href: 'chords.html', title: 'chords' },
           { href: 'keyboard.html', title: 'keyboard' },
+          { href: 'simone.html', title: 'simone' },
           { href: 'john.html', title: 'john' },
         ];
 

--- a/simone.html
+++ b/simone.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>simone</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      background: #000;
+      color: #fff;
+      font-family: "Cormorant Garamond", serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+      padding: 2.5rem 1rem 4rem;
+      box-sizing: border-box;
+    }
+    a { color: #9cd8ff; }
+    .back {
+      position: fixed;
+      top: 1rem;
+      left: 1rem;
+      font-size: 1rem;
+      color: #666;
+      text-decoration: none;
+    }
+    .back:hover { color: #d8d8ff; }
+
+    h1 {
+      margin: 0;
+      font-size: 2.2rem;
+      font-weight: 500;
+      letter-spacing: 0.06em;
+      text-transform: lowercase;
+    }
+    .hint {
+      margin: -0.5rem 0 0;
+      font-size: 1rem;
+      color: rgba(255, 255, 255, 0.5);
+      font-style: italic;
+      text-align: center;
+    }
+
+    /* Rotary dial */
+    .dial-wrap {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.6rem;
+    }
+    .dial {
+      width: 220px;
+      height: 220px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 50% 38%, #2a2a2a, #0c0c0c 72%);
+      border: 1px solid #444;
+      position: relative;
+      cursor: grab;
+      touch-action: none;
+      box-shadow: inset 0 2px 6px rgba(255,255,255,0.05),
+                  0 6px 18px rgba(0,0,0,0.6);
+    }
+    .dial:active { cursor: grabbing; }
+    .dial:focus-visible { outline: 2px solid #9cd8ff; outline-offset: 4px; }
+    /* The rotating part holds the pointer so it turns with the value. */
+    .dial .rotor {
+      position: absolute;
+      inset: 0;
+      transform: rotate(0deg);
+    }
+    .dial .pointer {
+      position: absolute;
+      top: 12px;
+      left: 50%;
+      width: 4px;
+      height: 70px;
+      margin-left: -2px;
+      border-radius: 2px;
+      background: linear-gradient(#9cd8ff, #2f6f8f);
+    }
+    .dial .hub {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 56px;
+      height: 56px;
+      margin: -28px 0 0 -28px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 50% 40%, #333, #111);
+      border: 1px solid #555;
+    }
+    /* tick marks at the two ends of the 270° sweep */
+    .dial .tick {
+      position: absolute;
+      font-size: 0.8rem;
+      color: rgba(255,255,255,0.4);
+    }
+    .dial .tick.lo { bottom: 14px; left: 14px; }
+    .dial .tick.hi { bottom: 14px; right: 14px; }
+
+    .readout {
+      font-size: 2rem;
+      letter-spacing: 0.03em;
+      color: #9cd8ff;
+      min-width: 7ch;
+      text-align: center;
+    }
+    .readout small { font-size: 1.1rem; color: rgba(255,255,255,0.5); }
+
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 0.7rem 1.6rem;
+      font-size: 1rem;
+      color: rgba(255, 255, 255, 0.75);
+    }
+    .radio {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45em;
+      cursor: pointer;
+      user-select: none;
+    }
+    .radio input { accent-color: #9cd8ff; width: 1.05em; height: 1.05em; }
+
+    button {
+      background: none;
+      border: 1px solid #666;
+      color: #ddd;
+      font-family: inherit;
+      font-size: 1.15rem;
+      letter-spacing: 0.04em;
+      padding: 0.5em 1.6em;
+      cursor: pointer;
+      text-transform: lowercase;
+    }
+    button:hover { border-color: #9cd8ff; color: #fff; }
+    button.on { background: #2f6f8f; border-color: #9cd8ff; color: #fff; }
+  </style>
+</head>
+<body>
+  <a class="back" href="index.html">← back</a>
+
+  <h1>simone</h1>
+  <p class="hint">turn the dial from 20 Hz to 20,000 Hz, then press start<br>add a major third or a perfect fifth above the tone</p>
+
+  <div class="dial-wrap">
+    <div class="dial" id="dial" role="slider" tabindex="0"
+         aria-label="frequency" aria-valuemin="20" aria-valuemax="20000" aria-valuenow="440">
+      <div class="rotor" id="rotor">
+        <div class="pointer"></div>
+      </div>
+      <div class="hub"></div>
+      <span class="tick lo">20</span>
+      <span class="tick hi">20k</span>
+    </div>
+    <div class="readout" id="readout">440 <small>Hz</small></div>
+  </div>
+
+  <div class="controls">
+    <label class="radio">
+      <input type="radio" name="harmony" value="none" checked> tone only
+    </label>
+    <label class="radio">
+      <input type="radio" name="harmony" value="third"> + third
+    </label>
+    <label class="radio">
+      <input type="radio" name="harmony" value="fifth"> + fifth
+    </label>
+  </div>
+
+  <button id="toggle" type="button">start</button>
+
+  <script>
+    // ---- frequency <-> dial geometry ----------------------------------------
+    // The dial sweeps 270°: pointer angle runs from -135° (lower-left, 20 Hz)
+    // clockwise to +135° (lower-right, 20 kHz). Frequency is logarithmic so each
+    // octave gets equal travel.
+    const F_MIN = 20, F_MAX = 20000;
+    const SWEEP = 135; // degrees either side of straight-up
+    const LOG_MIN = Math.log(F_MIN), LOG_RANGE = Math.log(F_MAX) - LOG_MIN;
+
+    const dial = document.getElementById('dial');
+    const rotor = document.getElementById('rotor');
+    const readout = document.getElementById('readout');
+    const toggle = document.getElementById('toggle');
+
+    let freq = 440;
+
+    function tFromFreq(f) { return (Math.log(f) - LOG_MIN) / LOG_RANGE; }
+    function freqFromT(t) { return Math.exp(LOG_MIN + t * LOG_RANGE); }
+
+    function render() {
+      const t = tFromFreq(freq);
+      rotor.style.transform = 'rotate(' + (-SWEEP + t * 2 * SWEEP) + 'deg)';
+      const shown = freq >= 1000
+        ? (freq / 1000).toFixed(freq >= 10000 ? 1 : 2) + ' <small>kHz</small>'
+        : Math.round(freq) + ' <small>Hz</small>';
+      readout.innerHTML = shown;
+      dial.setAttribute('aria-valuenow', Math.round(freq));
+      updateTone();
+    }
+
+    function setFreq(f) {
+      freq = Math.min(F_MAX, Math.max(F_MIN, f));
+      render();
+    }
+    function setT(t) { setFreq(freqFromT(Math.min(1, Math.max(0, t)))); }
+
+    // ---- dial interaction ----------------------------------------------------
+    function angleFromEvent(e) {
+      const r = dial.getBoundingClientRect();
+      const dx = e.clientX - (r.left + r.width / 2);
+      const dy = e.clientY - (r.top + r.height / 2);
+      // 0° = straight up, clockwise positive
+      let a = Math.atan2(dx, -dy) * 180 / Math.PI;
+      return Math.max(-SWEEP, Math.min(SWEEP, a));
+    }
+    function pointerMove(e) {
+      const a = angleFromEvent(e);
+      setT((a + SWEEP) / (2 * SWEEP));
+    }
+    dial.addEventListener('pointerdown', (e) => {
+      dial.setPointerCapture(e.pointerId);
+      pointerMove(e);
+      dial.addEventListener('pointermove', pointerMove);
+    });
+    dial.addEventListener('pointerup', (e) => {
+      dial.releasePointerCapture(e.pointerId);
+      dial.removeEventListener('pointermove', pointerMove);
+    });
+    // keyboard: arrows nudge, page keys jump an octave
+    dial.addEventListener('keydown', (e) => {
+      const step = 1 / 240; // ~1/4 of an octave-ish fine step
+      if (e.key === 'ArrowRight' || e.key === 'ArrowUp') { setT(tFromFreq(freq) + step); e.preventDefault(); }
+      else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') { setT(tFromFreq(freq) - step); e.preventDefault(); }
+      else if (e.key === 'PageUp') { setFreq(freq * 2); e.preventDefault(); }
+      else if (e.key === 'PageDown') { setFreq(freq / 2); e.preventDefault(); }
+    });
+    // scroll wheel for fine tuning
+    dial.addEventListener('wheel', (e) => {
+      e.preventDefault();
+      setT(tFromFreq(freq) + (e.deltaY < 0 ? 1 : -1) / 240);
+    }, { passive: false });
+
+    // ---- audio ---------------------------------------------------------------
+    // A root oscillator, optionally joined by an interval a major third
+    // (2^(4/12)) or perfect fifth (2^(7/12)) above it.
+    const RATIOS = { third: Math.pow(2, 4 / 12), fifth: Math.pow(2, 7 / 12) };
+    let ctx = null, root = null, harm = null, master = null;
+    let playing = false;
+
+    function harmonyMode() {
+      return document.querySelector('input[name="harmony"]:checked').value;
+    }
+
+    function start() {
+      if (!ctx) ctx = new (window.AudioContext || window.webkitAudioContext)();
+      if (ctx.state === 'suspended') ctx.resume();
+      master = ctx.createGain();
+      master.gain.value = 0;
+      master.connect(ctx.destination);
+
+      root = ctx.createOscillator();
+      root.type = 'sine';
+      root.frequency.value = freq;
+      root.connect(master);
+      root.start();
+
+      const mode = harmonyMode();
+      if (mode !== 'none') addHarmonic(mode);
+
+      // gentle fade-in to avoid a click
+      const now = ctx.currentTime;
+      master.gain.setValueAtTime(0, now);
+      master.gain.linearRampToValueAtTime(0.18, now + 0.02);
+
+      playing = true;
+      toggle.textContent = 'stop';
+      toggle.classList.add('on');
+    }
+
+    function addHarmonic(mode) {
+      harm = ctx.createOscillator();
+      harm.type = 'sine';
+      harm.frequency.value = freq * RATIOS[mode];
+      harm.connect(master);
+      harm.start();
+    }
+    function removeHarmonic() {
+      if (harm) { harm.stop(); harm.disconnect(); harm = null; }
+    }
+
+    function stop() {
+      if (!playing) return;
+      const g = master, r = root, h = harm;
+      const now = ctx.currentTime;
+      g.gain.cancelScheduledValues(now);
+      g.gain.setValueAtTime(g.gain.value, now);
+      g.gain.linearRampToValueAtTime(0, now + 0.03);
+      setTimeout(() => {
+        if (r) { r.stop(); r.disconnect(); }
+        if (h) { h.stop(); h.disconnect(); }
+        g.disconnect();
+      }, 60);
+      root = harm = master = null;
+      playing = false;
+      toggle.textContent = 'start';
+      toggle.classList.remove('on');
+    }
+
+    // keep a live tone in sync with the dial and radio buttons
+    function updateTone() {
+      if (!playing) return;
+      const now = ctx.currentTime;
+      root.frequency.setTargetAtTime(freq, now, 0.01);
+      if (harm) harm.frequency.setTargetAtTime(freq * RATIOS[harmonyMode()] || freq, now, 0.01);
+    }
+
+    toggle.addEventListener('click', () => playing ? stop() : start());
+
+    document.querySelectorAll('input[name="harmony"]').forEach((el) => {
+      el.addEventListener('change', () => {
+        if (!playing) return;
+        const mode = harmonyMode();
+        removeHarmonic();
+        if (mode !== 'none') {
+          addHarmonic(mode);
+          // match the master's running level (no re-fade needed)
+        }
+      });
+    });
+
+    render();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
A simple sine-tone generator, linked from the home page.

- **Rotary dial** sweeping **20 Hz – 20 kHz** on a logarithmic scale (drag to turn; arrow keys, page keys, and scroll wheel also work). Live readout in Hz/kHz.
- **Start button** that toggles to **stop**, gating the tone with a short fade to avoid clicks.
- **Radio buttons** to add a **major third** or **perfect fifth** above the fundamental (or tone only). The dial and harmony stay live while playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RewjZuiuEy6knvDnh8huGM)_