### PR TITLE
Add a practice page for Glen Hansard — Falling Slowly

### DIFF
--- a/songs.json
+++ b/songs.json
@@ -62,6 +62,11 @@
         { "start": "3:21",   "end": "3:34"   }
       ]
     },
+    "falling-slowly": {
+      "title": "Glen Hansard — Falling Slowly",
+      "videoId": "agf4tUnxotA",
+      "fineTune": true
+    },
     "burgmuller-nocturnes": {
       "title": "Friedrich Burgmüller (1806–1874) — 3 Nocturnes for Cello and Guitar",
       "videoId": "Hdj6Hv6ANsY"


### PR DESCRIPTION
Adds a `songs.json` entry for Glen Hansard — Falling Slowly, live at `song.html?s=falling-slowly` and listed automatically on the home page.

```json
"falling-slowly": {
  "title": "Glen Hansard — Falling Slowly",
  "videoId": "agf4tUnxotA",
  "fineTune": true
}
```

Spelling checked: **Glen Hansard**, **Falling Slowly** — written and performed with Markéta Irglová for the 2007 film *Once*, Academy Award for Best Original Song. The linked video (`agf4tUnxotA`) is titled just "Falling Slowly".

`fineTune` is on so the loop times can be nudged in 0.1s steps once they are measured.

**No loop sections yet.** Same blocker as Song of Good Hope: `tools/detect_loops.py` needs the audio, and YouTube is unreachable from the environment this was authored in — the egress proxy blocks it, and neither yt-dlp nor ffmpeg is installed. Loops can be placed by ear with the **set** buttons on the page and written back later.

Both CI checks pass locally: `songs.json valid` against the schema, and `tools/check-assets.mjs` reports all referenced assets exist.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUiyUnz2MDQ4vwfDpwKUDo)_