### PR TITLE
Spell the tone generator page name Simón

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
           { href: 'scales.html', title: 'scales' },
           { href: 'chords.html', title: 'chords' },
           { href: 'keyboard.html', title: 'keyboard' },
-          { href: 'simone.html', title: 'simone' },
+          { href: 'simone.html', title: 'simón' },
           { href: 'john.html', title: 'john' },
         ];
 

--- a/simone.html
+++ b/simone.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>simone</title>
+  <title>simón</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&display=swap" rel="stylesheet">
@@ -149,7 +149,7 @@
 <body>
   <a class="back" href="index.html">← back</a>
 
-  <h1>simone</h1>
+  <h1>simón</h1>
   <p class="hint">turn the dial from 20 Hz to 20,000 Hz, then press start<br>add a major third or a perfect fifth above the tone</p>
 
   <div class="dial-wrap">


### PR DESCRIPTION
Corrects the displayed page name to **Simón** (accented) in the page title, heading, and home-page link. The filename stays `simone.html` so the URL is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RewjZuiuEy6knvDnh8huGM)_