### PR TITLE
Stop a cached script from taking the shifting page down

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ still wired up, and init died with the page half-built). **Bump `?v=` whenever
 either file changes in a way the other depends on.** As a backstop the script
 looks its controls up through `control()`, which warns and skips rather than
 throwing, so a future skew costs one dead control instead of the whole page.
+And because a phone has no console, an inline watcher shows a visible notice
+(naming the file that failed, with a cache-busting reload link) whenever
+`shifting.js` doesn't reach its last line — a script that fails to fetch
+otherwise renders a perfect-looking page that does nothing.
 
 The audible slide comes from the `shape` option added to `playSequence` in
 `audio.js`: a per-note `{ artic, tail }`, where `tail` is

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ inherits the layout of the key you were last in, transposed. The stored blob
 carries a `v` — v1 hung a shift *between* two notes, so a v1 blob is ignored
 rather than misread.
 
+`shifting.html` loads its scripts with a `?v=` query. GitHub Pages serves HTML
+and JS with the same short max-age, so a reload can pick up fresh markup while
+reusing a stale script from cache — fatal the moment the two disagree about
+which controls exist (it happened: the markup dropped a toggle the cached script
+still wired up, and init died with the page half-built). **Bump `?v=` whenever
+either file changes in a way the other depends on.** As a backstop the script
+looks its controls up through `control()`, which warns and skips rather than
+throwing, so a future skew costs one dead control instead of the whole page.
+
 The audible slide comes from the `shape` option added to `playSequence` in
 `audio.js`: a per-note `{ artic, tail }`, where `tail` is
 `{ semis, at, over, level }` — the pitch leaves a note partway through its beat,

--- a/shifting.html
+++ b/shifting.html
@@ -301,7 +301,12 @@
     </label>
   </div>
 
-  <script src="audio.js"></script>
-  <script src="shifting.js"></script>
+  <!-- Versioned so a cached script can never pair with newer markup. GitHub
+       Pages serves both with the same short max-age, so a reload can pick up
+       fresh HTML while reusing a stale script from cache — which is fatal the
+       moment the two disagree about what controls exist. Bump ?v= whenever
+       either file changes in a way the other depends on. -->
+  <script src="audio.js?v=2"></script>
+  <script src="shifting.js?v=2"></script>
 </body>
 </html>

