### PR TITLE
Refactor scale playback into a reusable cello instrument

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -4,7 +4,9 @@
 // Exposes:
 //   AudioKit.midiToFreq(midi)
 //   AudioKit.pitchToMidi(name, defaultOctave = 3)
-//   AudioKit.playSequence(baseMidi, semitoneOffsets, opts)
+//   AudioKit.createInstrument({ name, timbre, expression }) -> { playSequence, ... }
+//   AudioKit.instruments.cello  -> the natural cello (default melodic voice)
+//   AudioKit.playSequence(baseMidi, semitoneOffsets, opts)  (legacy plain voice)
 //   AudioKit.createDrone()  -> { start, stop, retune, setRoot, setFifth, setVolume, playing }
 const AudioKit = (() => {
   const FIFTH_RATIO = 1.5;
@@ -124,9 +126,15 @@ const AudioKit = (() => {
     return { input: lp, output: fC, lp, baseCut: 5000 };
   }
 
-  // Expressiveness presets, indexed by level (0 = mechanical, 1 = natural,
-  // 2 = expressive). Every humanizing amount is 0 at level 0 so that level
-  // reproduces the plain re-articulated playback exactly.
+  // --- instrument model -----------------------------------------------------
+  // An instrument bundles a *timbre* (how one sustained voice sounds) with an
+  // optional *expression* profile (how a melodic line is phrased) and knows how
+  // to play a sequence of notes with that voice. The cello below is the first
+  // instrument; the poly synth's piano/cello timbres can be described as
+  // profiles here in a later pass so every voice shares one definition.
+  //
+  // A timbre: { wave, makeFilters(ctx) -> { input, output, lp?, baseCut? } }.
+  // An expression profile (null = plain, un-phrased re-articulation):
   //   glide     portamento time constant for note-to-note pitch (s)
   //   vib       vibrato depth as a fraction of the sounding frequency
   //   vibRate   vibrato speed (Hz)
@@ -137,15 +145,14 @@ const AudioKit = (() => {
   //   bite      attack brightness sweep on the lowpass (fraction of cutoff)
   //   artic     legato inter-note dip depth (how much the tone eases between
   //             slurred notes so they're heard as separate, not one smear)
-  // Expressive (level 2) is a *tasteful* step above natural — a touch more
-  // singing vibrato, dynamic shaping and bite — but deliberately keeps steady
-  // time (timing: 0) and only a hair more portamento, so an even scale doesn't
-  // wobble or sound seasick.
-  const EXPRESSION = [
-    { glide: 0,     vib: 0,      vibRate: 0,   dyn: 0,    accent: 0,    dynJitter: 0,    timing: 0, bite: 0,    artic: 0    },
-    { glide: 0.020, vib: 0.003,  vibRate: 5.2, dyn: 0.06, accent: 0.06, dynJitter: 0.03, timing: 0, bite: 0.16, artic: 0.14 },
-    { glide: 0.024, vib: 0.0052, vibRate: 5.6, dyn: 0.10, accent: 0.09, dynJitter: 0.03, timing: 0, bite: 0.22, artic: 0.16 },
-  ];
+  const CELLO_TIMBRE = { wave: 'sawtooth', makeFilters: celloFilters };
+  // The "natural" cello: connected, singing legato with gentle humanizing —
+  // steady time, a hair of portamento, fade-in vibrato and dynamic shaping.
+  const CELLO_EXPRESSION = {
+    glide: 0.020, vib: 0.003, vibRate: 5.2,
+    dyn: 0.06, accent: 0.06, dynJitter: 0.03,
+    timing: 0, bite: 0.16, artic: 0.14,
+  };
 
   // Current audio-clock time (creates the shared context if needed). Lets the
   // caller schedule contiguous loop passes against the same timeline.
@@ -172,13 +179,13 @@ const AudioKit = (() => {
   // "throb"). Distinct notes are still heard because the tone eases down a touch
   // at each boundary (EX.artic) before swelling back, and the pitch slides in
   // over a short portamento (EX.glide). A gentle vibrato fades in over the pass.
-  function renderConnected(ctx, baseMidi, seq, o) {
+  function renderConnected(ctx, timbre, baseMidi, seq, o) {
     const { start, step, gate, atk, release, EX, dynFor, timeFor, scheduleOnNote } = o;
     const n = seq.length;
     const osc = ctx.createOscillator();
-    const voice = celloFilters(ctx);
+    const voice = timbre.makeFilters(ctx);
     const gain = ctx.createGain();
-    osc.type = 'sawtooth';
+    osc.type = timbre.wave;
     osc.connect(voice.input);
     voice.output.connect(gain).connect(ctx.destination);
 
@@ -199,7 +206,7 @@ const AudioKit = (() => {
     const firstAtk = Math.min(Math.max(atk * 3, 0.05), gate * 0.7);
     gain.gain.setValueAtTime(0.0001, start);
     gain.gain.setTargetAtTime(p0, start, firstAtk / 3);
-    applyBite(voice, start, firstAtk, EX.bite); // open the tone in over the same soft attack
+    if (EX.bite > 0 && voice.lp) applyBite(voice, start, firstAtk, EX.bite); // open the tone in over the same soft attack
     scheduleOnNote(seq[0], 0, start);
 
     for (let i = 1; i < n; i++) {
@@ -237,27 +244,27 @@ const AudioKit = (() => {
     osc.onended = () => { const k = activeVoices.indexOf(rec); if (k >= 0) activeVoices.splice(k, 1); };
   }
 
-  // Plays a sequence of semitone offsets from baseMidi using the cello voice.
+  // Play a sequence of semitone offsets from baseMidi with `instr`'s voice.
   // opts: step (onset spacing, s), gate (sounding length, s), attack (s),
   // peak (gain), sustain (0 = plucked decay over the whole gate; >0 = hold at
-  // that fraction of peak until a short release — needed for legato/portato),
-  // release (release length, s), onNote(semi, i) fired as each note sounds,
-  // when (absolute audio-clock start time; default = now + 0.05), chain (true =
-  // keep the previous sequence's voices instead of stopping them, for gapless
+  // that fraction of peak until a short release — for portato/legato), release
+  // (release length, s), onNote(semi, i) fired as each note sounds, when
+  // (absolute audio-clock start time; default = now + 0.05), chain (true = keep
+  // the previous sequence's voices instead of stopping them, for gapless
   // looping), clickInterval (beat length in s; >0 adds a metronome tick on each
   // beat across this pass, locked to the note grid), clickAccent (accent the
-  // pass's first tick — the downbeat where the tonic sounds),
-  // expressiveness (0 = mechanical/plain re-articulation, 1 = natural, 2 =
-  // expressive — adds portamento, vibrato, loudness contour, attack bite and
-  // micro-timing), legato (true = this articulation fully connects, so at
-  // expressiveness >= 1 the pass is rendered as one continuous glided voice).
-  // Returns the audio-clock time the next contiguous note would start
-  // (= start + seq.length * step), so a loop can schedule the next pass exactly.
-  function playSequence(baseMidi, seq, opts = {}) {
+  // pass's first tick — the downbeat where the tonic sounds), legato (true = the
+  // articulation fully connects, so an expressive instrument renders the pass as
+  // one continuous glided voice instead of note-by-note). Returns the audio-clock
+  // time the next contiguous note would start (= start + seq.length * step), so a
+  // loop can schedule the next pass exactly.
+  function renderSequence(instr, baseMidi, seq, opts = {}) {
     const ctx = getSeqCtx();
     // Resume on any non-running state (covers iOS 'interrupted' after a lock),
     // running inside this user-gesture call so iOS allows it.
     if (ctx.state !== 'running') { try { ctx.resume(); } catch (e) {} }
+    const timbre = instr.timbre;
+    const EX = instr.expression; // null = plain, un-phrased playback
     const step = opts.step != null ? opts.step : 0.42;
     const gate = Math.max(opts.gate != null ? opts.gate : step * 0.92, 0.04);
     const attack = opts.attack != null ? opts.attack : 0.02;
@@ -265,34 +272,32 @@ const AudioKit = (() => {
     const sustain = opts.sustain != null ? opts.sustain : 0;
     const release = opts.release != null ? opts.release : 0.05;
     const onNote = typeof opts.onNote === 'function' ? opts.onNote : null;
-    const expr = Math.max(0, Math.min(2, opts.expressiveness | 0));
-    const EX = EXPRESSION[expr];
-    // "Connected" playback (legato) at expressiveness >= 1 is rendered as one
+    // A fully-connected articulation on an expressive instrument becomes one
     // continuous glided voice; everything else is note-by-note.
-    const connected = !!opts.legato && expr >= 1;
-    // Never layer a second scale over the first, unless chaining a loop pass.
+    const connected = !!opts.legato && !!EX;
+    // Never layer a second sequence over the first, unless chaining a loop pass.
     if (!opts.chain) stopSequence();
     const now = ctx.currentTime;
     const start = opts.when != null ? Math.max(opts.when, now) : now + 0.05;
     const atk = Math.min(attack, gate * 0.5);
 
-    // Loudness contour: at level 0 every note is `peak`; above that, higher
-    // notes sound a touch louder, the tonic is emphasized, and each note gets a
-    // small random nudge so the line breathes instead of marching.
+    // Loudness contour (expressive instruments only): higher notes a touch
+    // louder, the tonic emphasized, plus a small per-note nudge so the line
+    // breathes. Plain instruments hold a constant `peak`.
     const lo = Math.min(...seq), hi = Math.max(...seq);
     const spanSemis = Math.max(1, hi - lo);
     function dynFor(semi, i) {
-      if (expr === 0) return peak;
+      if (!EX) return peak;
       const contour = EX.dyn * (((semi - lo) / spanSemis) - 0.5) * 2;
       const accent = i === 0 ? EX.accent : 0;
       const jitter = EX.dynJitter ? (Math.random() * 2 - 1) * EX.dynJitter : 0;
       return Math.max(peak * (1 + contour + accent + jitter), 0.0002);
     }
-    // Micro-timing: nudge onsets off the grid at level 2, but never the first
-    // note of a pass, so loop seams stay locked and the tonic lands on the beat.
+    // Micro-timing: nudge onsets off the grid, but never the first note of a
+    // pass, so loop seams stay locked and the tonic lands on the beat.
     function timeFor(i) {
       const base = start + i * step;
-      if (EX.timing === 0 || i === 0) return base;
+      if (!EX || EX.timing === 0 || i === 0) return base;
       return base + (Math.random() * 2 - 1) * EX.timing;
     }
     function scheduleOnNote(semi, i, t) {
@@ -305,7 +310,7 @@ const AudioKit = (() => {
     }
 
     if (connected) {
-      renderConnected(ctx, baseMidi, seq, {
+      renderConnected(ctx, timbre, baseMidi, seq, {
         start, step, gate, atk, release, peak, EX, dynFor, timeFor, scheduleOnNote,
       });
     } else {
@@ -313,9 +318,9 @@ const AudioKit = (() => {
         const t = timeFor(i);
         const p = dynFor(semi, i);
         const osc = ctx.createOscillator();
-        const voice = celloFilters(ctx);
+        const voice = timbre.makeFilters(ctx);
         const gain = ctx.createGain();
-        osc.type = 'sawtooth';
+        osc.type = timbre.wave;
         osc.frequency.value = midiToFreq(baseMidi + semi);
         gain.gain.setValueAtTime(0.0001, t);
         gain.gain.linearRampToValueAtTime(p, t + atk);
@@ -327,9 +332,9 @@ const AudioKit = (() => {
           gain.gain.setValueAtTime(susLevel, Math.max(decayEnd, t + gate - release));
         }
         gain.gain.exponentialRampToValueAtTime(0.0001, t + gate);
-        // Bow "bite": a brief brightening on the attack, tied to the note's
-        // dynamic. Silent at level 0 (bite = 0) so timbre is unchanged there.
-        if (EX.bite > 0) applyBite(voice, t, atk, EX.bite);
+        // Bow "bite": a brief brightening on the attack (expressive instruments
+        // whose timbre has a lowpass to sweep).
+        if (EX && EX.bite > 0 && voice.lp) applyBite(voice, t, atk, EX.bite);
         osc.connect(voice.input);
         voice.output.connect(gain).connect(ctx.destination);
         osc.start(t);
@@ -353,6 +358,30 @@ const AudioKit = (() => {
     }
     return start + seq.length * step;
   }
+
+  // Build an instrument from a profile: { name, timbre, expression? }. Returns
+  // an object exposing playSequence(baseMidi, seq, opts) that renders with the
+  // profile's voice. All instruments share one scheduler and audio context, so
+  // only one instrument's sequence sounds at a time (stopSequence stops it).
+  function createInstrument(profile) {
+    const instr = {
+      name: profile.name || 'instrument',
+      timbre: profile.timbre,
+      expression: profile.expression || null,
+    };
+    instr.playSequence = (baseMidi, seq, opts = {}) => renderSequence(instr, baseMidi, seq, opts);
+    return instr;
+  }
+
+  // The natural cello — the site's default melodic voice.
+  const cello = createInstrument({ name: 'cello', timbre: CELLO_TIMBRE, expression: CELLO_EXPRESSION });
+  // Plain, un-phrased cello: keeps the original note-by-note playback for pages
+  // that haven't yet migrated to an expressive instrument.
+  const plainCello = createInstrument({ name: 'cello-plain', timbre: CELLO_TIMBRE, expression: null });
+
+  // Back-compat: the legacy top-level player. New code should reach for an
+  // instrument (e.g. AudioKit.instruments.cello) instead.
+  function playSequence(baseMidi, seq, opts) { return plainCello.playSequence(baseMidi, seq, opts); }
 
   // Sustained root with an optional perfect fifth. A sub-audible noise layer
   // keeps Bluetooth codecs from silence-gating the steady tone.
@@ -596,5 +625,10 @@ const AudioKit = (() => {
     };
   }
 
-  return { FIFTH_RATIO, midiToFreq, pitchToMidi, midiToName, playSequence, stopSequence, currentTime, createDrone, createPolySynth, resume: resumeCtxs };
+  return {
+    FIFTH_RATIO, midiToFreq, pitchToMidi, midiToName,
+    playSequence, stopSequence, currentTime,
+    createInstrument, instruments: { cello },
+    createDrone, createPolySynth, resume: resumeCtxs,
+  };
 })();

--- a/audio.js
+++ b/audio.js
@@ -147,9 +147,10 @@ const AudioKit = (() => {
   //             slurred notes so they're heard as separate, not one smear)
   const CELLO_TIMBRE = { wave: 'sawtooth', makeFilters: celloFilters };
   // The "natural" cello: connected, singing legato with gentle humanizing —
-  // steady time, a hair of portamento, fade-in vibrato and dynamic shaping.
+  // steady time, a hair of portamento, and dynamic shaping. No vibrato
+  // (vib: 0 skips the LFO); vibRate stays for any future instrument that wants it.
   const CELLO_EXPRESSION = {
-    glide: 0.020, vib: 0.003, vibRate: 5.2,
+    glide: 0.020, vib: 0, vibRate: 5.2,
     dyn: 0.06, accent: 0.06, dynJitter: 0.03,
     timing: 0, bite: 0.16, artic: 0.14,
   };

--- a/audio.js
+++ b/audio.js
@@ -137,10 +137,14 @@ const AudioKit = (() => {
   //   bite      attack brightness sweep on the lowpass (fraction of cutoff)
   //   artic     legato inter-note dip depth (how much the tone eases between
   //             slurred notes so they're heard as separate, not one smear)
+  // Expressive (level 2) is a *tasteful* step above natural — a touch more
+  // singing vibrato, dynamic shaping and bite — but deliberately keeps steady
+  // time (timing: 0) and only a hair more portamento, so an even scale doesn't
+  // wobble or sound seasick.
   const EXPRESSION = [
-    { glide: 0,     vib: 0,     vibRate: 0,   dyn: 0,    accent: 0,    dynJitter: 0,    timing: 0,     bite: 0,    artic: 0    },
-    { glide: 0.020, vib: 0.003, vibRate: 5.2, dyn: 0.06, accent: 0.06, dynJitter: 0.03, timing: 0,     bite: 0.16, artic: 0.14 },
-    { glide: 0.030, vib: 0.006, vibRate: 5.5, dyn: 0.12, accent: 0.10, dynJitter: 0.05, timing: 0.008, bite: 0.28, artic: 0.20 },
+    { glide: 0,     vib: 0,      vibRate: 0,   dyn: 0,    accent: 0,    dynJitter: 0,    timing: 0, bite: 0,    artic: 0    },
+    { glide: 0.020, vib: 0.003,  vibRate: 5.2, dyn: 0.06, accent: 0.06, dynJitter: 0.03, timing: 0, bite: 0.16, artic: 0.14 },
+    { glide: 0.024, vib: 0.0052, vibRate: 5.6, dyn: 0.10, accent: 0.09, dynJitter: 0.03, timing: 0, bite: 0.22, artic: 0.16 },
   ];
 
   // Current audio-clock time (creates the shared context if needed). Lets the
@@ -187,11 +191,15 @@ const AudioKit = (() => {
 
     // Pitch: start on the first note, glide to each subsequent one.
     osc.frequency.setValueAtTime(midiToFreq(baseMidi + seq[0]), start);
-    // Amplitude: attack once, then hold.
+    // Amplitude: soften the very first onset — a slow, rounded rise (the bow
+    // catching the string), gentler than the quick linear attack of the notes
+    // that swell out of the preceding one. setTargetAtTime gives a curved
+    // approach with no hard corner at the top.
     const p0 = dynFor(seq[0], 0);
+    const firstAtk = Math.min(Math.max(atk * 3, 0.05), gate * 0.7);
     gain.gain.setValueAtTime(0.0001, start);
-    gain.gain.linearRampToValueAtTime(p0, start + atk);
-    applyBite(voice, start, atk, EX.bite);
+    gain.gain.setTargetAtTime(p0, start, firstAtk / 3);
+    applyBite(voice, start, firstAtk, EX.bite); // open the tone in over the same soft attack
     scheduleOnNote(seq[0], 0, start);
 
     for (let i = 1; i < n; i++) {

--- a/scales.html
+++ b/scales.html
@@ -382,19 +382,6 @@
       <span class="track"><span class="thumb"></span></span>
       repeat top &amp; bottom
     </label>
-    <label class="ctl">
-      articulation
-      <select id="articulation">
-        <option value="staccato">staccato</option>
-        <option value="portato">portato</option>
-        <option value="legato" selected>legato</option>
-      </select>
-    </label>
-    <label class="ctl">
-      expression
-      <input id="expressiveness" type="range" min="0" max="2" step="1" value="1">
-      <span id="expressiveness-val" class="subdiv-val">natural</span>
-    </label>
   </div>
 
   <div id="modes"></div>

--- a/scales.js
+++ b/scales.js
@@ -144,14 +144,12 @@ let showExtra = false; // "show additional scales"
 let octaves = 1;
 
 const { pitchToMidi } = AudioKit;
+const cello = AudioKit.instruments.cello; // the natural, always-legato melodic voice
 
 // --- scale playback ---
 let autoDescend = false;
 let tempoBpm = 112;
 let metronomeOn = false; // audible click on each beat while a scale plays
-let articulation = 'legato';
-let expressiveness = 1; // 0 mechanical, 1 natural, 2 expressive (humanized playback)
-const EXPRESSIVENESS_LABELS = ['mechanical', 'natural', 'expressive'];
 let loopOn = false;
 let repeatEnds = false; // when looping, repeat the turnaround (top/bottom) notes
 let playingButton = null; // the play button whose scale is currently sounding
@@ -169,14 +167,10 @@ const SUBDIVS = [
   { label: '♬',  name: 'sixteenth', perBeat: 4 },
 ];
 
-// gate = fraction of the beat the note sounds; sustain = held level; atk/release
-// = envelope edges. A smooth continuum: staccato is gently detached (not clipped),
-// portato sits midway, legato fully connects.
-const ARTIC = {
-  staccato: { gate: 0.60, atk: 0.008, sustain: 0.50, release: 0.05 },
-  portato:  { gate: 0.80, atk: 0.015, sustain: 0.70, release: 0.06 },
-  legato:   { gate: 1.0,  atk: 0.025, sustain: 0.90, release: 0.06 },
-};
+// Every scale is played legato: notes fully connect and the natural cello
+// renders them as one continuous glided voice. gate = fraction of the beat the
+// note sounds; sustain = held level; atk/release = envelope edges.
+const LEGATO = { gate: 1.0, atk: 0.025, sustain: 0.90, release: 0.06 };
 
 // Expand a one-octave interval set (ending on 12) across `octaves` octaves,
 // e.g. major over 2 octaves -> 0,2,4,5,7,9,11,12,14,16,17,19,21,23,24.
@@ -254,23 +248,21 @@ function restartIfLooping() {
 function schedulePass(baseMidi, makeSeq, rowReadout, namer, when, chain, rowStaff) {
   const seq = makeSeq();
   const step = (60 / tempoBpm) / SUBDIVS[subdivIndex].perBeat;
-  const art = ARTIC[articulation] || ARTIC.legato;
   const center = document.getElementById('playing-note');
   const trebleEl = document.getElementById('toggle-treble');
   // When looping without repeating the turnaround, drop a trailing note that
   // duplicates the first (e.g. up-then-down) so the bottom isn't struck twice.
   const noRepeat = loopOn && !repeatEnds && seq.length > 1 && seq[0] === seq[seq.length - 1];
   const toPlay = noRepeat ? seq.slice(0, -1) : seq;
-  const nextStart = AudioKit.playSequence(baseMidi, toPlay, {
+  const nextStart = cello.playSequence(baseMidi, toPlay, {
     step,
-    gate: step * art.gate,
-    attack: art.atk,
-    sustain: art.sustain,
-    release: art.release,
+    gate: step * LEGATO.gate,
+    attack: LEGATO.atk,
+    sustain: LEGATO.sustain,
+    release: LEGATO.release,
     when,
     chain,
-    expressiveness,
-    legato: articulation === 'legato', // fully-connected articulation → glided legato voice
+    legato: true, // always fully connected → the cello's glided legato voice
     clickInterval: metronomeOn ? 60 / tempoBpm : 0,
     clickAccent: true, // accent each pass's first beat (the tonic downbeat)
     onNote: (semi) => {
@@ -702,24 +694,6 @@ function initScaleOptions() {
     repeatEnds = repeat.checked;
     restartIfLooping(); // apply immediately to a running loop
   });
-
-  const artic = document.getElementById('articulation');
-  articulation = artic.value;
-  artic.addEventListener('change', () => {
-    articulation = artic.value;
-    restartIfLooping(); // legato ↔ detached changes the voice; apply it now
-  });
-
-  const expr = document.getElementById('expressiveness');
-  const exprVal = document.getElementById('expressiveness-val');
-  const showExpr = () => { exprVal.textContent = EXPRESSIVENESS_LABELS[expressiveness]; };
-  expressiveness = parseInt(expr.value, 10);
-  showExpr();
-  expr.addEventListener('input', () => {
-    expressiveness = parseInt(expr.value, 10);
-    showExpr();
-    restartIfLooping(); // re-voice a running loop at the new level immediately
-  });
 }
 
 function initViewToggles() {
@@ -765,8 +739,6 @@ const PREFS = [
   { id: 'loop',          key: 'loop',        kind: 'bool',   ev: 'change' },
   { id: 'repeat-ends',   key: 'repeatEnds',  kind: 'bool',   ev: 'change' },
   { id: 'auto-descend',  key: 'autoDescend', kind: 'bool',   ev: 'change' },
-  { id: 'articulation',  key: 'articulation',kind: 'option', ev: 'change' },
-  { id: 'expressiveness', key: 'expressiveness', kind: 'num', min: 0, max: 2, ev: 'input' },
   { id: 'toggle-sig',    key: 'sig',         kind: 'bool',   ev: 'change' },
   { id: 'toggle-keysig', key: 'keysig',      kind: 'bool',   ev: 'change' },
   { id: 'toggle-treble', key: 'treble',      kind: 'bool',   ev: 'change' },


### PR DESCRIPTION
## Summary

Extracts the scales page's "natural" voice into a reusable instrument and pares the page's audio UI down to that single voice.

## Changes

- **Instrument model in `audio.js`**: new `AudioKit.createInstrument({ name, timbre, expression })`. A *timbre* is a waveform + filter chain; an *expression* profile is the phrasing (portamento glide, dynamics, attack "bite", legato articulation dips), or `null` for plain note-by-note. `renderSequence` drives both: an expressive instrument plays a fully-connected line as one continuous glided voice; a plain one re-articulates per note. The natural cello is registered as `AudioKit.instruments.cello`.
- **Scales page**: always uses the natural cello, always legato. Removed the expressiveness slider and the articulation selector, along with their state, persistence, and event wiring. One voice, no knobs.
- **No vibrato** on the cello (kept in the engine for future instruments).
- **First note** eases in with a soft, rounded attack rather than a hard onset.

## Compatibility

The old top-level `AudioKit.playSequence` is now a thin shim over a *plain* cello instrument, so the pages not migrated in this pass (`jazz7ths`, `song`) sound exactly as before. The instrument profile is shaped to also describe the poly synth's piano/cello timbres in a later pass.

## Verification

- `node --check` passes on all touched files.
- Driven headless in Chromium: the removed controls are gone; `createInstrument` / `instruments.cello` are exposed; one scale play renders a single continuous voice; the legacy `playSequence` path still runs; zero console errors (excluding the sandbox's blocked-font network error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2rJrUAd9FpwKyFMXdUoSE)_