### PR TITLE
Add metronome page with sweeping pendulum arm

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,7 @@
           { href: 'jazz7ths.html', title: 'jazz 7ths' },
           { href: 'giantsteps.html', title: 'giant steps' },
           { href: 'keyboard.html', title: 'keyboard' },
+          { href: 'metronome.html', title: 'metronome' },
           { href: 'simone.html', title: 'simón' },
           { href: 'john.html', title: 'john' },
         ];

--- a/metronome.html
+++ b/metronome.html
@@ -1,0 +1,659 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>metronome</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --accent: #9cd8ff;
+      --accent-dim: #2f6f8f;
+      --line: rgba(255, 255, 255, 0.12);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: radial-gradient(120% 90% at 50% -10%, #10151c 0%, #05070a 55%, #000 100%);
+      color: #fff;
+      font-family: "Cormorant Garamond", serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.4rem;
+      padding: 2.5rem 1rem 4rem;
+    }
+    a { color: var(--accent); }
+    .back {
+      position: fixed;
+      top: 1rem;
+      left: 1rem;
+      font-size: 1rem;
+      color: #666;
+      text-decoration: none;
+      z-index: 10;
+    }
+    .back:hover { color: #d8d8ff; }
+
+    h1 {
+      margin: 0;
+      font-size: 2.2rem;
+      font-weight: 500;
+      letter-spacing: 0.06em;
+      text-transform: lowercase;
+    }
+    .hint {
+      margin: -0.6rem 0 0;
+      font-size: 1rem;
+      color: rgba(255, 255, 255, 0.45);
+      font-style: italic;
+      text-align: center;
+      max-width: 30rem;
+    }
+
+    /* ---- the metronome body ---- */
+    .stage {
+      position: relative;
+      width: 300px;
+      height: 360px;
+      display: flex;
+      align-items: flex-end;
+      justify-content: center;
+      filter: drop-shadow(0 30px 40px rgba(0, 0, 0, 0.6));
+    }
+    .metronome-svg { width: 100%; height: 100%; overflow: visible; }
+
+    .arm {
+      transform-box: fill-box;
+      transform-origin: 150px 330px;
+    }
+
+    /* beat dots */
+    .beats {
+      display: flex;
+      gap: 0.6rem;
+      align-items: center;
+      min-height: 1.4rem;
+    }
+    .beat-dot {
+      width: 0.85rem;
+      height: 0.85rem;
+      border-radius: 50%;
+      border: 1px solid var(--accent-dim);
+      background: transparent;
+      transition: transform 0.08s ease, background 0.08s ease, box-shadow 0.08s ease;
+    }
+    .beat-dot.on {
+      background: var(--accent);
+      box-shadow: 0 0 12px var(--accent);
+      transform: scale(1.25);
+    }
+    .beat-dot.accent { border-color: var(--accent); }
+    .beat-dot.accent.on {
+      background: #fff;
+      box-shadow: 0 0 16px #fff;
+    }
+
+    /* ---- readout ---- */
+    .readout {
+      text-align: center;
+      line-height: 1;
+      user-select: none;
+    }
+    .bpm {
+      font-size: 5rem;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+      font-variant-numeric: tabular-nums;
+    }
+    .bpm small { font-size: 1.2rem; color: rgba(255,255,255,0.5); letter-spacing: 0.1em; }
+    .marking {
+      margin-top: 0.15rem;
+      font-style: italic;
+      font-size: 1.3rem;
+      color: var(--accent);
+      letter-spacing: 0.04em;
+      min-height: 1.4em;
+    }
+
+    /* ---- tempo controls ---- */
+    .tempo-row {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      width: min(30rem, 100%);
+    }
+    .step {
+      background: none;
+      border: 1px solid #555;
+      color: #ddd;
+      font-family: inherit;
+      font-size: 1.6rem;
+      line-height: 1;
+      width: 2.4rem;
+      height: 2.4rem;
+      border-radius: 50%;
+      cursor: pointer;
+      flex: none;
+      transition: border-color 0.15s, color 0.15s, background 0.15s;
+    }
+    .step:hover { border-color: var(--accent); color: #fff; }
+    .step:active { background: rgba(156, 216, 255, 0.15); }
+
+    input[type=range] {
+      -webkit-appearance: none;
+      appearance: none;
+      flex: 1;
+      height: 3px;
+      background: linear-gradient(to right, var(--accent) 0%, var(--accent) var(--fill, 40%), #333 var(--fill, 40%), #333 100%);
+      border-radius: 2px;
+      outline: none;
+    }
+    input[type=range]::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: #fff;
+      cursor: pointer;
+      box-shadow: 0 0 0 1px #000, 0 0 10px rgba(156, 216, 255, 0.7);
+    }
+    input[type=range]::-moz-range-thumb {
+      width: 20px;
+      height: 20px;
+      border: none;
+      border-radius: 50%;
+      background: #fff;
+      cursor: pointer;
+      box-shadow: 0 0 0 1px #000, 0 0 10px rgba(156, 216, 255, 0.7);
+    }
+
+    /* ---- start / tap ---- */
+    .actions { display: flex; align-items: center; gap: 1rem; }
+    .play {
+      width: 4.6rem;
+      height: 4.6rem;
+      border-radius: 50%;
+      border: 1px solid var(--accent);
+      background: rgba(156, 216, 255, 0.08);
+      color: var(--accent);
+      cursor: pointer;
+      display: grid;
+      place-items: center;
+      transition: background 0.15s, box-shadow 0.15s, transform 0.1s;
+    }
+    .play:hover { background: rgba(156, 216, 255, 0.18); box-shadow: 0 0 24px rgba(156, 216, 255, 0.35); }
+    .play:active { transform: scale(0.96); }
+    .play svg { width: 1.9rem; height: 1.9rem; fill: currentColor; }
+    .play.playing { color: #fff; border-color: #fff; box-shadow: 0 0 26px rgba(255,255,255,0.3); }
+
+    .tap {
+      background: none;
+      border: 1px solid #555;
+      color: #ddd;
+      font-family: inherit;
+      font-size: 1.05rem;
+      letter-spacing: 0.05em;
+      padding: 0.55em 1.2em;
+      border-radius: 2rem;
+      cursor: pointer;
+      transition: border-color 0.15s, color 0.15s;
+      text-transform: lowercase;
+    }
+    .tap:hover { border-color: var(--accent); color: #fff; }
+    .tap.flash { border-color: var(--accent); color: var(--accent); }
+
+    /* ---- lower controls ---- */
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 0.9rem 1.6rem;
+      font-size: 0.98rem;
+      color: rgba(255, 255, 255, 0.6);
+    }
+    .ctl { display: inline-flex; align-items: center; gap: 0.55em; }
+    .ctl select {
+      background: #000;
+      border: 1px solid #555;
+      color: #ddd;
+      font-family: inherit;
+      font-size: 0.98rem;
+      padding: 0.25em 0.4em;
+      border-radius: 3px;
+    }
+    .ctl select:hover { border-color: var(--accent); }
+
+    .switch { display: inline-flex; align-items: center; gap: 0.5em; cursor: pointer; user-select: none; }
+    .switch input { position: absolute; opacity: 0; width: 0; height: 0; }
+    .switch .track {
+      width: 2.4em; height: 1.2em;
+      border: 1px solid #555; border-radius: 1em;
+      position: relative; transition: background 0.15s, border-color 0.15s;
+    }
+    .switch .thumb {
+      position: absolute; top: 50%; left: 0.15em;
+      width: 0.9em; height: 0.9em; transform: translateY(-50%);
+      background: #ddd; border-radius: 50%;
+      transition: left 0.15s, background 0.15s;
+    }
+    .switch input:checked + .track { background: var(--accent-dim); border-color: var(--accent); }
+    .switch input:checked + .track .thumb { left: calc(100% - 1.05em); background: var(--accent); }
+
+    @media (max-width: 420px) {
+      .stage { width: 250px; height: 300px; }
+      .bpm { font-size: 4rem; }
+    }
+  </style>
+</head>
+<body>
+  <a class="back" href="index.html">← back</a>
+
+  <h1>metronome</h1>
+  <p class="hint">a swinging arm, ticking true &mdash; drag the tempo, tap it out, or nudge with &plusmn;<br>space toggles start/stop &middot; &uarr;&darr; change tempo</p>
+
+  <div class="stage">
+    <svg class="metronome-svg" viewBox="0 0 300 360" aria-hidden="true">
+      <defs>
+        <linearGradient id="body" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#20272f"/>
+          <stop offset="0.5" stop-color="#141920"/>
+          <stop offset="1" stop-color="#080b0f"/>
+        </linearGradient>
+        <linearGradient id="bodyEdge" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0" stop-color="rgba(255,255,255,0.10)"/>
+          <stop offset="0.5" stop-color="rgba(255,255,255,0)"/>
+          <stop offset="1" stop-color="rgba(0,0,0,0.35)"/>
+        </linearGradient>
+        <linearGradient id="slot" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#000"/>
+          <stop offset="1" stop-color="#0c1116"/>
+        </linearGradient>
+        <radialGradient id="tip" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0" stop-color="#ffffff"/>
+          <stop offset="0.35" stop-color="#9cd8ff"/>
+          <stop offset="1" stop-color="#2f6f8f"/>
+        </radialGradient>
+        <linearGradient id="arm" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0" stop-color="#6b7885"/>
+          <stop offset="0.5" stop-color="#c8d4de"/>
+          <stop offset="1" stop-color="#6b7885"/>
+        </linearGradient>
+        <filter id="glow" x="-60%" y="-60%" width="220%" height="220%">
+          <feGaussianBlur stdDeviation="4" result="b"/>
+          <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+        </filter>
+      </defs>
+
+      <!-- pyramid body -->
+      <path d="M90 60 L210 60 L280 340 L20 340 Z" fill="url(#body)" stroke="#000" stroke-width="1"/>
+      <path d="M90 60 L210 60 L280 340 L20 340 Z" fill="url(#bodyEdge)"/>
+      <!-- top cap -->
+      <rect x="88" y="52" width="124" height="12" rx="3" fill="#252d36" stroke="#000"/>
+      <!-- central slot the arm rides in -->
+      <path d="M144 74 L156 74 L162 330 L138 330 Z" fill="url(#slot)" stroke="rgba(0,0,0,0.6)"/>
+      <!-- tempo scale ticks -->
+      <g stroke="rgba(156,216,255,0.35)" stroke-width="1.4" id="scale-ticks"></g>
+
+      <!-- swinging arm (pivot at bottom, 150,330) -->
+      <g class="arm" id="arm">
+        <line x1="150" y1="330" x2="150" y2="96" stroke="url(#arm)" stroke-width="5" stroke-linecap="round"/>
+        <!-- sliding weight (bob) -->
+        <g id="bob">
+          <rect x="138" y="150" width="24" height="30" rx="3" fill="#2b333c" stroke="#0a0d10"/>
+          <rect x="140" y="153" width="20" height="4" rx="2" fill="rgba(255,255,255,0.18)"/>
+        </g>
+        <!-- glowing tip -->
+        <circle cx="150" cy="96" r="9" fill="url(#tip)" filter="url(#glow)"/>
+      </g>
+
+      <!-- pivot hub -->
+      <circle cx="150" cy="330" r="9" fill="#1a2027" stroke="#000"/>
+      <circle cx="150" cy="330" r="3" fill="#3a4550"/>
+    </svg>
+  </div>
+
+  <div class="beats" id="beats"></div>
+
+  <div class="readout">
+    <div class="bpm"><span id="bpm-val">96</span> <small>bpm</small></div>
+    <div class="marking" id="marking">andante</div>
+  </div>
+
+  <div class="tempo-row">
+    <button class="step" id="minus" type="button" aria-label="slower">&minus;</button>
+    <input id="slider" type="range" min="30" max="260" value="96" step="1" aria-label="tempo">
+    <button class="step" id="plus" type="button" aria-label="faster">+</button>
+  </div>
+
+  <div class="actions">
+    <button class="play" id="play" type="button" aria-label="start">
+      <svg id="play-icon" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+    </button>
+    <button class="tap" id="tap" type="button">tap tempo</button>
+  </div>
+
+  <div class="controls">
+    <label class="ctl">
+      time
+      <select id="meter">
+        <option value="1">1</option>
+        <option value="2">2 / 4</option>
+        <option value="3">3 / 4</option>
+        <option value="4" selected>4 / 4</option>
+        <option value="5">5 / 4</option>
+        <option value="6">6 / 8</option>
+        <option value="7">7 / 8</option>
+      </select>
+    </label>
+    <label class="ctl">
+      sound
+      <select id="sound">
+        <option value="wood" selected>woodblock</option>
+        <option value="click">click</option>
+        <option value="beep">beep</option>
+        <option value="tick">soft tick</option>
+      </select>
+    </label>
+    <label class="switch">
+      <input id="accent-toggle" type="checkbox" checked>
+      <span class="track"><span class="thumb"></span></span>
+      accent downbeat
+    </label>
+  </div>
+
+  <script>
+  (() => {
+    'use strict';
+
+    // ---------- state ----------
+    let bpm = 96;
+    const MIN = 30, MAX = 260;
+    let beatsPerBar = 4;
+    let accentOn = true;
+    let sound = 'wood';
+    let playing = false;
+
+    // ---------- audio (lookahead scheduler — "A Tale of Two Clocks") ----------
+    const AC = window.AudioContext || window.webkitAudioContext;
+    let ctx = null;
+    const LOOKAHEAD = 0.1;       // seconds of audio scheduled ahead
+    const TICK_MS = 25;          // scheduler wake interval
+    let nextNoteTime = 0;        // ctx time of the next beat
+    let beatInBar = 0;           // 0-indexed beat within the current bar
+    let schedulerTimer = null;
+
+    // A queue of {beat, time} so the visual layer can flash dots exactly on time.
+    const scheduled = [];
+
+    function ensureCtx() {
+      if (!ctx) ctx = new AC();
+      if (ctx.state === 'suspended') ctx.resume();
+      return ctx;
+    }
+
+    // Percussive click synth. Each sound is a short enveloped burst; the
+    // accented downbeat is a touch louder and brighter.
+    function playTick(time, accent) {
+      const c = ctx;
+      const gain = c.createGain();
+      gain.connect(c.destination);
+
+      if (sound === 'beep') {
+        const osc = c.createOscillator();
+        osc.type = 'sine';
+        osc.frequency.value = accent ? 1320 : 880;
+        osc.connect(gain);
+        gain.gain.setValueAtTime(0.0001, time);
+        gain.gain.exponentialRampToValueAtTime(accent ? 0.5 : 0.34, time + 0.005);
+        gain.gain.exponentialRampToValueAtTime(0.0001, time + 0.09);
+        osc.start(time); osc.stop(time + 0.1);
+        return;
+      }
+
+      if (sound === 'wood') {
+        // woodblock: triangle body + a filtered-noise transient
+        const osc = c.createOscillator();
+        osc.type = 'triangle';
+        osc.frequency.setValueAtTime(accent ? 1750 : 1300, time);
+        osc.frequency.exponentialRampToValueAtTime(accent ? 900 : 700, time + 0.02);
+        osc.connect(gain);
+        gain.gain.setValueAtTime(0.0001, time);
+        gain.gain.exponentialRampToValueAtTime(accent ? 0.6 : 0.42, time + 0.002);
+        gain.gain.exponentialRampToValueAtTime(0.0001, time + 0.055);
+        osc.start(time); osc.stop(time + 0.06);
+
+        const noise = burst(c, 0.03);
+        const bp = c.createBiquadFilter();
+        bp.type = 'bandpass'; bp.frequency.value = accent ? 2600 : 2000; bp.Q.value = 1.2;
+        const ng = c.createGain();
+        ng.gain.setValueAtTime(accent ? 0.35 : 0.22, time);
+        ng.gain.exponentialRampToValueAtTime(0.0001, time + 0.03);
+        noise.connect(bp).connect(ng).connect(c.destination);
+        noise.start(time); noise.stop(time + 0.03);
+        return;
+      }
+
+      if (sound === 'tick') {
+        const bp = c.createBiquadFilter();
+        bp.type = 'bandpass'; bp.frequency.value = accent ? 4200 : 3000; bp.Q.value = 0.8;
+        const noise = burst(c, 0.02);
+        gain.gain.setValueAtTime(accent ? 0.3 : 0.18, time);
+        gain.gain.exponentialRampToValueAtTime(0.0001, time + 0.022);
+        noise.connect(bp).connect(gain);
+        noise.start(time); noise.stop(time + 0.025);
+        return;
+      }
+
+      // 'click' — crisp square burst (classic digital metronome)
+      const osc = c.createOscillator();
+      osc.type = 'square';
+      osc.frequency.value = accent ? 2000 : 1500;
+      osc.connect(gain);
+      gain.gain.setValueAtTime(0.0001, time);
+      gain.gain.exponentialRampToValueAtTime(accent ? 0.34 : 0.22, time + 0.001);
+      gain.gain.exponentialRampToValueAtTime(0.0001, time + 0.035);
+      osc.start(time); osc.stop(time + 0.04);
+    }
+
+    // Short white-noise buffer source.
+    function burst(c, dur) {
+      const len = Math.max(1, Math.floor(c.sampleRate * dur));
+      const buf = c.createBuffer(1, len, c.sampleRate);
+      const data = buf.getChannelData(0);
+      for (let i = 0; i < len; i++) data[i] = Math.random() * 2 - 1;
+      const src = c.createBufferSource();
+      src.buffer = buf;
+      return src;
+    }
+
+    function secondsPerBeat() { return 60 / bpm; }
+
+    function scheduler() {
+      while (nextNoteTime < ctx.currentTime + LOOKAHEAD) {
+        const accent = accentOn && beatsPerBar > 1 && beatInBar === 0;
+        playTick(nextNoteTime, accent);
+        scheduled.push({ beat: beatInBar, time: nextNoteTime, accent });
+        nextNoteTime += secondsPerBeat();
+        beatInBar = (beatInBar + 1) % beatsPerBar;
+      }
+    }
+
+    // ---------- transport ----------
+    function start() {
+      ensureCtx();
+      playing = true;
+      beatInBar = 0;
+      nextNoteTime = ctx.currentTime + 0.08;
+      barZeroTime = nextNoteTime;     // arm reaches an extreme on beat 0
+      scheduled.length = 0;
+      schedulerTimer = setInterval(scheduler, TICK_MS);
+      playBtn.classList.add('playing');
+      playIcon.innerHTML = '<path d="M6 5h4v14H6zM14 5h4v14h-4z"/>';
+      requestAnimationFrame(animate);
+    }
+
+    function stop() {
+      playing = false;
+      clearInterval(schedulerTimer);
+      schedulerTimer = null;
+      scheduled.length = 0;
+      playBtn.classList.remove('playing');
+      playIcon.innerHTML = '<path d="M8 5v14l11-7z"/>';
+      resetArm();
+      clearDots();
+    }
+
+    function toggle() { playing ? stop() : start(); }
+
+    // ---------- pendulum animation (locked to the audio clock) ----------
+    // The arm reaches full deflection exactly on each beat and sweeps through
+    // centre at max speed mid-beat. Over two beats it completes one full swing,
+    // so ticks land at both extremes — just like a mechanical metronome.
+    const AMPLITUDE = 30; // degrees
+    let barZeroTime = 0;
+
+    function animate() {
+      if (!playing) return;
+      const t = ctx.currentTime;
+      const beatPos = (t - barZeroTime) / secondsPerBeat(); // beats since start
+      const angle = AMPLITUDE * Math.cos(Math.PI * beatPos);
+      armEl.style.transform = 'rotate(' + angle + 'deg)';
+
+      // flash beat dots as their scheduled time passes
+      while (scheduled.length && scheduled[0].time <= t) {
+        const ev = scheduled.shift();
+        flashDot(ev.beat, ev.accent);
+      }
+      requestAnimationFrame(animate);
+    }
+
+    function resetArm() { armEl.style.transform = 'rotate(0deg)'; }
+
+    // ---------- beat dots ----------
+    const beatsEl = document.getElementById('beats');
+    let dots = [];
+    function buildDots() {
+      beatsEl.innerHTML = '';
+      dots = [];
+      for (let i = 0; i < beatsPerBar; i++) {
+        const d = document.createElement('span');
+        d.className = 'beat-dot' + (i === 0 && accentOn && beatsPerBar > 1 ? ' accent' : '');
+        beatsEl.appendChild(d);
+        dots.push(d);
+      }
+    }
+    let dotTimers = [];
+    function flashDot(i, accent) {
+      const d = dots[i];
+      if (!d) return;
+      d.classList.add('on');
+      clearTimeout(dotTimers[i]);
+      dotTimers[i] = setTimeout(() => d.classList.remove('on'), Math.min(140, secondsPerBeat() * 1000 * 0.5));
+    }
+    function clearDots() { dots.forEach(d => d.classList.remove('on')); }
+
+    // ---------- tempo & bob position ----------
+    // On a real metronome the bob slides UP the arm for slower tempos. Map bpm
+    // to a vertical position along the arm so the visual tempo reads at a glance.
+    const bobEl = document.getElementById('bob');
+    const MARKINGS = [
+      [40, 'grave'], [48, 'largo'], [56, 'larghetto'], [66, 'adagio'],
+      [76, 'andante'], [92, 'andante'], [108, 'moderato'], [120, 'allegretto'],
+      [156, 'allegro'], [176, 'vivace'], [200, 'presto'], [999, 'prestissimo'],
+    ];
+    function markingFor(v) {
+      for (const [ceil, name] of MARKINGS) if (v < ceil) return name;
+      return 'prestissimo';
+    }
+
+    function updateBob() {
+      // slower => bob higher on the arm (smaller y). Arm spans ~y=110..300.
+      const frac = (bpm - MIN) / (MAX - MIN);          // 0 slow .. 1 fast
+      const y = 116 + frac * 150;                        // 116 (slow/top) .. 266 (fast/low)
+      bobEl.setAttribute('transform', 'translate(0,' + (y - 165) + ')');
+    }
+
+    // ---------- UI wiring ----------
+    const bpmVal = document.getElementById('bpm-val');
+    const markingEl = document.getElementById('marking');
+    const slider = document.getElementById('slider');
+    const armEl = document.getElementById('arm');
+    const playBtn = document.getElementById('play');
+    const playIcon = document.getElementById('play-icon');
+
+    function setBpm(v, fromSlider) {
+      bpm = Math.max(MIN, Math.min(MAX, Math.round(v)));
+      bpmVal.textContent = bpm;
+      markingEl.textContent = markingFor(bpm);
+      if (!fromSlider) slider.value = bpm;
+      slider.style.setProperty('--fill', ((bpm - MIN) / (MAX - MIN) * 100) + '%');
+      updateBob();
+    }
+
+    slider.addEventListener('input', e => setBpm(+e.target.value, true));
+    document.getElementById('minus').addEventListener('click', () => setBpm(bpm - 1));
+    document.getElementById('plus').addEventListener('click', () => setBpm(bpm + 1));
+    playBtn.addEventListener('click', toggle);
+
+    document.getElementById('meter').addEventListener('change', e => {
+      beatsPerBar = parseInt(e.target.value, 10);
+      beatInBar = 0;
+      buildDots();
+    });
+    document.getElementById('sound').addEventListener('change', e => { sound = e.target.value; });
+    document.getElementById('accent-toggle').addEventListener('change', e => {
+      accentOn = e.target.checked;
+      buildDots();
+    });
+
+    // ---------- tap tempo ----------
+    const tapBtn = document.getElementById('tap');
+    let taps = [];
+    tapBtn.addEventListener('click', () => {
+      const now = performance.now();
+      taps = taps.filter(t => now - t < 2500);   // forget stale taps
+      taps.push(now);
+      tapBtn.classList.add('flash');
+      setTimeout(() => tapBtn.classList.remove('flash'), 120);
+      if (taps.length >= 2) {
+        let sum = 0;
+        for (let i = 1; i < taps.length; i++) sum += taps[i] - taps[i - 1];
+        const avg = sum / (taps.length - 1);
+        setBpm(60000 / avg);
+      }
+    });
+
+    // ---------- keyboard ----------
+    document.addEventListener('keydown', e => {
+      if (e.target.tagName === 'SELECT') return;
+      if (e.code === 'Space') { e.preventDefault(); toggle(); }
+      else if (e.code === 'ArrowUp' || e.code === 'ArrowRight') { e.preventDefault(); setBpm(bpm + 1); }
+      else if (e.code === 'ArrowDown' || e.code === 'ArrowLeft') { e.preventDefault(); setBpm(bpm - 1); }
+    });
+
+    // ---------- draw the fixed tempo scale ticks on the body ----------
+    (function drawScale() {
+      const g = document.getElementById('scale-ticks');
+      for (let i = 0; i <= 10; i++) {
+        const y = 120 + i * 15;
+        const w = i % 5 === 0 ? 14 : 8;
+        const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        line.setAttribute('x1', 168); line.setAttribute('y1', y);
+        line.setAttribute('x2', 168 + w); line.setAttribute('y2', y);
+        g.appendChild(line);
+      }
+    })();
+
+    // ---------- init ----------
+    buildDots();
+    setBpm(96);
+  })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
A new `metronome.html`, linked from the index page.

## What it does
A self-contained metronome with an analog-style **swinging arm** rendered in SVG, locked to a Web Audio lookahead scheduler ("A Tale of Two Clocks") for sample-accurate timing. The pendulum reaches full deflection exactly on each beat and sweeps through centre mid-beat, driven from the audio clock so the visual swing and the click stay in sync — just like a mechanical metronome ticking at both ends of its swing.

## Features
- **Sweeping arm** with a glowing tip and a sliding weight (bob) that rides up/down the arm to reflect tempo, over an engraved tempo scale
- Tempo **30–260 bpm** via slider, ± nudges, **tap tempo**, and ↑/↓ keys
- **Beat dots** with downbeat accent; time signatures 1–7
- Four click voices: **woodblock, click, beep, soft tick**
- Large bpm readout with Italian **tempo markings** (largo … prestissimo)
- **Space** toggles start/stop
- Borrows the site's black / serif / blue design language and cues from the best metronome apps (pyramid body, pendulum, tap tempo, beat lights)

## Verification
Driven end-to-end in a headless browser: slider updates bpm + marking, ± and tap tempo work, the arm oscillates (positive↔negative rotation while playing), beat dots flash on schedule, stop resets the arm, and changing the meter rebuilds the dot row. No console errors (only the Google Fonts request, which the sandbox proxy blocks; it falls back to serif).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017k5sADy9pF7fxudZYBtP1P

---
_Generated by [Claude Code](https://claude.ai/code/session_017k5sADy9pF7fxudZYBtP1P)_