### PR TITLE
scales: keep the screen awake while practicing

### DIFF
--- a/scales.js
+++ b/scales.js
@@ -219,6 +219,7 @@ function finishPlayback() {
   playingButton = null;
   currentPlay = null;
   clearReadouts();
+  updateWakeLock(); // nothing sounding from a scale now; release unless the drone holds it
 }
 
 // User-initiated stop: silence any scheduled notes and reset.
@@ -235,6 +236,7 @@ function togglePlay(button, baseMidi, makeSeq, rowReadout, namer, rowStaff) {
   if (loopTimerId) { clearTimeout(loopTimerId); loopTimerId = null; }
   playingButton = button;
   button.classList.add('playing');
+  updateWakeLock(); // keep the screen awake for the duration of the scale (this click is the gesture)
   currentPlay = { baseMidi, makeSeq, rowReadout, namer, rowStaff };
   clearReadouts();
   schedulePass(baseMidi, makeSeq, rowReadout, namer, null, false, rowStaff);
@@ -303,6 +305,37 @@ function schedulePass(baseMidi, makeSeq, rowReadout, namer, when, chain, rowStaf
 // --- drone (root + optional fifth), shared engine in audio.js ---
 // Root is set by select() during startup and on every tonal-center change.
 const drone = AudioKit.createDrone();
+
+// --- screen wake lock -----------------------------------------------------
+// Phones lock the screen on their idle timer even while audio is playing, which
+// cuts a scale off mid-practice. Hold a Screen Wake Lock whenever something is
+// sounding (a scale or the drone) so the screen stays awake, and re-acquire it
+// when the tab becomes visible again — the OS releases the lock whenever the
+// page is hidden, and returning to it is one of the few non-gesture moments the
+// spec still lets us request a fresh one.
+let wakeLock = null;
+
+async function acquireWakeLock() {
+  if (wakeLock || !('wakeLock' in navigator)) return;
+  try {
+    wakeLock = await navigator.wakeLock.request('screen');
+    wakeLock.addEventListener('release', () => { wakeLock = null; });
+  } catch (e) { /* unsupported or blocked (e.g. low battery) — practice still works */ }
+}
+
+function releaseWakeLock() {
+  if (wakeLock) { wakeLock.release().catch(() => {}); wakeLock = null; }
+}
+
+// Single source of truth: keep the lock iff a scale is playing or the drone is on.
+function updateWakeLock() {
+  if (playingButton || drone.playing) acquireWakeLock();
+  else releaseWakeLock();
+}
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') updateWakeLock();
+});
 
 // --- UI ---
 function buildCircle() {
@@ -638,6 +671,7 @@ function initDroneControls() {
       btn.textContent = 'stop drone';
       btn.classList.add('on');
     }
+    updateWakeLock(); // the drone also keeps the screen awake while it sounds
   });
   const fifth = document.getElementById('drone-fifth');
   drone.setFifth(fifth.checked); // honor a restored value


### PR DESCRIPTION
## Problem

On the scales practice page, starting a scale and setting the phone down leads to the screen locking on its idle timer — cutting the scale off mid-practice. Audio playback alone does not inhibit the lock, so this made the page frustrating to actually practice with.

## Fix

Hold a [Screen Wake Lock](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API) whenever something is sounding:

- **Acquired** when a scale starts playing or the drone is turned on (the tap is the user gesture the API requires).
- **Released** once the scale finishes/stops *and* the drone is off, so nothing is held when the page is idle.
- **Re-acquired** on `visibilitychange` back to visible — the OS releases the lock whenever the tab is hidden, so returning to the page requests a fresh one.

A single `updateWakeLock()` helper (`playingButton || drone.playing`) is the source of truth, wired into `togglePlay` (start), `finishPlayback` (natural end and manual stop), and the drone toggle.

Feature-detected (`'wakeLock' in navigator`) and wrapped in `try/catch`, so browsers without the API — or when the OS declines (e.g. very low battery) — fall back to today's behavior.

## Notes / limitations

- Prevents *auto*-lock only; it can't override the physical side button or another app taking over. For "set the phone down and practice," this resolves the interruption.
- The metronome page has the same underlying issue; not touched here to keep this change focused.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADQ4UBpwdBNsQfNQz9rMmM)_