--- a/shifting.html
+++ b/shifting.html
@@ -151,6 +151,30 @@
     .shift-row button:hover { opacity: 1; color: #fff; }
     .note.sounding .shift-row button:hover { color: #000; }
 
+    /* Shown only when the page's scripts didn't run. Without it a failed script
+       fetch looks identical to a broken practice tool: the markup and styling
+       render perfectly and nothing works, with no way to tell why from a
+       phone. */
+    #load-error {
+      margin: 0;
+      padding: 0.8rem 1rem;
+      max-width: min(34rem, 92vw);
+      border: 1px solid rgba(232, 122, 122, 0.5);
+      color: #e8a0a0;
+      font-size: 1rem;
+      text-align: center;
+      line-height: 1.5;
+    }
+    #load-error a { color: #ffb066; }
+    #load-error .detail {
+      display: block;
+      margin-top: 0.4rem;
+      font-size: 0.8rem;
+      color: rgba(232, 160, 160, 0.7);
+      font-family: ui-monospace, monospace;
+      word-break: break-word;
+    }
+
     .strip-note {
       font-size: 0.95rem;
       color: rgba(255, 255, 255, 0.4);
@@ -247,6 +271,12 @@
     — to the note the hand has to pass through, so you learn to hear it.
   </p>
 
+  <p id="load-error" hidden>
+    this page didn't finish loading — its scripts never ran.
+    <a id="load-error-reload" href="">reload</a> to fetch a fresh copy.
+    <span class="detail" id="load-error-detail"></span>
+  </p>
+
   <svg id="circle" viewBox="0 0 360 360" aria-label="circle of fifths"></svg>
 
   <div class="center">key: <span id="center-label">—</span></div>
@@ -300,6 +330,29 @@
       <input id="drone-volume" type="range" min="0" max="0.4" step="0.01" value="0.1">
     </label>
   </div>
+
+  <script>
+    // Watch the scripts below. A phone has no console, so a script that fails
+    // to fetch (flaky connection, a stale or negative cache entry) leaves a
+    // page that looks fine and does nothing, with no way to tell why. Listen in
+    // the capture phase — resource load failures don't bubble — and report on
+    // the page if shifting.js never reached its last line.
+    window.__shiftingProblems = [];
+    addEventListener('error', (e) => {
+      const src = e.target && e.target.src;
+      window.__shiftingProblems.push(src ? 'could not load ' + src.split('/').pop() : (e.message || 'script error'));
+    }, true);
+    addEventListener('load', () => {
+      if (window.__shiftingReady) return;
+      const box = document.getElementById('load-error');
+      const detail = document.getElementById('load-error-detail');
+      const again = document.getElementById('load-error-reload');
+      // A unique query is the one reload a cache can't answer from its own copy.
+      if (again) again.href = location.pathname + '?r=' + Date.now();
+      if (detail) detail.textContent = window.__shiftingProblems.join('; ');
+      if (box) box.hidden = false;
+    });
+  </script>
 
   <!-- Versioned so a cached script can never pair with newer markup. GitHub
        Pages serves both with the same short max-age, so a reload can pick up

--- a/shifting.js
+++ b/shifting.js
@@ -234,6 +234,7 @@ function schedulePass(when, chain, lead) {
 // because it happens inside the same beat.
 function buildStrip() {
   const strip = document.getElementById('strip');
+  if (!strip) return;
   strip.innerHTML = '';
   const center = CIRCLE[selectedIndex];
   const namer = makeNamer(center.root, center.sig);
@@ -325,6 +326,7 @@ function afterEdit() {
 // --- circle of fifths -----------------------------------------------------
 function buildCircle() {
   const svg = document.getElementById('circle');
+  if (!svg) return;
   const cx = 180, cy = 180, ringR = 122;
   CIRCLE.forEach((entry, i) => {
     const ang = (-90 + i * 30) * Math.PI / 180;
@@ -371,8 +373,9 @@ function select(i) {
     const seed = shiftsByRoot[from] || DEFAULT_SHIFTS;
     shiftsByRoot[root] = seed.map(s => ({ on: s.on, drop: s.drop }));
   }
-  CIRCLE.forEach((e, j) => e.el.classList.toggle('selected', j === i));
-  document.getElementById('center-label').textContent = CIRCLE[i].label + ' major';
+  CIRCLE.forEach((e, j) => { if (e.el) e.el.classList.toggle('selected', j === i); });
+  const label = document.getElementById('center-label');
+  if (label) label.textContent = CIRCLE[i].label + ' major';
   drone.setRoot(pitchToMidi(root, 3));
   buildStrip();
   persist();
@@ -383,8 +386,8 @@ function select(i) {
 const drone = AudioKit.createDrone();
 
 function initDroneControls() {
-  const btn = document.getElementById('drone-btn');
-  btn.addEventListener('click', () => {
+  const btn = control('drone-btn');
+  if (btn) btn.addEventListener('click', () => {
     if (drone.playing) {
       drone.stop();
       btn.textContent = 'drone';
@@ -396,12 +399,16 @@ function initDroneControls() {
     }
     updateWakeLock();
   });
-  const fifth = document.getElementById('drone-fifth');
-  drone.setFifth(fifth.checked);
-  fifth.addEventListener('change', () => drone.setFifth(fifth.checked));
-  const vol = document.getElementById('drone-volume');
-  drone.setVolume(parseFloat(vol.value));
-  vol.addEventListener('input', () => drone.setVolume(parseFloat(vol.value)));
+  const fifth = control('drone-fifth');
+  if (fifth) {
+    drone.setFifth(fifth.checked);
+    fifth.addEventListener('change', () => drone.setFifth(fifth.checked));
+  }
+  const vol = control('drone-volume');
+  if (vol) {
+    drone.setVolume(parseFloat(vol.value));
+    vol.addEventListener('input', () => drone.setVolume(parseFloat(vol.value)));
+  }
 }
 
 // --- screen wake lock -----------------------------------------------------
@@ -432,36 +439,54 @@ document.addEventListener('visibilitychange', () => {
 });
 
 // --- controls -------------------------------------------------------------
+// Every control is looked up through control(), which tolerates its absence.
+// A browser can serve this script against a cached copy of the markup that
+// predates it (or the reverse): the cost of a control the other side doesn't
+// know about has to be one dead control, never a half-initialized page with no
+// scale and no key selected.
+function control(id) {
+  const el = document.getElementById(id);
+  if (!el) console.warn(`shifting: no #${id} in this page — control skipped`);
+  return el;
+}
+
 function initControls() {
-  document.getElementById('play').addEventListener('click', togglePlay);
+  const play = control('play');
+  if (play) play.addEventListener('click', togglePlay);
 
-  const tempo = document.getElementById('tempo');
-  tempoBpm = Number(tempo.value);
-  tempo.addEventListener('input', () => {
-    const n = Number(tempo.value);
-    if (Number.isFinite(n) && n >= 30 && n <= 200) { tempoBpm = n; restartIfLooping(); }
-  });
+  const tempo = control('tempo');
+  if (tempo) {
+    tempoBpm = Number(tempo.value);
+    tempo.addEventListener('input', () => {
+      const n = Number(tempo.value);
+      if (Number.isFinite(n) && n >= 30 && n <= 200) { tempoBpm = n; restartIfLooping(); }
+    });
+  }
 
-  const oct = document.getElementById('octaves');
+  const oct = control('octaves');
   const octVal = document.getElementById('octaves-val');
-  const applyOct = () => {
-    octaves = Number(oct.value);
-    octVal.textContent = oct.value;
-    buildStrip();
-    restartIfLooping();
-  };
-  applyOct();
-  oct.addEventListener('input', applyOct);
+  if (oct) {
+    const applyOct = () => {
+      octaves = Number(oct.value);
+      if (octVal) octVal.textContent = oct.value;
+      buildStrip();
+      restartIfLooping();
+    };
+    applyOct();
+    oct.addEventListener('input', applyOct);
+  }
 
-  const slide = document.getElementById('slide');
+  const slide = control('slide');
   const slideVal = document.getElementById('slide-val');
-  const applySlide = () => {
-    slidePct = Number(slide.value);
-    slideVal.textContent = slide.value + '%';
-    restartIfLooping();
-  };
-  applySlide();
-  slide.addEventListener('input', applySlide);
+  if (slide) {
+    const applySlide = () => {
+      slidePct = Number(slide.value);
+      if (slideVal) slideVal.textContent = slide.value + '%';
+      restartIfLooping();
+    };
+    applySlide();
+    slide.addEventListener('input', applySlide);
+  }
 
   const toggles = [
     ['metronome', (v) => { metronomeOn = v; }],
@@ -469,7 +494,8 @@ function initControls() {
     ['loop',      (v) => { loopOn = v; }],
   ];
   toggles.forEach(([id, apply]) => {
-    const el = document.getElementById(id);
+    const el = control(id);
+    if (!el) return;
     apply(el.checked);
     el.addEventListener('change', () => { apply(el.checked); restartIfLooping(); });
   });
@@ -497,11 +523,13 @@ const prefEl = (p) => document.getElementById(p.id);
 
 function readPref(p) {
   const el = prefEl(p);
+  if (!el) return undefined; // control absent — leave the stored value alone
   return p.kind === 'bool' ? el.checked : Number(el.value);
 }
 
 function writePref(p, v) {
   const el = prefEl(p);
+  if (!el) return;
   if (p.kind === 'bool') { if (typeof v === 'boolean') el.checked = v; }
   else { const n = Number(v); if (Number.isFinite(n)) el.value = Math.min(p.max, Math.max(p.min, n)); }
 }
@@ -509,13 +537,13 @@ function writePref(p, v) {
 // Persist on any control change (the tonal center and the shift layouts persist
 // through select()/afterEdit()).
 function initPersistence() {
-  PREFS.forEach(p => prefEl(p).addEventListener(p.ev, persist));
+  PREFS.forEach(p => { const el = prefEl(p); if (el) el.addEventListener(p.ev, persist); });
 }
 
 function persist() {
   try {
     const data = { v: PREFS_VERSION, center: selectedIndex, shifts: shiftsByRoot };
-    PREFS.forEach(p => { data[p.key] = readPref(p); });
+    PREFS.forEach(p => { const v = readPref(p); if (v !== undefined) data[p.key] = v; });
     localStorage.setItem(PREFS_KEY, JSON.stringify(data));
   } catch (e) { /* storage unavailable (private mode, etc.) — silently skip */ }
 }

--- a/shifting.js
+++ b/shifting.js
@@ -576,3 +576,8 @@ initControls();
 initDroneControls();
 initPersistence();
 select(selectedIndex);
+
+// Reached only if everything above ran. The page's load handler shows a visible
+// notice when this flag is missing, which is the only way a phone can tell a
+// script that failed to fetch from a practice tool that's simply broken.
+window.__shiftingReady = true;


### PR DESCRIPTION
The shifting page came up dead on a phone after #126. Two causes, both fixed here.

## The crash I reproduced

#126 removed the `restate` toggle from the markup. A browser holding a cached copy of the older `shifting.js` still read its `.checked` during startup, threw on null, and init stopped there: no key selected, `key: —`, the strip drawn from the stale layout, drone and settings dead. GitHub Pages serves HTML and JS with the same short max-age, which is exactly the window where a reload takes fresh markup and reuses a stale script.

`shifting.html` now loads `audio.js?v=2` and `shifting.js?v=2` — a new URL is a cache miss, so newer markup can't pair with an older script. As a backstop, controls are looked up through `control()`, which warns and skips when one is absent instead of throwing.

## The failure that outlived it

A later report showed the circle of fifths empty as well, not merely unselected. Everything visible on the page is drawn before any control is touched, so an empty circle means the script never executed at all — a failed fetch, not a crash. From a phone there's no console, and a page whose markup and styling render perfectly while nothing works looks identical to a broken practice tool.

The page now watches its own scripts. An inline listener in the capture phase (resource load failures don't bubble) records what failed, and if `shifting.js` never reaches its last line the page shows a notice naming the file, with a reload link carrying a unique query — the one request a cache can't answer from its own copy.

## Testing

- Served the new markup against the previous `shifting.js`: reproduced the original break exactly (`key: —`, empty selection, stale strip, `Cannot read properties of null (reading 'checked')`).
- Served the page with four controls cut out of the markup: the scale, circle, and playback all still come up, with warnings instead of a throw.
- Served the page with `shifting.js` absent: notice appears reading `could not load shifting.js?v=2`, reload link carries a fresh query.
- Healthy page: notice stays hidden, `__shiftingReady` set, strip reads `G A B(⟍ G♯) C D E F♯ G`, no console errors.
- Opposite skew (old cached markup + new script): comes up clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwTMwdY1CvRUaqAwm1wEJJ)_