### PR TITLE
Render note-value glyphs in Bravura so whole/half show correctly

### DIFF
--- a/scales.html
+++ b/scales.html
@@ -182,7 +182,11 @@
     .ctl input[type="range"] { width: 6em; }
     .ctl-val { min-width: 1ch; color: #9cd8ff; }
     .subdiv-val { min-width: 5.5em; color: #9cd8ff; }
-    .note-eq { font-size: 1.25rem; color: rgba(255, 255, 255, 0.8); }
+    /* Note-value glyphs are SMuFL (Bravura) so whole/half render everywhere;
+       line-height:0 keeps the tall stem from stretching the control row. */
+    .note-glyph { font-family: 'Bravura'; font-size: 1.4em; line-height: 0; vertical-align: -0.05em; }
+    .subdiv-val sup { font-size: 0.7em; }
+    .note-eq { color: rgba(255, 255, 255, 0.8); }
     .ctl .unit { opacity: 0.55; }
     .ctl input[type="number"],
     .ctl select {
@@ -354,7 +358,7 @@
       <span id="octaves-val" class="ctl-val">1</span>
     </label>
     <label class="ctl">
-      <span class="note-eq">&#x2669; =</span>
+      <span class="note-eq"><span class="note-glyph">&#xE1D5;</span> =</span>
       <input id="tempo" type="number" min="40" max="300" step="1" value="112">
     </label>
     <label class="switch">
@@ -365,7 +369,7 @@
     <label class="ctl">
       note
       <input id="subdiv" type="range" min="0" max="5" step="1" value="2">
-      <span id="subdiv-val" class="subdiv-val">&#x2669; quarter</span>
+      <span id="subdiv-val" class="subdiv-val"><span class="note-glyph">&#xE1D5;</span> quarter</span>
     </label>
     <label class="switch">
       <input id="loop" type="checkbox">

--- a/scales.js
+++ b/scales.js
@@ -157,14 +157,18 @@ let currentPlay = null; // { baseMidi, makeSeq, rowReadout } for re-triggering a
 let loopTimerId = null; // pending timer that schedules the next loop pass
 
 // Note value per beat: how many scale notes fit in one quarter-note beat.
+// `glyph` is a SMuFL (Bravura) codepoint, not a Unicode "Musical Symbols" char:
+// the whole/half-note codepoints (U+1D15D/1D15E) are absent from most device
+// fonts and rendered as "no glyph" tofu, while quarter/eighth (U+2669/266A) did
+// not. Bravura is self-hosted, so every note value now renders identically.
 let subdivIndex = 0;
 const SUBDIVS = [
-  { label: '𝅝',  name: 'whole',     perBeat: 0.25 },
-  { label: '𝅗𝅥',  name: 'half',      perBeat: 0.5  },
-  { label: '♩',  name: 'quarter',   perBeat: 1 },
-  { label: '♪',  name: 'eighth',    perBeat: 2 },
-  { label: '♪³', name: 'triplet',   perBeat: 3 },
-  { label: '♬',  name: 'sixteenth', perBeat: 4 },
+  { glyph: '', name: 'whole',     perBeat: 0.25 },          // noteWhole
+  { glyph: '', name: 'half',      perBeat: 0.5  },          // noteHalfUp
+  { glyph: '', name: 'quarter',   perBeat: 1    },          // noteQuarterUp
+  { glyph: '', name: 'eighth',    perBeat: 2    },          // note8thUp
+  { glyph: '', name: 'triplet',   perBeat: 3, sup: '3' },   // note8thUp + "3"
+  { glyph: '', name: 'sixteenth', perBeat: 4    },          // note16thUp
 ];
 
 // Every scale is played legato: notes fully connect and the natural cello
@@ -675,7 +679,11 @@ function initScaleOptions() {
   const subdivVal = document.getElementById('subdiv-val');
   const showSubdiv = () => {
     const s = SUBDIVS[subdivIndex];
-    subdivVal.textContent = `${s.label} ${s.name}`;
+    // The note glyph is a Bravura codepoint, so it needs the music font (via
+    // the .note-glyph class); the name stays in the page font. Content is from
+    // the constant SUBDIVS table, so innerHTML carries no untrusted input.
+    subdivVal.innerHTML =
+      `<span class="note-glyph">${s.glyph}</span>${s.sup ? `<sup>${s.sup}</sup>` : ''} ${s.name}`;
   };
   subdivIndex = parseInt(subdiv.value, 10);
   showSubdiv();


### PR DESCRIPTION
## Summary

The subdivision ("note") label's whole and half notes rendered as "no glyph" tofu on most devices, while quarter/eighth looked fine.

## Cause

Whole/half used Unicode "Musical Symbols" codepoints (U+1D15D / U+1D15E) that most device fonts don't include; quarter/eighth used the widely-supported Miscellaneous Symbols block (U+2669 / U+266A), which happened to render.

## Fix

Switch every note-value glyph — the subdivision label and the tempo `= ` mark — to SMuFL codepoints in the self-hosted **Bravura** font already used for the staves, so all six render identically on every device. A `.note-glyph` span carries the music font; `line-height: 0` keeps the stem from stretching the control row.

## Verification

- `node --check` passes.
- Driven headless in Chromium: Bravura loads, all six note values render with clean alignment, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2rJrUAd9FpwKyFMXdUoSE)_