### PR TITLE
Add a shifting practice page that sounds the note under the travelling hand

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,26 @@ entirely from the song's `drone` field: `song.js` parses the note name to a
 MIDI number (`pitchToMidi`), so the same field both enables the drone and sets
 its note and label. The fifth is derived as root × 1.5.
 
+## The shifting page
+
+`shifting.html` / `shifting.js` is a standalone practice page (not a song). It
+plays a major scale in strict time and, at each shift, slides the pitch down to
+the note the hand travels through, sounding it on its own beat — in G major you
+hear `G A B C ⟍G♯ C D E F♯ G`. The ghost note is deliberately outside the key:
+the point is to stop hearing it as a mistake.
+
+Where the shifts fall is a fingering decision, so the page stores rather than
+derives them: each key keeps a list of `{ after, drop }` (the index of the note
+you shift away from, and how many semitones the hand travels below it) in
+`localStorage` under `shifting:prefs`. Click a gap in the note strip to add a
+shift, `▾`/`▴` to move the ghost note. A key you haven't set up inherits the
+layout of the key you were last in, transposed.
+
+The audible slide comes from the `shape` option added to `playSequence` in
+`audio.js`: a per-note `{ slide, artic, level }` that gives one note a real,
+timed portamento (and lets the note after it re-articulate as a fresh bow on a
+new string) instead of the near-instant legato smoothing used everywhere else.
+
 ## Assets
 
 Per-song score images live under `scores/<slug>/` (e.g.

--- a/audio.js
+++ b/audio.js
@@ -257,7 +257,7 @@ const AudioKit = (() => {
   // at each boundary (EX.artic) before swelling back, and the pitch slides in
   // over a short portamento (EX.glide). A gentle vibrato fades in over the pass.
   function renderConnected(ctx, timbre, baseMidi, seq, o) {
-    const { start, step, gate, atk, release, EX, dynFor, timeFor, scheduleOnNote } = o;
+    const { start, step, gate, atk, release, EX, dynFor, timeFor, scheduleOnNote, shapeAt } = o;
     const n = seq.length;
     const osc = ctx.createOscillator();
     const voice = timbre.makeFilters(ctx);
@@ -288,9 +288,23 @@ const AudioKit = (() => {
 
     for (let i = 1; i < n; i++) {
       const t = timeFor(i);
-      osc.frequency.setTargetAtTime(midiToFreq(baseMidi + seq[i]), Math.max(start, t - 0.004), glide);
+      const sh = shapeAt(i);
+      const target = midiToFreq(baseMidi + seq[i]);
+      const from = Math.max(start, t - 0.004);
+      if (sh && sh.slide > 0) {
+        // A *heard* slide (a shift), not the near-instant smoothing of EX.glide:
+        // the pitch travels for sh.slide seconds. setTargetAtTime is ~98% of the
+        // way there after four time constants, so aim it at a quarter of the
+        // travel and pin the arrival — the note the hand lands on has to be dead
+        // in tune, since hearing it is the whole point.
+        const travel = Math.min(sh.slide, step * 0.95);
+        osc.frequency.setTargetAtTime(target, from, travel / 4);
+        osc.frequency.setValueAtTime(target, from + travel);
+      } else {
+        osc.frequency.setTargetAtTime(target, from, glide);
+      }
       const p = dynFor(seq[i], i);
-      const dip = Math.max(p * (1 - EX.artic), 0.0002);
+      const dip = Math.max(p * (1 - (sh && sh.artic != null ? sh.artic : EX.artic)), 0.0002);
       gain.gain.setTargetAtTime(dip, Math.max(start + atk, t - dipLead), dipTc); // ease down into the new note
       gain.gain.setTargetAtTime(p, t + 0.004, recTc);                            // swell back up on it
       scheduleOnNote(seq[i], i, start + i * step);
@@ -332,7 +346,9 @@ const AudioKit = (() => {
   // beat across this pass, locked to the note grid), clickAccent (accent the
   // pass's first tick — the downbeat where the tonic sounds), legato (true = the
   // articulation fully connects, so an expressive instrument renders the pass as
-  // one continuous glided voice instead of note-by-note). Returns the audio-clock
+  // one continuous glided voice instead of note-by-note), shape (per-note
+  // { slide, artic, level } overrides for connected playback — see below).
+  // Returns the audio-clock
   // time the next contiguous note would start (= start + seq.length * step), so a
   // loop can schedule the next pass exactly.
   function renderSequence(instr, baseMidi, seq, opts = {}) {
@@ -352,6 +368,15 @@ const AudioKit = (() => {
     // A fully-connected articulation on an expressive instrument becomes one
     // continuous glided voice; everything else is note-by-note.
     const connected = !!opts.legato && !!EX;
+    // Per-note shaping for connected playback: shape[i] = { slide, artic, level }.
+    //   slide  seconds the pitch takes to travel into note i — an audible
+    //          portamento (a shift), where EX.glide is just legato smoothing
+    //   artic  how far the tone eases before note i (overrides EX.artic), so a
+    //          note that starts a fresh bow stroke can be re-articulated harder
+    //   level  multiplier on note i's loudness — a hand travelling between
+    //          positions sounds under the bow's weight, not on it
+    const shape = Array.isArray(opts.shape) ? opts.shape : null;
+    const shapeAt = (i) => (shape && shape[i]) || null;
     // Never layer a second sequence over the first, unless chaining a loop pass.
     if (!opts.chain) stopSequence();
     const now = ctx.currentTime;
@@ -364,11 +389,13 @@ const AudioKit = (() => {
     const lo = Math.min(...seq), hi = Math.max(...seq);
     const spanSemis = Math.max(1, hi - lo);
     function dynFor(semi, i) {
-      if (!EX) return peak;
+      const sh = shapeAt(i);
+      const lvl = sh && sh.level != null ? sh.level : 1;
+      if (!EX) return peak * lvl;
       const contour = EX.dyn * (((semi - lo) / spanSemis) - 0.5) * 2;
       const accent = i === 0 ? EX.accent : 0;
       const jitter = EX.dynJitter ? (Math.random() * 2 - 1) * EX.dynJitter : 0;
-      return Math.max(peak * (1 + contour + accent + jitter), 0.0002);
+      return Math.max(peak * lvl * (1 + contour + accent + jitter), 0.0002);
     }
     // Micro-timing: nudge onsets off the grid, but never the first note of a
     // pass, so loop seams stay locked and the tonic lands on the beat.
@@ -388,7 +415,7 @@ const AudioKit = (() => {
 
     if (connected) {
       renderConnected(ctx, timbre, baseMidi, seq, {
-        start, step, gate, atk, release, peak, EX, dynFor, timeFor, scheduleOnNote,
+        start, step, gate, atk, release, peak, EX, dynFor, timeFor, scheduleOnNote, shapeAt,
       });
     } else {
       seq.forEach((semi, i) => {

--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
         // Special pages
         const extras = [
           { href: 'scales.html', title: 'scales' },
+          { href: 'shifting.html', title: 'shifting' },
           { href: 'chords.html', title: 'chords' },
           { href: 'jazz7ths.html', title: 'jazz 7ths' },
           { href: 'giantsteps.html', title: 'giant steps' },

--- a/shifting.html
+++ b/shifting.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>shifting</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      background: #000;
+      color: #fff;
+      font-family: "Cormorant Garamond", serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+      padding: 2.5rem 1rem 4rem;
+      box-sizing: border-box;
+    }
+    a { color: #9cd8ff; }
+    .back {
+      position: fixed;
+      top: 1rem;
+      left: 1rem;
+      font-size: 1rem;
+      color: #666;
+      text-decoration: none;
+    }
+    .back:hover { color: #d8d8ff; }
+
+    h1 {
+      margin: 0;
+      font-size: 2.2rem;
+      font-weight: 500;
+      letter-spacing: 0.06em;
+      text-transform: lowercase;
+    }
+    .hint {
+      margin: -0.5rem 0 0;
+      font-size: 1rem;
+      color: rgba(255, 255, 255, 0.5);
+      font-style: italic;
+      text-align: center;
+      max-width: 34rem;
+    }
+
+    /* --- circle of fifths (same look as the scales page) --- */
+    #circle {
+      width: min(320px, 88vw);
+      height: auto;
+    }
+    .node circle {
+      fill: #161616;
+      stroke: #555;
+      stroke-width: 1.5;
+      transition: fill 0.15s, stroke 0.15s;
+    }
+    .node text {
+      fill: #cfcfcf;
+      font-size: 18px;
+      font-weight: 500;
+      pointer-events: none;
+    }
+    .node { cursor: pointer; }
+    .node:hover circle { stroke: #9cd8ff; }
+    .node:focus { outline: none; }
+    .node:focus-visible circle { stroke: #9cd8ff; stroke-width: 2.5; }
+    .node .alt { font-size: 12px; fill: rgba(255, 255, 255, 0.55); }
+    .node.selected circle { fill: #9cd8ff; stroke: #9cd8ff; }
+    .node.selected text { fill: #06121c; }
+
+    .center {
+      font-size: 1.4rem;
+      letter-spacing: 0.04em;
+      margin-top: -0.5rem;
+    }
+    .center #center-label { color: #9cd8ff; font-size: 1.7rem; }
+
+    /* --- the scale strip: notes, shift pills, and the gaps you add them in --- */
+    #strip {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      align-items: stretch;
+      gap: 0.15rem;
+      width: min(58rem, 96vw);
+      min-height: 3.2rem;
+    }
+    .note {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 2.4em;
+      padding: 0.3em 0.45em;
+      font-size: 1.35rem;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      color: #ddd;
+      transition: background 0.1s, color 0.1s, border-color 0.1s;
+    }
+    .note.restated { border-style: dashed; color: rgba(255, 255, 255, 0.65); }
+    .note.sounding { background: #9cd8ff; border-color: #9cd8ff; color: #06121c; }
+
+    /* The ghost: the note under the hand as it travels. Orange, because the ear
+       has to learn it as the one pitch in the pass that is outside the key. */
+    .ghost {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.1em;
+      padding: 0.15em 0.2em;
+      border: 1px dashed rgba(200, 116, 60, 0.7);
+      color: #f0b48a;
+      font-size: 1.1rem;
+    }
+    .ghost.sounding { background: rgba(200, 116, 60, 0.28); border-style: solid; }
+    .ghost-name { min-width: 2.2em; text-align: center; font-size: 1.25rem; }
+    .ghost button {
+      border: none;
+      background: none;
+      color: rgba(240, 180, 138, 0.75);
+      font-family: inherit;
+      font-size: 0.95rem;
+      line-height: 1;
+      padding: 0.25em 0.3em;
+      cursor: pointer;
+    }
+    .ghost button:hover { color: #fff; }
+    .ghost .drop-label {
+      font-size: 0.7rem;
+      color: rgba(240, 180, 138, 0.6);
+      letter-spacing: 0.05em;
+      align-self: flex-end;
+      padding-bottom: 0.35em;
+    }
+
+    /* A clickable gap between two notes — where a shift can be added. */
+    .gap {
+      border: none;
+      background: none;
+      color: rgba(255, 255, 255, 0.16);
+      font-family: inherit;
+      font-size: 1rem;
+      padding: 0 0.15em;
+      cursor: pointer;
+      align-self: center;
+    }
+    .gap:hover { color: #f0b48a; }
+
+    .strip-note {
+      font-size: 0.95rem;
+      color: rgba(255, 255, 255, 0.4);
+      font-style: italic;
+      margin: -0.9rem 0 0;
+      text-align: center;
+    }
+
+    /* --- controls --- */
+    .controls, .drone {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 0.7rem 1.4rem;
+      font-size: 0.95rem;
+      color: rgba(255, 255, 255, 0.6);
+      max-width: min(58rem, 96vw);
+    }
+    .ctl { display: inline-flex; align-items: center; gap: 0.5em; }
+    .ctl input[type="range"] { width: 6em; }
+    .ctl-val { min-width: 2.5ch; color: #9cd8ff; }
+    .ctl input[type="number"] {
+      background: #000;
+      border: 1px solid #666;
+      color: #ddd;
+      font-family: inherit;
+      font-size: 0.95rem;
+      padding: 0.2em 0.35em;
+      width: 3.4em;
+    }
+    .ctl input[type="number"]:hover { border-color: #9cd8ff; }
+
+    button {
+      background: none;
+      border: 1px solid #666;
+      color: #ddd;
+      font-family: inherit;
+      font-size: 1rem;
+      padding: 0.35em 0.7em;
+      cursor: pointer;
+    }
+    button:hover { border-color: #9cd8ff; color: #fff; }
+    #play {
+      font-size: 1.3rem;
+      padding: 0.4em 1.6em;
+      letter-spacing: 0.05em;
+    }
+    #play.playing { border-color: #9cd8ff; color: #9cd8ff; background: rgba(156, 216, 255, 0.12); }
+    #drone-btn.on { border-color: #c8743c; color: #f0b48a; }
+
+    .switch {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45em;
+      cursor: pointer;
+      user-select: none;
+    }
+    .switch input { position: absolute; opacity: 0; width: 0; height: 0; }
+    .switch .track {
+      width: 2.4em;
+      height: 1.2em;
+      border: 1px solid #666;
+      border-radius: 1em;
+      position: relative;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .switch .thumb {
+      position: absolute;
+      top: 50%;
+      left: 0.15em;
+      width: 0.9em;
+      height: 0.9em;
+      transform: translateY(-50%);
+      background: #ddd;
+      border-radius: 50%;
+      transition: left 0.15s, background 0.15s;
+    }
+    .switch input:checked + .track { background: #24506b; border-color: #9cd8ff; }
+    .switch input:checked + .track .thumb { left: calc(100% - 1.05em); background: #9cd8ff; }
+    .drone .switch input:checked + .track { background: #7a4322; border-color: #c8743c; }
+    .drone .switch input:checked + .track .thumb { background: #f0b48a; }
+    .drone-vol { display: inline-flex; align-items: center; gap: 0.5em; }
+    .drone-vol input[type="range"] { width: 6em; }
+  </style>
+</head>
+<body>
+  <a class="back" href="index.html">← back</a>
+
+  <h1>shifting</h1>
+  <p class="hint">
+    slow shifting practice for the ear. the scale plays in time; at each shift the
+    pitch slides down to the note the hand passes through — sounded on its own
+    beat, so you learn to hear it.
+  </p>
+
+  <svg id="circle" viewBox="0 0 360 360" aria-label="circle of fifths"></svg>
+
+  <div class="center">key: <span id="center-label">—</span></div>
+
+  <div id="strip"></div>
+  <p class="strip-note">click a gap between two notes to add a shift there; ▾ ▴ move the note the hand slides to</p>
+
+  <button id="play" type="button">play</button>
+
+  <div class="controls">
+    <label class="ctl">
+      <span>♩ =</span>
+      <input id="tempo" type="number" min="30" max="200" step="1" value="52">
+    </label>
+    <label class="ctl">
+      octaves
+      <input id="octaves" type="range" min="1" max="2" step="1" value="1">
+      <span id="octaves-val" class="ctl-val">1</span>
+    </label>
+    <label class="ctl">
+      slide
+      <input id="slide" type="range" min="15" max="90" step="5" value="55">
+      <span id="slide-val" class="ctl-val">55%</span>
+    </label>
+    <label class="switch">
+      <input id="restate" type="checkbox" checked>
+      <span class="track"><span class="thumb"></span></span>
+      play the note again after the shift
+    </label>
+    <label class="switch">
+      <input id="metronome" type="checkbox" checked>
+      <span class="track"><span class="thumb"></span></span>
+      metronome
+    </label>
+    <label class="switch">
+      <input id="count-in" type="checkbox" checked>
+      <span class="track"><span class="thumb"></span></span>
+      count-in
+    </label>
+    <label class="switch">
+      <input id="loop" type="checkbox" checked>
+      <span class="track"><span class="thumb"></span></span>
+      loop
+    </label>
+  </div>
+
+  <div class="drone">
+    <button id="drone-btn" type="button">drone</button>
+    <label class="switch">
+      <input id="drone-fifth" type="checkbox" checked>
+      <span class="track"><span class="thumb"></span></span>
+      add 5th
+    </label>
+    <label class="drone-vol">
+      vol
+      <input id="drone-volume" type="range" min="0" max="0.4" step="0.01" value="0.1">
+    </label>
+  </div>
+
+  <script src="audio.js"></script>
+  <script src="shifting.js"></script>
+</body>
+</html>

--- a/shifting.js
+++ b/shifting.js
@@ -1,0 +1,547 @@
+// Shifting practice page. A major scale plays in strict time; wherever the hand
+// has to change position, the pitch *slides* down to the note the hand travels
+// through and sounds it on its own beat before the next note is played.
+//
+// The point is ear training, not notation: in G major the hand leaves C and
+// carries down to G♯ before the first finger crosses to C on the next string.
+// G♯ has no business in G major, so the ear rejects it — which is exactly why
+// it has to be heard, slowly and in tempo, until it stops sounding like a
+// mistake and starts sounding like a landmark.
+//
+// Where the shifts fall is a fingering decision, not a theory one, so the page
+// doesn't guess: click a gap between two notes to put a shift there, and ▾ ▴ to
+// move the note the hand slides to. Each key keeps its own layout, seeded from
+// whichever key you last had open — the circle of fifths is the point.
+//
+// Audio helpers (pitchToMidi, the cello voice, the drone) live in audio.js.
+
+const NS = 'http://www.w3.org/2000/svg';
+
+// Tonal centers clockwise around the circle, starting at the top. Mirrors the
+// table in scales.js (sig = major-key signature: + sharps, − flats).
+const CIRCLE = [
+  { label: 'C',  root: 'C',  sig: 0 },
+  { label: 'G',  root: 'G',  sig: 1 },
+  { label: 'D',  root: 'D',  sig: 2 },
+  { label: 'A',  root: 'A',  sig: 3 },
+  { label: 'E',  root: 'E',  sig: 4 },
+  { label: 'B',  alt: 'C♭', root: 'B',  sig: 5 },
+  { label: 'G♭', alt: 'F♯', root: 'Gb', sig: -6 },
+  { label: 'D♭', alt: 'C♯', root: 'Db', sig: -5 },
+  { label: 'A♭', root: 'Ab', sig: -4 },
+  { label: 'E♭', root: 'Eb', sig: -3 },
+  { label: 'B♭', root: 'Bb', sig: -2 },
+  { label: 'F',  root: 'F',  sig: -1 },
+];
+
+const MAJOR = { intervals: [0, 2, 4, 5, 7, 9, 11, 12], letterSteps: [0, 1, 2, 3, 4, 5, 6, 7] };
+
+const { pitchToMidi } = AudioKit;
+const cello = AudioKit.instruments.cello;
+
+let selectedIndex = 1; // default G major
+let octaves = 1;
+let tempoBpm = 52;
+let slidePct = 55;     // how much of the shift's beat the pitch spends travelling
+let restate = true;    // sound the note again, on the new string, once the hand lands
+let metronomeOn = true;
+let countIn = true;
+let loopOn = true;
+
+// Shift layouts, one per key root: [{ after, drop }] — `after` is the index of
+// the scale note you shift away from, `drop` how far the hand travels below it
+// in semitones. G major starts with the C-string shift: leave C, carry down a
+// major third to G♯, cross to C on the G string.
+const DEFAULT_SHIFTS = [{ after: 3, drop: 4 }];
+let shiftsByRoot = { G: DEFAULT_SHIFTS.map(s => ({ ...s })) };
+
+const currentRoot = () => CIRCLE[selectedIndex].root;
+const currentShifts = () => shiftsByRoot[currentRoot()] || [];
+
+// --- note spelling (same approach as scales.js) ---------------------------
+const LETTERS = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
+const LETTER_PC = [0, 2, 4, 5, 7, 9, 11];
+
+function parseTonic(root) {
+  const li = LETTERS.indexOf(root[0].toUpperCase());
+  const acc = root[1] === 'b' || root[1] === '♭' ? -1 : (root[1] === '#' || root[1] === '♯' ? 1 : 0);
+  return { letterIdx: li, pc: (LETTER_PC[li] + acc + 12) % 12 };
+}
+
+function spellPc(letterIdx, pc) {
+  const diff = ((pc - LETTER_PC[letterIdx] + 6) % 12 + 12) % 12 - 6;
+  const glyphs = { '-2': '𝄫', '-1': '♭', '0': '', '1': '♯', '2': '𝄪' };
+  const key = String(diff);
+  // hasOwnProperty, not `||` — a natural's glyph is the empty string.
+  return LETTERS[letterIdx] + (Object.prototype.hasOwnProperty.call(glyphs, key) ? glyphs[key] : '?');
+}
+
+// semi (offset from the tonic) -> spelled name. Scale tones are spelled by
+// letter so the key reads correctly; the note under a travelling hand is
+// chromatic, so it falls back to the key's preferred accidental.
+function makeNamer(root, sig) {
+  const base = pitchToMidi(root, 4);
+  const { letterIdx, pc: tonicPc } = parseTonic(root);
+  const map = {};
+  MAJOR.intervals.forEach((iv, d) => {
+    const li = (letterIdx + MAJOR.letterSteps[d]) % 7;
+    map[(tonicPc + iv) % 12] = spellPc(li, (tonicPc + iv) % 12);
+  });
+  return (semi) => {
+    const pc = ((base + semi) % 12 + 12) % 12;
+    return map[pc] != null ? map[pc] : AudioKit.midiToName(base + semi, sig < 0);
+  };
+}
+
+// --- the played pass ------------------------------------------------------
+// The scale's notes as semitone offsets from the tonic, across `octaves`.
+function scaleNotes() {
+  const degrees = MAJOR.intervals.slice(0, -1);
+  const out = [];
+  for (let o = 0; o < octaves; o++) for (const d of degrees) out.push(d + 12 * o);
+  out.push(12 * octaves);
+  return out;
+}
+
+// Expand the scale into the events actually heard: every note, plus — at each
+// shift — the note the hand slides through, and (optionally) the note restated
+// once the hand has landed. A shift parked past the end of the scale (left over
+// from a wider octave setting) is ignored rather than dropped, so narrowing the
+// range and widening it again doesn't lose the layout.
+function buildEvents() {
+  const notes = scaleNotes();
+  const shifts = currentShifts();
+  const out = [];
+  notes.forEach((semi, i) => {
+    out.push({ semi, kind: 'note', noteIndex: i });
+    const sh = shifts.find(s => s.after === i);
+    if (!sh || i >= notes.length - 1) return;
+    out.push({ semi: semi - sh.drop, kind: 'ghost', shift: sh });
+    if (restate) out.push({ semi, kind: 'note', noteIndex: i, restated: true });
+  });
+  return out;
+}
+
+// Per-note shaping handed to the cello voice: the hand travels quietly and
+// without re-articulating (it's one bow), and whatever follows it starts a
+// fresh stroke — on the cello that note is on a new string, under a new finger.
+function shapeFor(events, step) {
+  return events.map((e, i) => {
+    if (e.kind === 'ghost') return { slide: step * (slidePct / 100), level: 0.7, artic: 0.04 };
+    if (i > 0 && events[i - 1].kind === 'ghost') return { artic: 0.8 };
+    return null;
+  });
+}
+
+// --- playback -------------------------------------------------------------
+let playing = false;
+let loopTimerId = null;
+let liveEvents = [];   // the events of the pass currently sounding
+
+function clearHighlight() {
+  document.querySelectorAll('#strip .sounding').forEach(el => el.classList.remove('sounding'));
+}
+
+function finishPlayback() {
+  if (loopTimerId) { clearTimeout(loopTimerId); loopTimerId = null; }
+  playing = false;
+  document.getElementById('play').classList.remove('playing');
+  document.getElementById('play').textContent = 'play';
+  clearHighlight();
+  updateWakeLock();
+}
+
+function stopPlayback() {
+  AudioKit.stopSequence();
+  finishPlayback();
+}
+
+function togglePlay() {
+  if (playing) { stopPlayback(); return; }
+  playing = true;
+  const btn = document.getElementById('play');
+  btn.classList.add('playing');
+  btn.textContent = 'stop';
+  updateWakeLock();
+  schedulePass(null, false, true);
+}
+
+// Re-trigger a running loop so a changed option (a new shift, a wider range)
+// takes effect at the next seam instead of only after a manual stop.
+function restartIfLooping() {
+  if (playing && loopOn) {
+    if (loopTimerId) { clearTimeout(loopTimerId); loopTimerId = null; }
+    clearHighlight();
+    schedulePass(null, false, false); // already mid-practice: no second count-in
+  }
+}
+
+// Play one pass, then schedule the next on the audio clock (gapless) or finish.
+// `lead` delays the first note by a beat and ticks a count-in on it.
+function schedulePass(when, chain, lead) {
+  if (lead) AudioKit.prepareOutput();
+  const center = CIRCLE[selectedIndex];
+  const baseMidi = pitchToMidi(center.root, 2); // the bottom octave, in cello register
+  const events = buildEvents();
+  liveEvents = events;
+  const step = 60 / tempoBpm; // one event per beat — this is slow practice
+  const startWhen = lead && countIn ? AudioKit.currentTime() + 0.05 + step : when;
+  const nextStart = cello.playSequence(baseMidi, events.map(e => e.semi), {
+    step,
+    gate: step,
+    attack: 0.025,
+    sustain: 0.9,
+    release: 0.06,
+    when: startWhen,
+    chain,
+    legato: true,
+    shape: shapeFor(events, step),
+    clickInterval: metronomeOn ? step : 0,
+    clickAccent: true,
+    onNote: (semi, i) => {
+      clearHighlight();
+      const el = document.querySelector(`#strip [data-ev="${i}"]`);
+      if (el) el.classList.add('sounding');
+    },
+  });
+  // Scheduled after playSequence, whose fresh-start stopSequence() would
+  // otherwise cancel a tick placed before it.
+  if (lead && countIn) AudioKit.click(startWhen - step, false);
+  if (loopOn) {
+    const ahead = Math.min(0.25, events.length * step * 0.5);
+    const delay = Math.max(0, (nextStart - ahead - AudioKit.currentTime()) * 1000);
+    loopTimerId = setTimeout(() => {
+      if (loopOn && playing) schedulePass(nextStart, true, false);
+      else loopTimerId = setTimeout(finishPlayback, Math.max(0, (nextStart - AudioKit.currentTime()) * 1000));
+    }, delay);
+  } else {
+    loopTimerId = setTimeout(finishPlayback, Math.max(0, (nextStart - AudioKit.currentTime()) * 1000));
+  }
+}
+
+// --- the scale strip ------------------------------------------------------
+// Rendered from the same events as the pass, so what you see is what sounds:
+// each element carries its event index, which playback highlights as it goes.
+function buildStrip() {
+  const strip = document.getElementById('strip');
+  strip.innerHTML = '';
+  const center = CIRCLE[selectedIndex];
+  const namer = makeNamer(center.root, center.sig);
+  const events = buildEvents();
+  const shifts = currentShifts();
+  const lastNote = scaleNotes().length - 1;
+
+  events.forEach((e, i) => {
+    if (e.kind === 'ghost') {
+      strip.appendChild(makeGhost(e, i, namer));
+      return;
+    }
+    const chip = document.createElement('span');
+    chip.className = 'note' + (e.restated ? ' restated' : '');
+    chip.dataset.ev = i;
+    chip.textContent = namer(e.semi);
+    strip.appendChild(chip);
+    // A gap after this note, unless a shift already lives there (or it's the
+    // last note, where there's nothing left to shift into). The restated copy
+    // never gets one: it's the same scale note, and a second shift on the same
+    // note would be unreachable — buildEvents only honors the first.
+    const free = !e.restated && !shifts.some(s => s.after === e.noteIndex);
+    if (free && e.noteIndex < lastNote) strip.appendChild(makeGap(e.noteIndex));
+  });
+}
+
+function makeGap(afterIndex) {
+  const b = document.createElement('button');
+  b.className = 'gap';
+  b.type = 'button';
+  b.textContent = '+';
+  b.title = 'add a shift here';
+  b.setAttribute('aria-label', 'add a shift after this note');
+  b.addEventListener('click', () => {
+    const list = shiftsByRoot[currentRoot()] || (shiftsByRoot[currentRoot()] = []);
+    list.push({ after: afterIndex, drop: 4 });
+    afterEdit();
+  });
+  return b;
+}
+
+function makeGhost(event, evIndex, namer) {
+  const wrap = document.createElement('span');
+  wrap.className = 'ghost';
+  wrap.dataset.ev = evIndex;
+
+  const down = document.createElement('button');
+  down.type = 'button';
+  down.textContent = '▾';
+  down.setAttribute('aria-label', 'slide further down');
+  down.addEventListener('click', () => nudge(event.shift, 1));
+
+  const name = document.createElement('span');
+  name.className = 'ghost-name';
+  name.textContent = namer(event.semi);
+
+  const up = document.createElement('button');
+  up.type = 'button';
+  up.textContent = '▴';
+  up.setAttribute('aria-label', 'slide less far down');
+  up.addEventListener('click', () => nudge(event.shift, -1));
+
+  const drop = document.createElement('span');
+  drop.className = 'drop-label';
+  drop.textContent = `−${event.shift.drop}`;
+
+  const kill = document.createElement('button');
+  kill.type = 'button';
+  kill.textContent = '×';
+  kill.setAttribute('aria-label', 'remove this shift');
+  kill.addEventListener('click', () => {
+    const list = shiftsByRoot[currentRoot()] || [];
+    const k = list.indexOf(event.shift);
+    if (k >= 0) list.splice(k, 1);
+    afterEdit();
+  });
+
+  wrap.append(down, name, up, drop, kill);
+  return wrap;
+}
+
+// A shift travels at least a semitone and at most an octave — past that it's a
+// different position, not a shift.
+function nudge(shift, by) {
+  shift.drop = Math.min(12, Math.max(1, shift.drop + by));
+  afterEdit();
+}
+
+// Every edit redraws the strip, saves, and re-syncs a running loop.
+function afterEdit() {
+  buildStrip();
+  persist();
+  restartIfLooping();
+}
+
+// --- circle of fifths -----------------------------------------------------
+function buildCircle() {
+  const svg = document.getElementById('circle');
+  const cx = 180, cy = 180, ringR = 122;
+  CIRCLE.forEach((entry, i) => {
+    const ang = (-90 + i * 30) * Math.PI / 180;
+    const x = cx + ringR * Math.cos(ang);
+    const y = cy + ringR * Math.sin(ang);
+    const g = document.createElementNS(NS, 'g');
+    g.setAttribute('class', 'node');
+    g.setAttribute('tabindex', '0');
+    g.setAttribute('role', 'button');
+    g.setAttribute('aria-label', `${entry.label} major${entry.alt ? ' or ' + entry.alt + ' major' : ''}`);
+    const c = document.createElementNS(NS, 'circle');
+    c.setAttribute('cx', x); c.setAttribute('cy', y); c.setAttribute('r', 26);
+    const t = document.createElementNS(NS, 'text');
+    t.setAttribute('x', x);
+    t.setAttribute('y', entry.alt ? y - 6 : y);
+    t.setAttribute('text-anchor', 'middle');
+    t.setAttribute('dominant-baseline', 'central');
+    t.textContent = entry.label;
+    if (entry.alt) {
+      const alt = document.createElementNS(NS, 'tspan');
+      alt.setAttribute('class', 'alt');
+      alt.setAttribute('x', x);
+      alt.setAttribute('dy', '15');
+      alt.textContent = entry.alt;
+      t.appendChild(alt);
+    }
+    g.append(c, t);
+    g.addEventListener('click', () => select(i));
+    g.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); select(i); }
+    });
+    svg.appendChild(g);
+    entry.el = g;
+  });
+}
+
+function select(i) {
+  const from = CIRCLE[selectedIndex].root;
+  selectedIndex = i;
+  const root = currentRoot();
+  // A key you haven't set up yet inherits the shape you were just working in —
+  // the same shifts, transposed — rather than starting blank.
+  if (!shiftsByRoot[root]) {
+    const seed = shiftsByRoot[from] || DEFAULT_SHIFTS;
+    shiftsByRoot[root] = seed.map(s => ({ after: s.after, drop: s.drop }));
+  }
+  CIRCLE.forEach((e, j) => e.el.classList.toggle('selected', j === i));
+  document.getElementById('center-label').textContent = CIRCLE[i].label + ' major';
+  drone.setRoot(pitchToMidi(root, 3));
+  buildStrip();
+  persist();
+  restartIfLooping();
+}
+
+// --- drone ----------------------------------------------------------------
+const drone = AudioKit.createDrone();
+
+function initDroneControls() {
+  const btn = document.getElementById('drone-btn');
+  btn.addEventListener('click', () => {
+    if (drone.playing) {
+      drone.stop();
+      btn.textContent = 'drone';
+      btn.classList.remove('on');
+    } else {
+      drone.start();
+      btn.textContent = 'stop drone';
+      btn.classList.add('on');
+    }
+    updateWakeLock();
+  });
+  const fifth = document.getElementById('drone-fifth');
+  drone.setFifth(fifth.checked);
+  fifth.addEventListener('change', () => drone.setFifth(fifth.checked));
+  const vol = document.getElementById('drone-volume');
+  drone.setVolume(parseFloat(vol.value));
+  vol.addEventListener('input', () => drone.setVolume(parseFloat(vol.value)));
+}
+
+// --- screen wake lock -----------------------------------------------------
+// Phones sleep on their idle timer even while audio plays, cutting practice off
+// mid-pass. Hold the lock whenever something is sounding, and re-acquire it when
+// the tab becomes visible again (the OS drops it while the page is hidden).
+let wakeLock = null;
+
+async function acquireWakeLock() {
+  if (wakeLock || !('wakeLock' in navigator)) return;
+  try {
+    wakeLock = await navigator.wakeLock.request('screen');
+    wakeLock.addEventListener('release', () => { wakeLock = null; });
+  } catch (e) { /* unsupported or blocked — practice still works */ }
+}
+
+function releaseWakeLock() {
+  if (wakeLock) { wakeLock.release().catch(() => {}); wakeLock = null; }
+}
+
+function updateWakeLock() {
+  if (playing || drone.playing) acquireWakeLock();
+  else releaseWakeLock();
+}
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') updateWakeLock();
+});
+
+// --- controls -------------------------------------------------------------
+function initControls() {
+  document.getElementById('play').addEventListener('click', togglePlay);
+
+  const tempo = document.getElementById('tempo');
+  tempoBpm = Number(tempo.value);
+  tempo.addEventListener('input', () => {
+    const n = Number(tempo.value);
+    if (Number.isFinite(n) && n >= 30 && n <= 200) { tempoBpm = n; restartIfLooping(); }
+  });
+
+  const oct = document.getElementById('octaves');
+  const octVal = document.getElementById('octaves-val');
+  const applyOct = () => {
+    octaves = Number(oct.value);
+    octVal.textContent = oct.value;
+    buildStrip();
+    restartIfLooping();
+  };
+  applyOct();
+  oct.addEventListener('input', applyOct);
+
+  const slide = document.getElementById('slide');
+  const slideVal = document.getElementById('slide-val');
+  const applySlide = () => {
+    slidePct = Number(slide.value);
+    slideVal.textContent = slide.value + '%';
+    restartIfLooping();
+  };
+  applySlide();
+  slide.addEventListener('input', applySlide);
+
+  const toggles = [
+    ['restate',    (v) => { restate = v; buildStrip(); }],
+    ['metronome',  (v) => { metronomeOn = v; }],
+    ['count-in',   (v) => { countIn = v; }],
+    ['loop',       (v) => { loopOn = v; }],
+  ];
+  toggles.forEach(([id, apply]) => {
+    const el = document.getElementById(id);
+    apply(el.checked);
+    el.addEventListener('change', () => { apply(el.checked); restartIfLooping(); });
+  });
+}
+
+// --- settings persistence -------------------------------------------------
+// One JSON blob, same shape as the other practice pages, plus the per-key shift
+// layouts — those are the page's real content, so losing them on reload would
+// make it useless.
+const PREFS_KEY = 'shifting:prefs';
+const PREFS = [
+  { id: 'tempo',        key: 'tempo',      kind: 'num', min: 30, max: 200, ev: 'input' },
+  { id: 'octaves',      key: 'octaves',    kind: 'num', min: 1,  max: 2,   ev: 'input' },
+  { id: 'slide',        key: 'slide',      kind: 'num', min: 15, max: 90,  ev: 'input' },
+  { id: 'restate',      key: 'restate',    kind: 'bool', ev: 'change' },
+  { id: 'metronome',    key: 'metronome',  kind: 'bool', ev: 'change' },
+  { id: 'count-in',     key: 'countIn',    kind: 'bool', ev: 'change' },
+  { id: 'loop',         key: 'loop',       kind: 'bool', ev: 'change' },
+  { id: 'drone-fifth',  key: 'droneFifth', kind: 'bool', ev: 'change' },
+  { id: 'drone-volume', key: 'droneVol',   kind: 'num', min: 0, max: 0.4, ev: 'input' },
+];
+
+const prefEl = (p) => document.getElementById(p.id);
+
+function readPref(p) {
+  const el = prefEl(p);
+  return p.kind === 'bool' ? el.checked : Number(el.value);
+}
+
+function writePref(p, v) {
+  const el = prefEl(p);
+  if (p.kind === 'bool') { if (typeof v === 'boolean') el.checked = v; }
+  else { const n = Number(v); if (Number.isFinite(n)) el.value = Math.min(p.max, Math.max(p.min, n)); }
+}
+
+// Persist on any control change (the tonal center and the shift layouts persist
+// through select()/afterEdit()).
+function initPersistence() {
+  PREFS.forEach(p => prefEl(p).addEventListener(p.ev, persist));
+}
+
+function persist() {
+  try {
+    const data = { center: selectedIndex, shifts: shiftsByRoot };
+    PREFS.forEach(p => { data[p.key] = readPref(p); });
+    localStorage.setItem(PREFS_KEY, JSON.stringify(data));
+  } catch (e) { /* storage unavailable (private mode, etc.) — silently skip */ }
+}
+
+// Validate on the way in: a stale or hand-edited blob must not be able to
+// produce a shift pointing at a note that doesn't exist, or a NaN drop.
+function applyPrefs() {
+  let p;
+  try { p = JSON.parse(localStorage.getItem(PREFS_KEY) || 'null'); } catch (e) { return; }
+  if (!p || typeof p !== 'object') return;
+  if (Number.isInteger(p.center) && p.center >= 0 && p.center < CIRCLE.length) selectedIndex = p.center;
+  PREFS.forEach(entry => writePref(entry, p[entry.key]));
+  if (p.shifts && typeof p.shifts === 'object') {
+    const clean = {};
+    CIRCLE.forEach(({ root }) => {
+      const list = p.shifts[root];
+      if (!Array.isArray(list)) return;
+      clean[root] = list
+        .filter(s => s && Number.isInteger(s.after) && s.after >= 0 && s.after < 15
+                     && Number.isFinite(s.drop) && s.drop >= 1 && s.drop <= 12)
+        .map(s => ({ after: s.after, drop: Math.round(s.drop) }));
+    });
+    if (Object.keys(clean).length) shiftsByRoot = clean;
+  }
+}
+
+applyPrefs();
+buildCircle();
+initControls();
+initDroneControls();
+initPersistence();
+select(selectedIndex);


### PR DESCRIPTION
Slow shifting practice is as much ear training as hand training: the note the hand passes through on the way to a new position is usually outside the key, so the ear rejects it. In G major you leave C and carry down to G♯ before the first finger crosses to C on the next string, and G♯ is exactly the pitch that sounds wrong until you've heard it enough times.

`shifting.html` plays a major scale in strict time and gives that ghost note its own beat — the pitch slides down to it, sits there in tune, and the note you left is restated on the new string:

```
G   A   B   C   ⟍G♯   C   D   E   F♯   G
```

The circle of fifths picks the key, defaulting to G.

## Where the shifts fall

That's a fingering decision, not a theory one, so the page stores shifts rather than deriving them. Each key keeps a list of `{ after, drop }` — the index of the note you shift away from, and how far below it the hand travels — in `localStorage`. Click a gap in the note strip to add a shift, `▾`/`▴` to move the ghost note. A key you haven't set up inherits the layout of the key you were last in, transposed.

It ships seeded with the one G major shift and nothing else, so the rest get placed by ear.

## Controls

Tempo (default ♩=52), 1–2 octaves, a *slide* slider for how much of the beat the travel takes, metronome, count-in, loop, and the drone with its fifth — a G drone under this is the fastest way to make the G♯ register as a landmark instead of a wrong note. A toggle chooses between `C ⟍G♯ C` and `C ⟍G♯ D`.

## Engine change

`playSequence` in `audio.js` grew a `shape` option: a per-note `{ slide, artic, level }` that gives a single note a real, timed portamento — and lets the note after it re-articulate as a fresh bow on a new string — instead of the near-instant smoothing legato uses everywhere else. Existing callers pass no shape and render exactly as before.

## Testing

Driven in headless Chromium:

- The strip renders `G A B C ⟍G♯ C D E F♯ G` and the highlight walks it in time.
- The pitch automation was inspected directly: at ♩=160 the engine targets 103.8 Hz (G♯2) over a 0.206 s travel and pins the arrival, so the ghost note lands in tune.
- Adding, nudging, and removing shifts; switching keys (D seeds as `G ⟍D♯ G`); one and two octaves; survives a reload.
- Re-ran the scales page against the modified engine — plays unchanged, no console errors.

Not included: descending shifts. The ghost notes going down are different ones, and the ascending set isn't settled yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwTMwdY1CvRUaqAwm1wEJJ)_