### PR TITLE
Top jazz 7th arpeggios on the 7th; default play-down-after-up

### DIFF
--- a/jazz7ths.html
+++ b/jazz7ths.html
@@ -367,7 +367,7 @@
       loop
     </label>
     <label class="switch">
-      <input id="auto-descend" type="checkbox">
+      <input id="auto-descend" type="checkbox" checked>
       <span class="track"><span class="thumb"></span></span>
       play down after up
     </label>

--- a/jazz7ths.js
+++ b/jazz7ths.js
@@ -167,13 +167,12 @@ const ARTIC = {
   legato:   { gate: 1.0,  atk: 0.025, sustain: 0.90, release: 0.06 },
 };
 
-// Expand a chord's four tones into an arpeggio across `octaves`, capped with the
-// top octave root so it turns around cleanly — e.g. maj7 over 1 octave ->
-// 0,4,7,11,12; over 2 -> 0,4,7,11,12,16,19,23,24.
+// Expand a chord's four tones into an arpeggio across `octaves`, topping out on
+// the 7th (not the octave root) so the turnaround lands on the chord's colour
+// tone — e.g. maj7 over 1 octave -> 0,4,7,11; over 2 -> 0,4,7,11,12,16,19,23.
 function expand(chord, n) {
   const out = [];
   for (let o = 0; o < n; o++) for (const iv of chord.intervals) out.push(iv + 12 * o);
-  out.push(12 * n);
   return out;
 }
 


### PR DESCRIPTION
Follow-up to the jazz 7ths page (#105):

- **Top note is now the 7th**, not the octave root — each arpeggio turns around on the chord's colour tone (e.g. C maj7 → `C E G B` up and back down).
- **"Play down after up" defaults on**, so each chord plays up and back down out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZWC37sfhXiCUan8rQU3DV)_