### PR TITLE
Repeat the top turnaround note when "repeat top & bottom" is on

### DIFF
--- a/scales.js
+++ b/scales.js
@@ -191,11 +191,15 @@ function expand(oneOctave, n) {
 // is just the ascending form reversed.
 const seqAsc = (mode) => expand(mode.intervals, octaves);
 const seqDesc = (mode) => expand(mode.descIntervals || mode.intervals, octaves).reverse();
-// up then back down, with the top note as a single turnaround.
+// Up then back down. When "repeat top & bottom" is on the top turnaround note
+// is struck twice (…C♯ D D C♯…); otherwise it's a single turnaround. The bottom
+// is handled at the loop seam in schedulePass (its trailing copy is dropped when
+// the ends aren't repeated), so both ends now honor the toggle symmetrically.
 const seqUpDown = (mode) => {
   const up = expand(mode.intervals, octaves);
   const down = expand(mode.descIntervals || mode.intervals, octaves);
-  return up.concat(down.slice(0, -1).reverse());
+  const back = (repeatEnds ? down : down.slice(0, -1)).reverse();
+  return up.concat(back);
 };
 
 function clearReadouts() {


### PR DESCRIPTION
## Problem

On the scales page, the **repeat top & bottom** toggle only repeated the *bottom* note. The top turnaround note was never doubled, no matter the toggle — most obvious on the D chromatic scale, but it affected every up-and-down scale.

## Cause

`seqUpDown()` built the descending half with `down.slice(0, -1)`, unconditionally stripping the top note so the peak was always a single turnaround. The `repeatEnds` toggle only ever affected the trailing bottom note (dropped at the loop seam in `schedulePass`), leaving the two ends asymmetric.

## Fix

Gate the slice on `repeatEnds`:

```js
const back = (repeatEnds ? down : down.slice(0, -1)).reverse();
```

- **toggle on** → top struck twice at the turnaround (…C♯ D D C♯…) *and* bottom doubled at the loop seam.
- **toggle off** → top single *and* bottom single.

Both ends now honor the toggle symmetrically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAq41ZoThkVwendgZ279cV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAq41ZoThkVwendgZ279cV)_