### PR TITLE
Derive the rest of the shifts from the fingerboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,38 @@ finger to cross to C on the next string. The shift adds no note and no beat; it
 bends one that's already there. The ghost pitch is deliberately outside the key:
 the point is to stop hearing it as a mistake.
 
-Where the shifts fall is a fingering decision, so the page stores rather than
-derives them: each key keeps a list of `{ on, drop }` (the index of the scale
-note the hand shifts during, and how many semitones it travels below it) in
-`localStorage` under `shifting:prefs`. Click a note in the strip to put a shift
-on it, `▾`/`▴` to move the note the hand slides to. A key you haven't set up
-inherits the layout of the key you were last in, transposed. The stored blob
-carries a `v` — v1 hung a shift *between* two notes, so a v1 blob is ignored
-rather than misread.
+Each key keeps a list of `{ on, drop }` — the index of the scale note the hand
+shifts during, and how many semitones it travels below it — in `localStorage`
+under `shifting:prefs`. Click a note in the strip to put a shift on it,
+`▾`/`▴` to move the note the hand slides to. The stored blob carries a `v` — v1
+hung a shift *between* two notes, so a v1 blob is ignored rather than misread.
+
+The defaults are derived from the fingerboard rather than guessed. Fingered
+1–2–4 with a forward extension, a major scale falls onto the strings in groups
+of three — degrees 1-2-3, then 4-5-6, then 7-8-9 — each group starting on the
+first finger a string higher. So the hand shifts on the last note of each group:
+**indices 2, 5 and 8**. Crossing puts the first finger a fifth above where it
+sat, and the hand lands closed (the extension is a forward reach made after it
+arrives), so the fourth finger carrying the hand comes to rest a major third
+below the note being crossed to:
+
+| shift | drop | lands on | in the key? |
+|---|---|---|---|
+| index 2 (3rd degree) | 3 | the raised tonic (G♯ in G) | never |
+| index 5 (6th degree) | 2 | the dominant (D in G) | always |
+| index 8 (9th degree) | 2 | the octave (G in G) | always |
+
+All three fall out of the scale's shape, so they are identical in every key —
+which is why transposing a layout around the circle is the right thing to do.
+The strip greys out a ghost note that's already in the key, leaving the raised
+tonic under the first shift as the one the eye and ear go to.
+
+What *does* vary is the instrument. Where a crossing note happens to be an open
+string — low D and A major especially — the open string covers the move and
+there is no shift; remove it with `×`. Two octaves also end with four notes that
+need a shift *up* the A string, a gesture this page doesn't model.
+
+The derivation script is `tools/cello_shifts.py`.
 
 `shifting.html` loads its scripts with a `?v=` query. GitHub Pages serves HTML
 and JS with the same short max-age, so a reload can pick up fresh markup while

