### PR TITLE
Set scales page defaults to the preferred configuration

### DIFF
--- a/scales.html
+++ b/scales.html
@@ -341,7 +341,7 @@
   <div class="drone">
     <button id="drone-btn" type="button">drone</button>
     <label class="switch">
-      <input id="drone-fifth" type="checkbox">
+      <input id="drone-fifth" type="checkbox" checked>
       <span class="track"><span class="thumb"></span></span>
       add 5th
     </label>
@@ -354,15 +354,15 @@
   <div class="controls">
     <label class="ctl">
       octaves
-      <input id="octaves" type="range" min="1" max="3" step="1" value="1">
-      <span id="octaves-val" class="ctl-val">1</span>
+      <input id="octaves" type="range" min="1" max="3" step="1" value="3">
+      <span id="octaves-val" class="ctl-val">3</span>
     </label>
     <label class="ctl">
       <span class="note-eq"><span class="note-glyph">&#xE1D5;</span> =</span>
-      <input id="tempo" type="number" min="40" max="300" step="1" value="112">
+      <input id="tempo" type="number" min="40" max="300" step="1" value="60">
     </label>
     <label class="switch">
-      <input id="metronome" type="checkbox">
+      <input id="metronome" type="checkbox" checked>
       <span class="track"><span class="thumb"></span></span>
       metronome
     </label>
@@ -372,17 +372,17 @@
       <span id="subdiv-val" class="subdiv-val"><span class="note-glyph">&#xE1D5;</span> quarter</span>
     </label>
     <label class="switch">
-      <input id="loop" type="checkbox">
+      <input id="loop" type="checkbox" checked>
       <span class="track"><span class="thumb"></span></span>
       loop
     </label>
     <label class="switch">
-      <input id="auto-descend" type="checkbox">
+      <input id="auto-descend" type="checkbox" checked>
       <span class="track"><span class="thumb"></span></span>
       play down after up
     </label>
     <label class="switch">
-      <input id="repeat-ends" type="checkbox">
+      <input id="repeat-ends" type="checkbox" checked>
       <span class="track"><span class="thumb"></span></span>
       repeat top &amp; bottom
     </label>

--- a/scales.js
+++ b/scales.js
@@ -141,14 +141,14 @@ const GROUP_LABEL = { mode: 'modes', other: 'other scales' };
 
 let selectedIndex = 0; // default C
 let showExtra = false; // "show additional scales"
-let octaves = 1;
+let octaves = 3;
 
 const { pitchToMidi } = AudioKit;
 const cello = AudioKit.instruments.cello; // the natural, always-legato melodic voice
 
 // --- scale playback ---
 let autoDescend = false;
-let tempoBpm = 112;
+let tempoBpm = 60;
 let metronomeOn = false; // audible click on each beat while a scale plays
 let loopOn = false;
 let repeatEnds = false; // when looping, repeat the turnaround (top/bottom) notes


### PR DESCRIPTION
## Summary

Bake the preferred settings as the fresh-visitor defaults on the scales page.

## Defaults changed

- octaves → 3
- tempo → 60 BPM
- metronome → on
- loop → on
- play down after up → on
- repeat top & bottom → on
- drone add-5th → on

Note value stays quarter; drone volume stays 0.1.

## Notes

- These are HTML control defaults, so they only apply to visitors with no saved preferences. Anyone who has already used the page keeps their `localStorage` settings, which still win.
- The drone can't default to *playing* (browsers block audio until a user gesture); only its add-5th toggle and volume are defaulted, so pressing **drone** starts with the fifth already on.

## Verification

- `node --check` passes.
- Driven headless with `localStorage` cleared: every control reflects the new defaults, no page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2rJrUAd9FpwKyFMXdUoSE)_