### PR TITLE
scales: one-beat count-in before a scale/arpeggio starts

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -161,6 +161,16 @@ const AudioKit = (() => {
     return getSeqCtx().currentTime;
   }
 
+  // Schedule a single metronome tick on the shared sequence clock at absolute
+  // time `when` (same clock as currentTime()/playSequence's `when`). Lets a page
+  // place a count-in beat before a pass. Registered in activeVoices, so
+  // stopSequence() silences a pending tick if playback is stopped during it.
+  function click(when, accent) {
+    const ctx = getSeqCtx();
+    if (ctx.state !== 'running') { try { ctx.resume(); } catch (e) {} }
+    scheduleClick(ctx, Math.max(when, ctx.currentTime), !!accent);
+  }
+
   // A brief brightening of the lowpass on a note's attack — the "bite" of a
   // bow catching the string. Dips the cutoff just under its resting value, opens
   // past it during the attack, then settles back. `amount` is a fraction of the
@@ -628,7 +638,7 @@ const AudioKit = (() => {
 
   return {
     FIFTH_RATIO, midiToFreq, pitchToMidi, midiToName,
-    playSequence, stopSequence, currentTime,
+    playSequence, stopSequence, currentTime, click,
     createInstrument, instruments: { cello },
     createDrone, createPolySynth, resume: resumeCtxs,
   };

--- a/scales.html
+++ b/scales.html
@@ -379,6 +379,11 @@
       <span class="track"><span class="thumb"></span></span>
       metronome
     </label>
+    <label class="switch">
+      <input id="count-in" type="checkbox" checked>
+      <span class="track"><span class="thumb"></span></span>
+      count-in
+    </label>
     <label class="ctl">
       note
       <input id="subdiv" type="range" min="0" max="5" step="1" value="2">

--- a/scales.js
+++ b/scales.js
@@ -171,6 +171,7 @@ const cello = AudioKit.instruments.cello; // the natural, always-legato melodic 
 let autoDescend = false;
 let tempoBpm = 60;
 let metronomeOn = false; // audible click on each beat while a scale plays
+let countIn = true; // one-beat count-in tick before a scale starts (time to set the bow)
 let loopOn = false;
 let repeatEnds = false; // when looping, repeat the turnaround (top/bottom) notes
 let playingButton = null; // the play button whose scale is currently sounding
@@ -260,7 +261,7 @@ function togglePlay(button, baseMidi, makeSeq, rowReadout, namer, rowStaff) {
   updateWakeLock(); // keep the screen awake for the duration of the scale (this click is the gesture)
   currentPlay = { baseMidi, makeSeq, rowReadout, namer, rowStaff };
   clearReadouts();
-  schedulePass(baseMidi, makeSeq, rowReadout, namer, null, false, rowStaff);
+  schedulePass(baseMidi, makeSeq, rowReadout, namer, null, false, rowStaff, true); // fresh start: count-in
 }
 
 // Re-trigger the current looping scale so a toggled option takes effect now
@@ -269,18 +270,26 @@ function restartIfLooping() {
   if (playingButton && loopOn && currentPlay) {
     if (loopTimerId) { clearTimeout(loopTimerId); loopTimerId = null; }
     clearReadouts();
-    schedulePass(currentPlay.baseMidi, currentPlay.makeSeq, currentPlay.rowReadout, currentPlay.namer, null, false, currentPlay.rowStaff);
+    // Already mid-practice (bow is set): re-sync without another count-in.
+    schedulePass(currentPlay.baseMidi, currentPlay.makeSeq, currentPlay.rowReadout, currentPlay.namer, null, false, currentPlay.rowStaff, false);
   }
 }
 
 // Play one pass, then either schedule the next pass exactly on the audio clock
 // (gapless loop) or finish. `when` is the absolute start time (null = default
 // lead-in); `chain` keeps the previous pass's tail so the seam is seamless.
-function schedulePass(baseMidi, makeSeq, rowReadout, namer, when, chain, rowStaff) {
+// `lead` (fresh start only) delays the first note by one beat and ticks a
+// count-in on that beat, so there's time to set the bow before the scale begins.
+function schedulePass(baseMidi, makeSeq, rowReadout, namer, when, chain, rowStaff, lead) {
   const seq = makeSeq();
   const step = (60 / tempoBpm) / SUBDIVS[subdivIndex].perBeat;
+  const beat = 60 / tempoBpm; // one quarter-note beat, independent of the note subdivision
   const center = document.getElementById('playing-note');
   const trebleEl = document.getElementById('toggle-treble');
+  // One-beat count-in on a fresh start: push the first note a beat later and
+  // tick once on the empty lead beat (below, after playSequence clears the clock).
+  const doLead = !!lead && countIn;
+  const startWhen = doLead ? AudioKit.currentTime() + 0.05 + beat : when;
   // When looping without repeating the turnaround, drop a trailing note that
   // duplicates the first (e.g. up-then-down) so the bottom isn't struck twice.
   const noRepeat = loopOn && !repeatEnds && seq.length > 1 && seq[0] === seq[seq.length - 1];
@@ -291,7 +300,7 @@ function schedulePass(baseMidi, makeSeq, rowReadout, namer, when, chain, rowStaf
     attack: LEGATO.atk,
     sustain: LEGATO.sustain,
     release: LEGATO.release,
-    when,
+    when: startWhen,
     chain,
     legato: true, // always fully connected → the cello's glided legato voice
     clickInterval: metronomeOn ? 60 / tempoBpm : 0,
@@ -306,6 +315,10 @@ function schedulePass(baseMidi, makeSeq, rowReadout, namer, when, chain, rowStaf
       }
     },
   });
+  // Count-in tick on the lead beat. Scheduled AFTER playSequence, whose fresh-
+  // start stopSequence() would otherwise cancel this just-scheduled tick. A plain
+  // (unaccented) tick, one beat before the first note lands on the downbeat.
+  if (doLead) AudioKit.click(startWhen - beat, false);
   if (loopOn) {
     // Set up the next pass a touch before the seam so its notes are scheduled
     // ahead of time and the loop stays perfectly continuous.
@@ -313,7 +326,7 @@ function schedulePass(baseMidi, makeSeq, rowReadout, namer, when, chain, rowStaf
     const delay = Math.max(0, (nextStart - lead - AudioKit.currentTime()) * 1000);
     loopTimerId = setTimeout(() => {
       if (loopOn && playingButton) {
-        schedulePass(baseMidi, makeSeq, rowReadout, namer, nextStart, true, rowStaff);
+        schedulePass(baseMidi, makeSeq, rowReadout, namer, nextStart, true, rowStaff, false);
       } else {
         loopTimerId = setTimeout(finishPlayback, Math.max(0, (nextStart - AudioKit.currentTime()) * 1000));
       }
@@ -787,6 +800,10 @@ function initScaleOptions() {
     restartIfLooping(); // start/stop ticks immediately on a running loop
   });
 
+  const countInEl = document.getElementById('count-in');
+  countIn = countInEl.checked; // honor a restored value
+  countInEl.addEventListener('change', () => { countIn = countInEl.checked; });
+
   const subdiv = document.getElementById('subdiv');
   const subdivVal = document.getElementById('subdiv-val');
   const showSubdiv = () => {
@@ -855,6 +872,7 @@ const PREFS = [
   { id: 'octaves',       key: 'octaves',     kind: 'num', min: 1,  max: 3,   ev: 'input' },
   { id: 'tempo',         key: 'tempo',       kind: 'num', min: 40, max: 300, ev: 'input' },
   { id: 'metronome',     key: 'metronome',   kind: 'bool',   ev: 'change' },
+  { id: 'count-in',      key: 'countIn',     kind: 'bool',   ev: 'change' },
   { id: 'subdiv',        key: 'subdiv',      kind: 'num', min: 0,  max: SUBDIVS.length - 1, ev: 'input' },
   { id: 'loop',          key: 'loop',        kind: 'bool',   ev: 'change' },
   { id: 'repeat-ends',   key: 'repeatEnds',  kind: 'bool',   ev: 'change' },


### PR DESCRIPTION
## What

Adds a one-beat (quarter-note) count-in before a scale or arpeggio begins, so there's time to set the bow. Pressing a play button now waits one beat — with a single count-in tick on that empty beat — then the line starts on the downbeat.

## Behavior

- The lead is always **one quarter-note beat** (`60 / tempoBpm`), independent of the note-value subdivision.
- Fires only on a **fresh start** — not on loop seams or mid-loop option changes — so looping stays gapless and toggling an option mid-practice won't re-insert a gap.
- The count-in tick sounds whether or not the metronome is on, so it's a dependable cue either way. Stopping during the lead beat silences the pending tick.
- New **count-in** toggle beside the metronome switch, default **on**, persisted in localStorage with the other settings. Off = instant start (previous behavior).

## Implementation

- `audio.js`: exposes `AudioKit.click(when, accent)` — a public wrapper over the existing internal `scheduleClick`, placing a tick on the shared sequence clock and registering it in `activeVoices` so `stopSequence()` silences it. Purely additive; no change to existing callers.
- `scales.js`: `schedulePass` gains a `lead` flag. On a fresh start it pushes the first note's `when` one beat later and schedules the count-in tick **after** `playSequence` runs (whose fresh-start `stopSequence()` would otherwise cancel the just-scheduled tick). `togglePlay` passes `lead: true`; loop continuations and `restartIfLooping` pass `false`.

## Testing

- `node --check` on audio.js and scales.js.
- Headless Chromium timing test at 60 bpm: first note lands ~1s later with count-in on vs. ~100ms with it off (the delta is the one-beat lead), and `AudioKit.click` is exposed. No script errors (only a sandbox-blocked Google Fonts request).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADQ4UBpwdBNsQfNQz9rMmM)_