--- a/shifting.html
+++ b/shifting.html
@@ -137,6 +137,13 @@
     }
     .ghost-name.sounding { color: #ffb066; font-weight: 600; }
     .note.sounding .ghost-name.sounding { color: #4a2308; }
+    /* A ghost that's already in the key — the dominant the hand passes through
+       on the second shift — is a pitch the ear knows. Muted, so the one note
+       that is genuinely outside the key is the one that catches the eye. */
+    .ghost-name.in-key { color: rgba(255, 255, 255, 0.45); }
+    .ghost-name.in-key.sounding { color: #e6e6e6; }
+    .note.sounding .ghost-name.in-key { color: rgba(6, 18, 28, 0.55); }
+    .note.sounding .ghost-name.in-key.sounding { color: #06121c; }
     .shift-row button {
       border: none;
       background: none;
@@ -282,7 +289,10 @@
   <div class="center">key: <span id="center-label">—</span></div>
 
   <div id="strip"></div>
-  <p class="strip-note">click a note to put a shift on it; ▾ ▴ move the note the hand slides to</p>
+  <p class="strip-note">
+    click a note to put a shift on it; ▾ ▴ move the note the hand slides to.
+    the ghost notes in orange are the ones outside the key — those are the ones to listen for
+  </p>
 
   <button id="play" type="button">play</button>
 
@@ -359,7 +369,7 @@
        fresh HTML while reusing a stale script from cache — which is fatal the
        moment the two disagree about what controls exist. Bump ?v= whenever
        either file changes in a way the other depends on. -->
-  <script src="audio.js?v=2"></script>
-  <script src="shifting.js?v=2"></script>
+  <script src="audio.js?v=3"></script>
+  <script src="shifting.js?v=3"></script>
 </body>
 </html>

--- a/shifting.js
+++ b/shifting.js
@@ -57,11 +57,33 @@ let loopOn = true;
 
 // Shift layouts, one per key root: [{ on, drop }] — `on` is the index of the
 // scale note the hand shifts during, `drop` how far it travels below that note
-// in semitones. G major starts with the C-string shift: the fourth finger plays
-// B and carries down a minor third to G♯, where the first finger can cross to C
-// on the G string.
-const DEFAULT_SHIFTS = [{ on: 2, drop: 3 }];
-let shiftsByRoot = { G: DEFAULT_SHIFTS.map(s => ({ ...s })) };
+// in semitones.
+//
+// The defaults are derived, not guessed. Fingered 1–2–4 with a forward
+// extension, a major scale falls onto the strings in groups of three: degrees
+// 1-2-3, then 4-5-6, then 7-8-9, each group starting on the first finger a
+// string higher. So the hand shifts on the LAST note of each group — degrees 3,
+// 6 and 9, i.e. indices 2, 5 and 8. Crossing puts the first finger a fifth above
+// where it sat, and the hand lands closed (the extension is a forward reach made
+// after it arrives), so the fourth finger carrying the hand comes to rest a
+// major third below the note being crossed to:
+//
+//   index 2, drop 3   →  a minor third down, landing on the RAISED TONIC
+//                        (G♯ in G major). Never in the key — this is the one
+//                        the ear has to be taught.
+//   index 5, drop 2   →  a whole step down, landing on the DOMINANT (D in G).
+//   index 8, drop 2   →  a whole step down, landing on the OCTAVE (G in G);
+//                        only reached with two octaves selected.
+//
+// All three fall out of the scale's shape, so they're the same in every key —
+// which is why transposing a layout around the circle is the right thing to do.
+// What does vary is the instrument: where a crossing note happens to be an open
+// string (low D and A major especially) there's no shift at all, and × removes
+// it. Two octaves also end with four notes that need a shift UP the A string,
+// a gesture this page doesn't model.
+const DEFAULT_SHIFTS = [{ on: 2, drop: 3 }, { on: 5, drop: 2 }, { on: 8, drop: 2 }];
+const defaultShifts = () => DEFAULT_SHIFTS.map(s => ({ ...s }));
+let shiftsByRoot = Object.fromEntries(CIRCLE.map(c => [c.root, defaultShifts()]));
 
 const currentRoot = () => CIRCLE[selectedIndex].root;
 const currentShifts = () => shiftsByRoot[currentRoot()] || [];
@@ -285,8 +307,13 @@ function makeShiftRow(shift, semi, namer) {
   down.addEventListener('click', () => nudge(shift, 1));
 
   const name = document.createElement('span');
-  name.className = 'ghost-name';
-  name.textContent = '⟍ ' + namer(semi - shift.drop);
+  // Only some of these are outside the key. The raised tonic under the first
+  // shift is the ear-training note; the dominant under the second is a pitch
+  // the hand passes through but the ear already knows. Colour says which.
+  const ghostSemi = semi - shift.drop;
+  const inKey = MAJOR.intervals.includes(((ghostSemi % 12) + 12) % 12);
+  name.className = 'ghost-name' + (inKey ? ' in-key' : '');
+  name.textContent = '⟍ ' + namer(ghostSemi);
 
   const up = document.createElement('button');
   up.type = 'button';
@@ -364,15 +391,10 @@ function buildCircle() {
 }
 
 function select(i) {
-  const from = CIRCLE[selectedIndex].root;
   selectedIndex = i;
   const root = currentRoot();
-  // A key you haven't set up yet inherits the shape you were just working in —
-  // the same shifts, transposed — rather than starting blank.
-  if (!shiftsByRoot[root]) {
-    const seed = shiftsByRoot[from] || DEFAULT_SHIFTS;
-    shiftsByRoot[root] = seed.map(s => ({ on: s.on, drop: s.drop }));
-  }
+  // Every key starts from the derived default; only keys you've edited differ.
+  if (!shiftsByRoot[root]) shiftsByRoot[root] = defaultShifts();
   CIRCLE.forEach((e, j) => { if (e.el) e.el.classList.toggle('selected', j === i); });
   const label = document.getElementById('center-label');
   if (label) label.textContent = CIRCLE[i].label + ' major';

--- a/tools/cello_shifts.py
+++ b/tools/cello_shifts.py
@@ -1,0 +1,149 @@
+"""Derive cello shifts for a major scale, from a neck-position hand model.
+
+Model
+-----
+Strings (open, MIDI):        C2 36   G2 43   D3 50   A3 57
+Closed hand, offsets from 1: 1=0  2=1  3=2  4=3        (a minor 3rd, 1 to 4)
+Extended hand:               1=0  2=2  3=3  4=4        (forward extension, 1 to 2
+                                                        a whole step; a major 3rd,
+                                                        1 to 4)
+Position n: the 1st finger sits n semitones above the open string. 4th position
+is +7 (a fifth, thumb at the neck heel) — the highest we treat as a neck
+position here.
+
+Layout rule
+-----------
+Put the 1st finger on the tonic and take as many consecutive scale notes on that
+string as one hand frame reaches; then cross to the next string, again landing
+the 1st finger. Closed is preferred when it reaches — it's the relaxed frame.
+
+Shift rule
+----------
+The hand arrives CLOSED, with the 1st finger over the note it's crossing to
+(the extension, if the next group needs one, is a forward reach made after the
+hand lands). So the finger that played the last note before the crossing slides
+to where that finger sits in the arriving closed hand — and the note it lands on
+is what the ear hears.
+"""
+
+STRINGS = [36, 43, 50, 57]
+CLOSED = [0, 1, 2, 3]     # index 0 -> finger 1 ... index 3 -> finger 4
+EXTENDED = [0, 2, 3, 4]
+MAX_POS = 7               # 4th position: 1st finger a fifth above the open string
+MIN_POS = 1               # half position (never an open string in this exercise)
+
+NAMES_SHARP = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+NAMES_FLAT  = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B']
+
+def name(m, flats=False):
+    return (NAMES_FLAT if flats else NAMES_SHARP)[m % 12] + str(m // 12 - 1)
+
+def frame_for(offsets):
+    """The relaxed frame that reaches this set of offsets, or None."""
+    for frame in (CLOSED, EXTENDED):
+        if all(o in frame for o in offsets):
+            return frame
+    return None
+
+def group_notes(notes, start_string):
+    """Split ascending notes into per-string groups, each starting on finger 1.
+
+    Depth-first with backtracking: a greedy pass can strand itself by filling a
+    string so full that the next note lands on an open string (unplayable with
+    the 1st finger), so try longer groups first but fall back to shorter ones.
+    Returns (groups, leftover) — leftover is what no further string can take,
+    which needs a shift up the same string rather than a crossing.
+    """
+    def reach(i, s):
+        first = notes[i]
+        if s >= len(STRINGS) or not (MIN_POS <= first - STRINGS[s] <= MAX_POS):
+            return None
+        take = [first]
+        j = i + 1
+        while j < len(notes) and frame_for([n - first for n in take + [notes[j]]]):
+            take.append(notes[j])
+            j += 1
+        return take
+
+    def walk(i, s):
+        take = reach(i, s)
+        if take is None:
+            return None, notes[i:]
+        # Longest group first; shorten only if the remainder can't be placed.
+        best_leftover = None
+        for n in range(len(take), 0, -1):
+            head = take[:n]
+            group = {'string': s, 'notes': head,
+                     'frame': frame_for([x - head[0] for x in head])}
+            if i + n >= len(notes):
+                return [group], []
+            rest, leftover = walk(i + n, s + 1)
+            if rest is not None:
+                return [group] + rest, leftover
+            if best_leftover is None:
+                best_leftover = ([group], leftover)
+        return (None, notes[i:]) if best_leftover is None else best_leftover
+
+    groups, leftover = walk(0, start_string)
+    return groups, leftover
+
+def fingers(group):
+    first = group['notes'][0]
+    return [group['frame'].index(n - first) + 1 for n in group['notes']]
+
+def shifts_for(notes, start_string):
+    """Per-crossing: which note the hand shifts during, and how far it drops."""
+    groups, leftover = group_notes(notes, start_string)
+    if groups is None:
+        return None, None, leftover
+    out = []
+    for g, nxt in zip(groups, groups[1:]):
+        last = g['notes'][-1]
+        guide = fingers(g)[-1]                       # the finger that played it
+        arrival_1 = nxt['notes'][0] - 7              # that hand's 1st finger, on THIS string
+        ghost = arrival_1 + CLOSED[guide - 1]        # ...arriving closed
+        out.append({
+            'on': notes.index(last), 'note': last, 'guide': guide,
+            'ghost': ghost, 'drop': last - ghost,
+        })
+    return groups, out, leftover
+
+
+if __name__ == '__main__':
+    STRNAME = ['C', 'G', 'D', 'A']
+    MAJOR = [0, 2, 4, 5, 7, 9, 11, 12, 14, 16, 17, 19]
+    KEYS = [('C', 0, 0), ('G', 7, 0), ('D', 2, 0), ('A', 9, 0), ('E', 4, 0),
+            ('B', 11, 0), ('Gb', 6, 1), ('Db', 1, 1), ('Ab', 8, 1),
+            ('Eb', 3, 1), ('Bb', 10, 1), ('F', 5, 1)]
+
+    def start_for(pc):
+        """Lowest tonic at position 4-7 on the C or G string: the shape needs
+        position >= 4 so the third group still lands in a neck position."""
+        c = [STRINGS[s] + p for s in (0, 1) for p in range(4, MAX_POS + 1)
+             if (STRINGS[s] + p) % 12 == pc]
+        return min(c) if c else None
+
+    for label, pc, flat in KEYS:
+        tonic = start_for(pc)
+        if tonic is None:
+            print(f'{label:2} major   no tonic at position 4-7 on the C or G string; '
+                  f'a cellist starts this one lower, on open strings')
+            continue
+        ss = 0 if 4 <= tonic - STRINGS[0] <= MAX_POS else 1
+        notes = [tonic + d for d in MAJOR]
+        groups, sh, leftover = shifts_for(notes, ss)
+        pcs = {n % 12 for n in notes[:8]}
+        print(f'\n{label:2} major   1st finger on {name(tonic, flat)}, '
+              f'{STRNAME[ss]} string, position +{tonic - STRINGS[ss]}')
+        for g in groups or []:
+            frame = 'extended' if g['frame'] is EXTENDED else 'closed  '
+            print('     %s string  +%-2d %s  %s' % (
+                STRNAME[g['string']], g['notes'][0] - STRINGS[g['string']], frame,
+                ' '.join(f'{name(n, flat)}({f})' for n, f in zip(g['notes'], fingers(g)))))
+        if leftover:
+            print('     needs a shift UP the same string:',
+                  ' '.join(name(n, flat) for n in leftover))
+        for x in sh or []:
+            tag = 'OUTSIDE the key' if x['ghost'] % 12 not in pcs else 'in the key'
+            print(f'     index {x["on"]}: shift on {name(x["note"], flat)} (finger '
+                  f'{x["guide"]}), down {x["drop"]} to {name(x["ghost"], flat)}  [{tag}]')


### PR DESCRIPTION
The page shipped with one shift placed by hand and the others left for the player to find by ear. They can be derived instead.

## The derivation

Fingered 1–2–4 with a forward extension, a major scale falls onto the strings in groups of three — degrees 1-2-3, then 4-5-6, then 7-8-9 — each group starting on the first finger a string higher. So the hand shifts on the last note of each group: **indices 2, 5 and 8**. Crossing puts the first finger a fifth above where it sat, and the hand lands *closed* (the extension is a forward reach made after it arrives), so the fourth finger carrying the hand comes to rest a major third below the note being crossed to.

| shift | drop | lands on | in the key? |
|---|---|---|---|
| index 2 (3rd degree) | 3 | the raised tonic — G♯ in G | **never** |
| index 5 (6th degree) | 2 | the dominant — D in G | always |
| index 8 (9th degree) | 2 | the octave — G in G | always |

G major, checked against the model: C string 4th position extended `G(1) A(2) B(4)` → shift on B down to G♯ → G string 3rd position extended `C(1) D(2) E(4)` → shift on E down to D → D string 2½ closed `F♯(1) G(2)`.

It follows from the scale's shape rather than the key, so the indices and drops hold in all twelve — which is why transposing a layout around the circle was the right behaviour.

## Page

Exactly one ghost per octave is ever outside the key, and it always is: the raised tonic. The strip now greys a ghost that's already in the key and leaves that one in orange, so the eye lands on the note the ear needs.

Every key seeds from the derived default rather than inheriting the last key you were in.

## What isn't predicted

Where a crossing note is an open string the open string covers the move and there is no shift — low D and A major especially. Which octave the player uses isn't knowable here, so those come off with the `×`. Two octaves also end with four notes needing a shift *up* the A string, which the page can't express.

`tools/cello_shifts.py` carries the model and prints the fingering, position by position, for every key.

## Testing

- Strip contents per key: G `G A B[⟍G♯ out] C D E[⟍D in] F♯ G`; two octaves adds `A[⟍G in]`; D `F♯[⟍D♯ out] … B[⟍A in]`; C `E[⟍C♯ out] … A[⟍G in]`; F `A[⟍G♭ out] … D[⟍C in]`; A♭ `C[⟍A out] … F[⟍E♭ in]`.
- Pitch automation at ♩=120 confirms both shifts sound: B 123.5 Hz at 0.996 → departs 1.250 → G♯ 103.8 Hz pinned 1.425 → C 130.8 Hz at 1.496; and E 164.8 → D 146.8 pinned 2.925 → F♯ 185 at 2.996.
- No console errors; `tools/cello_shifts.py` runs clean for all twelve keys.
- Script tags bumped to `?v=3` per the cache note added in #127.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwTMwdY1CvRUaqAwm1wEJJ)_