### PR TITLE
Add explicit GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,51 @@
+name: deploy-pages
+
+# Explicit GitHub Pages deploy for this static site. Replaces the automatic
+# "pages build and deployment" flow so we control the deploy — most importantly
+# the concurrency policy and a manual re-run button (workflow_dispatch), because
+# the managed deploy has intermittently hung in "queued" and needed a human to
+# re-run it.
+#
+# NOTE: for this workflow to take over, the repo's Pages *source* must be set to
+# "GitHub Actions" (Settings → Pages → Build and deployment → Source). While the
+# source is still "Deploy from a branch", GitHub keeps running its own build and
+# this workflow will error at the "deploy" step.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Least-privilege token: read the repo, mint the Pages OIDC token, write Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time. cancel-in-progress kills a stuck/queued deploy when a
+# newer push or a manual re-run comes in, instead of queueing behind it — the
+# fix for the "hangs forever and blocks everything" behavior.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Plain static site served from the repo root. .nojekyll is already
+          # present so files (incl. leading-underscore names) are served as-is.
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -105,10 +105,19 @@ node tools/check-assets.mjs
 
 GitHub Pages serves the `main` branch root. A `.nojekyll` file disables Jekyll
 so files are served as-is (this is a plain static site, not a Jekyll site).
-Pushing/merging to `main` redeploys.
+Pushing/merging to `main` redeploys via the `deploy-pages` workflow
+(`.github/workflows/deploy-pages.yml`), which uploads the repo root and deploys
+it with `actions/deploy-pages`.
 
-**Gotcha:** if a change isn't showing up live after a few minutes, the Pages
-build may be stuck or cached, not your code. Check the repo's **Actions** tab
-for the "pages build and deployment" run, and note that the custom domain can
-cache HTML harder than a browser hard-refresh clears — a fresh deploy purges
-it.
+For this workflow to be the active deploy path, the repo's Pages **source** must
+be set to **GitHub Actions** (Settings → Pages → Build and deployment → Source).
+The workflow also has a `workflow_dispatch` trigger, so a stuck deploy can be
+re-run on demand from the **Actions** tab, and a `concurrency` policy that
+cancels an in-progress deploy when a newer one starts (so a hung deploy no longer
+blocks the next push).
+
+**Gotcha:** if a change isn't showing up live after a few minutes, the deploy
+may be stuck or the HTML cached, not your code. Check the repo's **Actions** tab
+for the latest `deploy-pages` run (re-run it if it's stuck), and note that the
+custom domain can cache HTML harder than a browser hard-refresh clears — a fresh
+deploy purges it.


### PR DESCRIPTION
## Why

The site is deployed by GitHub's automatic **"pages build and deployment"** flow, which has intermittently hung or failed — visible in this repo's Actions history:

- **Jul 4** — two deploys `failure`d back-to-back.
- **Jul 6** — one deploy sat stuck for **~78 minutes** before a re-run (`run_attempt=2`) pushed it through.
- **Aug 6** — the deploy for #114 stuck in `queued` again.

The repo's own `validate` CI passes in ~15s every time; the flakiness is entirely in the managed Pages deploy step, and unsticking it requires a manual re-run each time.

## What

Replace reliance on the managed flow with an explicit `deploy-pages` workflow (`.github/workflows/deploy-pages.yml`) that uploads the repo root and deploys via `actions/deploy-pages`. Key properties:

- **`workflow_dispatch` trigger** — a stuck deploy can be re-run on demand from the Actions tab (no code change needed).
- **`concurrency: { group: pages, cancel-in-progress: true }`** — a newer push or manual re-run **cancels** a hung in-progress deploy instead of queueing behind it. This is the direct fix for the "hangs and blocks the next deploy" behavior.
- **Least-privilege permissions** — `contents: read`, `pages: write`, `id-token: write`.

`README.md`'s deployment section is updated to describe the new flow.

## Required manual step (one-time)

For this workflow to take over, set the repo's Pages **source** to **GitHub Actions**:

> Settings → Pages → Build and deployment → **Source: GitHub Actions**

While the source is still "Deploy from a branch," GitHub keeps running its own build and the `deploy` step here will error. After flipping it, this workflow becomes the single deploy path.

## Notes

- No changes to site content — the driftwood-burnin page from #114 is already on `main`.
- `.nojekyll` is already present, so the root is served as-is (including `_format`-style names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01729Rj7z6muzPd7Gzu5WzVe

---
_Generated by [Claude Code](https://claude.ai/code/session_01729Rj7z6muzPd7Gzu5WzVe)_